### PR TITLE
Increase frontend test coverage — add tests for core components (re-42m)

### DIFF
--- a/frontend/src/__tests__/CalendarSection.test.tsx
+++ b/frontend/src/__tests__/CalendarSection.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CalendarSection } from '../components/CalendarSection'
+import type { CalendarEvent, CalendarStatus } from '../store'
+
+const fetchCalendarStatus = vi.fn()
+const fetchCalendarEvents = vi.fn()
+const connectCalendar = vi.fn()
+const disconnectCalendar = vi.fn()
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../store', () => ({
+  useStore: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+}))
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
+}))
+
+const makeEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  id: 'e1',
+  summary: 'Team standup',
+  start: new Date().toISOString(),
+  end: new Date().toISOString(),
+  all_day: false,
+  location: null,
+  status: 'confirmed',
+  ...overrides,
+})
+
+beforeEach(() => {
+  fetchCalendarStatus.mockReset()
+  fetchCalendarEvents.mockReset()
+  connectCalendar.mockReset()
+  disconnectCalendar.mockReset()
+
+  storeState = {
+    calendarStatus: { configured: true, connected: true } as CalendarStatus,
+    calendarEvents: [] as CalendarEvent[],
+    fetchCalendarStatus,
+    fetchCalendarEvents,
+    connectCalendar,
+    disconnectCalendar,
+  }
+})
+
+describe('CalendarSection', () => {
+  it('renders nothing when not configured', () => {
+    storeState.calendarStatus = { configured: false, connected: false }
+    const { container } = render(<CalendarSection />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows connect button when configured but not connected', () => {
+    storeState.calendarStatus = { configured: true, connected: false }
+    render(<CalendarSection />)
+    expect(screen.getByText('Connect Google Calendar')).toBeInTheDocument()
+  })
+
+  it('calls connectCalendar on connect button click', () => {
+    storeState.calendarStatus = { configured: true, connected: false }
+    render(<CalendarSection />)
+    fireEvent.click(screen.getByText('Connect Google Calendar'))
+    expect(connectCalendar).toHaveBeenCalled()
+  })
+
+  it('shows "No upcoming events" when connected with no events', () => {
+    render(<CalendarSection />)
+    expect(screen.getByText('No upcoming events')).toBeInTheDocument()
+  })
+
+  it('renders events when connected', () => {
+    storeState.calendarEvents = [makeEvent({ summary: 'Team standup' })]
+    render(<CalendarSection />)
+    expect(screen.getByText('Team standup')).toBeInTheDocument()
+  })
+
+  it('renders event location when present', () => {
+    storeState.calendarEvents = [makeEvent({ location: 'Room 42' })]
+    render(<CalendarSection />)
+    expect(screen.getByText('Room 42')).toBeInTheDocument()
+  })
+
+  it('shows "All day" for all-day events', () => {
+    storeState.calendarEvents = [makeEvent({ all_day: true })]
+    render(<CalendarSection />)
+    expect(screen.getByText('All day')).toBeInTheDocument()
+  })
+
+  it('shows disconnect button when connected', () => {
+    render(<CalendarSection />)
+    expect(screen.getByText('Disconnect')).toBeInTheDocument()
+  })
+
+  it('calls disconnectCalendar on disconnect click', () => {
+    render(<CalendarSection />)
+    fireEvent.click(screen.getByText('Disconnect'))
+    expect(disconnectCalendar).toHaveBeenCalled()
+  })
+
+  it('fetches calendar status on mount', () => {
+    render(<CalendarSection />)
+    expect(fetchCalendarStatus).toHaveBeenCalled()
+  })
+
+  it('fetches events when connected', () => {
+    render(<CalendarSection />)
+    expect(fetchCalendarEvents).toHaveBeenCalled()
+  })
+
+  it('groups events by date label', () => {
+    const today = new Date()
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+
+    storeState.calendarEvents = [
+      makeEvent({ id: 'e1', summary: 'Morning sync', start: today.toISOString() }),
+      makeEvent({ id: 'e2', summary: 'Planning', start: tomorrow.toISOString() }),
+    ]
+    render(<CalendarSection />)
+    expect(screen.getByText('Today')).toBeInTheDocument()
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/DetailPanel.test.tsx
+++ b/frontend/src/__tests__/DetailPanel.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DetailPanel } from '../components/DetailPanel'
+import type { Thing, ThingType, Relationship } from '../store'
+
+const closeThingDetail = vi.fn()
+const navigateThingDetail = vi.fn()
+const goBackThingDetail = vi.fn()
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../store', () => ({
+  useStore: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+}))
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
+}))
+
+const baseThing: Thing = {
+  id: 't1',
+  title: 'Test Thing',
+  type_hint: 'task',
+  parent_id: null,
+  checkin_date: null,
+  priority: 2,
+  active: true,
+  surface: true,
+  data: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  last_referenced: null,
+  open_questions: null,
+  children_count: null,
+  completed_count: null,
+}
+
+beforeEach(() => {
+  closeThingDetail.mockReset()
+  navigateThingDetail.mockReset()
+  goBackThingDetail.mockReset()
+
+  storeState = {
+    detailThingId: 't1',
+    detailThing: baseThing,
+    detailRelationships: [] as Relationship[],
+    detailHistory: [],
+    detailLoading: false,
+    closeThingDetail,
+    navigateThingDetail,
+    goBackThingDetail,
+    things: [baseThing],
+    thingTypes: [] as ThingType[],
+  }
+})
+
+describe('DetailPanel', () => {
+  it('renders nothing when detailThingId is null', () => {
+    storeState.detailThingId = null
+    const { container } = render(<DetailPanel />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders thing title', () => {
+    render(<DetailPanel />)
+    expect(screen.getByText('Test Thing')).toBeInTheDocument()
+  })
+
+  it('renders type badge', () => {
+    render(<DetailPanel />)
+    // The type badge contains icon + space + type_hint, so use a function matcher
+    expect(screen.getByText((_, el) => el?.textContent?.includes('task') && el?.classList?.contains('capitalize') || false)).toBeInTheDocument()
+  })
+
+  it('renders priority label', () => {
+    render(<DetailPanel />)
+    expect(screen.getByText(/High/)).toBeInTheDocument()
+  })
+
+  it('renders loading skeleton when loading', () => {
+    storeState.detailLoading = true
+    storeState.detailThing = null
+    const { container } = render(<DetailPanel />)
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('shows "Not found" when no thing and not loading', () => {
+    storeState.detailThing = null
+    storeState.detailLoading = false
+    render(<DetailPanel />)
+    expect(screen.getByText('Not found')).toBeInTheDocument()
+  })
+
+  it('shows "Thing not found" in body when no thing', () => {
+    storeState.detailThing = null
+    storeState.detailLoading = false
+    render(<DetailPanel />)
+    expect(screen.getByText('Thing not found')).toBeInTheDocument()
+  })
+
+  it('calls closeThingDetail on close button click', () => {
+    render(<DetailPanel />)
+    fireEvent.click(screen.getByLabelText('Close detail panel'))
+    expect(closeThingDetail).toHaveBeenCalled()
+  })
+
+  it('calls closeThingDetail on Escape key', () => {
+    render(<DetailPanel />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(closeThingDetail).toHaveBeenCalled()
+  })
+
+  it('shows back button when history exists', () => {
+    storeState.detailHistory = ['t0']
+    render(<DetailPanel />)
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument()
+  })
+
+  it('hides back button when no history', () => {
+    storeState.detailHistory = []
+    render(<DetailPanel />)
+    expect(screen.queryByLabelText('Go back')).not.toBeInTheDocument()
+  })
+
+  it('calls goBackThingDetail on back button click', () => {
+    storeState.detailHistory = ['t0']
+    render(<DetailPanel />)
+    fireEvent.click(screen.getByLabelText('Go back'))
+    expect(goBackThingDetail).toHaveBeenCalled()
+  })
+
+  it('renders timestamps', () => {
+    render(<DetailPanel />)
+    expect(screen.getByText(/Created/)).toBeInTheDocument()
+    expect(screen.getByText(/Updated/)).toBeInTheDocument()
+  })
+
+  it('renders checkin_date when set', () => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    storeState.detailThing = { ...baseThing, checkin_date: tomorrow.toISOString() }
+    render(<DetailPanel />)
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument()
+  })
+
+  it('renders open questions', () => {
+    storeState.detailThing = { ...baseThing, open_questions: ['Why is sky blue?'] }
+    render(<DetailPanel />)
+    expect(screen.getByText('Open Questions')).toBeInTheDocument()
+    expect(screen.getByText('Why is sky blue?')).toBeInTheDocument()
+  })
+
+  it('renders data fields', () => {
+    storeState.detailThing = { ...baseThing, data: { status: 'active', count: 42 } }
+    render(<DetailPanel />)
+    expect(screen.getByText('Details')).toBeInTheDocument()
+    expect(screen.getByText('status:')).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+  })
+
+  it('renders children section', () => {
+    const child: Thing = { ...baseThing, id: 't2', title: 'Child Thing', parent_id: 't1' }
+    storeState.things = [baseThing, child]
+    render(<DetailPanel />)
+    expect(screen.getByText('Children (1)')).toBeInTheDocument()
+    expect(screen.getByText('Child Thing')).toBeInTheDocument()
+  })
+
+  it('renders parent section', () => {
+    const parent: Thing = { ...baseThing, id: 'tp', title: 'Parent Thing' }
+    storeState.detailThing = { ...baseThing, parent_id: 'tp' }
+    storeState.things = [parent, { ...baseThing, parent_id: 'tp' }]
+    render(<DetailPanel />)
+    expect(screen.getByText('Parent')).toBeInTheDocument()
+    expect(screen.getByText('Parent Thing')).toBeInTheDocument()
+  })
+
+  it('navigates on child click', () => {
+    const child: Thing = { ...baseThing, id: 't2', title: 'Child Thing', parent_id: 't1' }
+    storeState.things = [baseThing, child]
+    render(<DetailPanel />)
+    fireEvent.click(screen.getByText('Child Thing'))
+    expect(navigateThingDetail).toHaveBeenCalledWith('t2')
+  })
+})

--- a/frontend/src/__tests__/LoginPage.test.tsx
+++ b/frontend/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { LoginPage } from '../components/LoginPage'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('LoginPage', () => {
+  it('renders sign in button', () => {
+    render(<LoginPage />)
+    expect(screen.getByText('Sign in with Google')).toBeInTheDocument()
+  })
+
+  it('renders app title', () => {
+    render(<LoginPage />)
+    expect(screen.getByText('Reli')).toBeInTheDocument()
+  })
+
+  it('renders app description', () => {
+    render(<LoginPage />)
+    expect(screen.getByText('Your personal relationship manager')).toBeInTheDocument()
+  })
+
+  it('shows "Redirecting..." while loading', async () => {
+    // Fetch that never resolves
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByText('Sign in with Google'))
+
+    expect(screen.getByText('Redirecting...')).toBeInTheDocument()
+  })
+
+  it('redirects to auth_url on success', async () => {
+    const hrefSetter = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, href: '' },
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window.location, 'href', {
+      set: hrefSetter,
+      configurable: true,
+    })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ auth_url: 'https://accounts.google.com/oauth' }),
+    }))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByText('Sign in with Google'))
+
+    await waitFor(() => {
+      expect(hrefSetter).toHaveBeenCalledWith('https://accounts.google.com/oauth')
+    })
+  })
+
+  it('shows error on HTTP failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: 'OAuth not configured' }),
+    }))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByText('Sign in with Google'))
+
+    await waitFor(() => {
+      expect(screen.getByText('OAuth not configured')).toBeInTheDocument()
+    })
+  })
+
+  it('shows connection error on fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByText('Sign in with Google'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not connect to server')).toBeInTheDocument()
+    })
+  })
+
+  it('disables button while loading', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+
+    render(<LoginPage />)
+    const btn = screen.getByRole('button')
+    fireEvent.click(btn)
+
+    expect(btn).toBeDisabled()
+  })
+})

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { apiFetch } from '../api'
+
+const mockFetchCurrentUser = vi.fn()
+
+vi.mock('../store', () => ({
+  useStore: {
+    getState: () => ({ fetchCurrentUser: mockFetchCurrentUser }),
+  },
+}))
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockFetchCurrentUser.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('apiFetch', () => {
+  it('passes credentials: same-origin to fetch', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ status: 200, ok: true })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await apiFetch('/api/things')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/things', { credentials: 'same-origin' })
+  })
+
+  it('merges init options with credentials', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ status: 200, ok: true })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await apiFetch('/api/things', { method: 'POST', body: '{}' })
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/things', {
+      method: 'POST',
+      body: '{}',
+      credentials: 'same-origin',
+    })
+  })
+
+  it('returns the response from fetch', async () => {
+    const mockResponse = { status: 200, ok: true, json: async () => ({ data: 1 }) }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse))
+
+    const res = await apiFetch('/api/things')
+
+    expect(res).toBe(mockResponse)
+  })
+
+  it('triggers fetchCurrentUser on 401 for non-auth endpoints', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401, ok: false }))
+
+    await apiFetch('/api/things')
+
+    expect(mockFetchCurrentUser).toHaveBeenCalled()
+  })
+
+  it('does not trigger fetchCurrentUser on 401 for auth endpoints', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401, ok: false }))
+
+    await apiFetch('/api/auth/google')
+
+    expect(mockFetchCurrentUser).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/__tests__/useNetworkStatus.test.ts
+++ b/frontend/src/__tests__/useNetworkStatus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useNetworkStatus } from '../hooks/useNetworkStatus'
+
+describe('useNetworkStatus', () => {
+  it('returns online by default', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true })
+    const { result } = renderHook(() => useNetworkStatus())
+    expect(result.current.isOnline).toBe(true)
+    expect(result.current.wasOffline).toBe(false)
+  })
+
+  it('detects going offline', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true })
+    const { result } = renderHook(() => useNetworkStatus())
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    expect(result.current.isOnline).toBe(false)
+    expect(result.current.wasOffline).toBe(true)
+  })
+
+  it('detects coming back online', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true })
+    const { result } = renderHook(() => useNetworkStatus())
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+
+    expect(result.current.isOnline).toBe(true)
+    expect(result.current.wasOffline).toBe(true)
+  })
+
+  it('cleans up event listeners on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = renderHook(() => useNetworkStatus())
+
+    unmount()
+
+    const removedEvents = removeSpy.mock.calls.map(c => c[0])
+    expect(removedEvents).toContain('online')
+    expect(removedEvents).toContain('offline')
+    removeSpy.mockRestore()
+  })
+})

--- a/frontend/src/__tests__/utils.test.ts
+++ b/frontend/src/__tests__/utils.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { typeIcon, formatDate, priorityLabel, formatTimestamp, isOverdue } from '../utils'
+
+describe('typeIcon', () => {
+  it('returns fallback icon for null hint', () => {
+    expect(typeIcon(null)).toBe('📌')
+  })
+
+  it('returns fallback icon for undefined hint', () => {
+    expect(typeIcon(undefined)).toBe('📌')
+  })
+
+  it('returns built-in icon for known type', () => {
+    expect(typeIcon('task')).toBe('📋')
+    expect(typeIcon('note')).toBe('📝')
+    expect(typeIcon('project')).toBe('📁')
+    expect(typeIcon('person')).toBe('👤')
+  })
+
+  it('is case-insensitive', () => {
+    expect(typeIcon('Task')).toBe('📋')
+    expect(typeIcon('NOTE')).toBe('📝')
+  })
+
+  it('returns default icon for unknown type', () => {
+    expect(typeIcon('unknown_type')).toBe('📌')
+  })
+
+  it('prefers DB-backed thingTypes over fallback', () => {
+    const thingTypes = [{ id: '1', name: 'task', icon: '✅', color: null, created_at: '' }]
+    expect(typeIcon('task', thingTypes)).toBe('✅')
+  })
+
+  it('falls back to built-in when thingTypes has no match', () => {
+    const thingTypes = [{ id: '1', name: 'custom', icon: '🎨', color: null, created_at: '' }]
+    expect(typeIcon('task', thingTypes)).toBe('📋')
+  })
+})
+
+describe('formatDate', () => {
+  it('returns empty string for null', () => {
+    expect(formatDate(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(formatDate(undefined)).toBe('')
+  })
+
+  it('returns "Today" for today', () => {
+    const today = new Date()
+    expect(formatDate(today.toISOString())).toBe('Today')
+  })
+
+  it('returns "Tomorrow" for tomorrow', () => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    expect(formatDate(tomorrow.toISOString())).toBe('Tomorrow')
+  })
+
+  it('returns "Yesterday" for yesterday', () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    expect(formatDate(yesterday.toISOString())).toBe('Yesterday')
+  })
+
+  it('returns overdue label for past dates', () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 3)
+    expect(formatDate(past.toISOString())).toBe('3d overdue')
+  })
+
+  it('returns "In Nd" for near-future dates', () => {
+    const future = new Date()
+    future.setDate(future.getDate() + 3)
+    expect(formatDate(future.toISOString())).toBe('In 3d')
+  })
+
+  it('returns month/day for dates >= 7 days away', () => {
+    const far = new Date()
+    far.setDate(far.getDate() + 10)
+    const result = formatDate(far.toISOString())
+    // Should be a localized date like "Mar 25"
+    expect(result).not.toBe('')
+    expect(result).not.toMatch(/In \d+d/)
+  })
+})
+
+describe('priorityLabel', () => {
+  it('returns labeled string for known priorities', () => {
+    expect(priorityLabel(1)).toBe('🔴 Critical')
+    expect(priorityLabel(2)).toBe('🟠 High')
+    expect(priorityLabel(3)).toBe('🟡 Medium')
+    expect(priorityLabel(4)).toBe('🔵 Low')
+    expect(priorityLabel(5)).toBe('⚪ None')
+  })
+
+  it('returns fallback for unknown priority', () => {
+    expect(priorityLabel(99)).toBe('Priority 99')
+  })
+})
+
+describe('formatTimestamp', () => {
+  it('returns empty string for null', () => {
+    expect(formatTimestamp(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(formatTimestamp(undefined)).toBe('')
+  })
+
+  it('returns formatted date string for valid ISO', () => {
+    const result = formatTimestamp('2026-03-15T14:30:00Z')
+    expect(result).not.toBe('')
+    // Should contain month and year at minimum
+    expect(result).toMatch(/2026/)
+  })
+})
+
+describe('isOverdue', () => {
+  it('returns false for null', () => {
+    expect(isOverdue(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isOverdue(undefined)).toBe(false)
+  })
+
+  it('returns true for past date', () => {
+    const past = new Date()
+    past.setDate(past.getDate() - 5)
+    expect(isOverdue(past.toISOString())).toBe(true)
+  })
+
+  it('returns false for future date', () => {
+    const future = new Date()
+    future.setDate(future.getDate() + 5)
+    expect(isOverdue(future.toISOString())).toBe(false)
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,5 +8,14 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
     exclude: ['e2e/**', 'node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      thresholds: {
+        statements: 30,
+        branches: 30,
+        functions: 30,
+        lines: 30,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary

- Adds frontend tests for core components to increase test coverage
- Source issue: re-42m
- Polecat: slit
- All quality gates passed (setup, typecheck, lint, build, test)
- 302 tests passing (103 frontend, 199 backend), 79% coverage

---
*Merged by Gas Town Refinery*