### PR TITLE
feat: add 'new version available' banner when frontend is outdated (re-9e3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useStore } from './store'
 import { Sidebar } from './components/Sidebar'
 import { ChatPanel } from './components/ChatPanel'
 import { DetailPanel } from './components/DetailPanel'
+import { useVersionCheck } from './hooks/useVersionCheck'
 
 function App() {
   const { fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, error } = useStore(
@@ -18,6 +19,8 @@ function App() {
       error: s.error,
     }))
   )
+
+  const { newVersionAvailable, dismiss, refresh } = useVersionCheck()
 
   useEffect(() => {
     fetchThingTypes()
@@ -41,6 +44,24 @@ function App() {
 
   return (
     <div className="flex w-full h-full overflow-hidden bg-white dark:bg-gray-900">
+      {newVersionAvailable && (
+        <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-3 bg-blue-600 text-white text-sm px-4 py-2 shadow-md">
+          <span>A new version is available.</span>
+          <button
+            onClick={refresh}
+            className="underline font-medium hover:text-blue-100"
+          >
+            Refresh to update
+          </button>
+          <button
+            onClick={dismiss}
+            className="ml-2 text-blue-200 hover:text-white text-lg leading-none"
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      )}
       {error && (
         <div className="fixed top-3 right-3 z-50 max-w-sm bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-300 text-xs rounded-lg px-3 py-2 shadow">
           ⚠ {error}

--- a/frontend/src/hooks/useVersionCheck.ts
+++ b/frontend/src/hooks/useVersionCheck.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+
+declare const __APP_BUILD_VERSION__: string
+
+const CHECK_INTERVAL_MS = 60_000
+
+/**
+ * Polls /version.json to detect when a new frontend build has been deployed.
+ * Returns whether a new version is available and a dismiss handler.
+ * The banner reappears on the next successful check after dismissal.
+ */
+export function useVersionCheck() {
+  const [newVersionAvailable, setNewVersionAvailable] = useState(false)
+  const dismissedRef = useRef(false)
+
+  useEffect(() => {
+    // __APP_BUILD_VERSION__ is injected at build time by the versionJsonPlugin.
+    // In dev mode it won't exist, so skip polling entirely.
+    if (typeof __APP_BUILD_VERSION__ === 'undefined') return
+
+    const currentVersion = __APP_BUILD_VERSION__
+
+    async function check() {
+      try {
+        const res = await fetch(`/version.json?_=${Date.now()}`)
+        if (!res.ok) return
+        const data = await res.json()
+        if (data.version && data.version !== currentVersion) {
+          if (!dismissedRef.current) {
+            setNewVersionAvailable(true)
+          }
+        }
+      } catch {
+        // Network error — skip silently
+      }
+    }
+
+    const interval = setInterval(check, CHECK_INTERVAL_MS)
+
+    // Also check on visibility change (user returns to tab)
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        dismissedRef.current = false
+        check()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  function dismiss() {
+    setNewVersionAvailable(false)
+    dismissedRef.current = true
+  }
+
+  function refresh() {
+    window.location.reload()
+  }
+
+  return { newVersionAvailable, dismiss, refresh }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,26 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { writeFileSync } from 'fs'
+import { resolve } from 'path'
+
+function versionJsonPlugin(): Plugin {
+  const buildVersion = Date.now().toString()
+  return {
+    name: 'version-json',
+    config() {
+      return { define: { __APP_BUILD_VERSION__: JSON.stringify(buildVersion) } }
+    },
+    writeBundle(options) {
+      const outDir = options.dir ?? resolve(__dirname, 'dist')
+      writeFileSync(resolve(outDir, 'version.json'), JSON.stringify({ version: buildVersion }))
+    },
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), versionJsonPlugin()],
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Detects when a new frontend version has been deployed and shows a non-intrusive banner prompting the user to refresh
- Generates version.json at build time, frontend polls periodically to detect changes
- Banner is dismissible but reappears on next check

Source issue: re-9e3
Worker: slit
MR: hq-wisp-kjlf

🤖 Generated with [Claude Code](https://claude.com/claude-code)