### PR TITLE
feat: add mobile tab navigation for Things/Chat views (re-88d)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,11 +10,13 @@ import { OfflineIndicator } from './components/OfflineIndicator'
 import { SettingsPanel } from './components/SettingsPanel'
 
 function App() {
-  const { currentUser, authChecked, settingsOpen, fetchCurrentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, error } = useStore(
+  const { currentUser, authChecked, settingsOpen, mobileView, setMobileView, fetchCurrentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, error } = useStore(
     useShallow(s => ({
       currentUser: s.currentUser,
       authChecked: s.authChecked,
       settingsOpen: s.settingsOpen,
+      mobileView: s.mobileView,
+      setMobileView: s.setMobileView,
       fetchCurrentUser: s.fetchCurrentUser,
       fetchThingTypes: s.fetchThingTypes,
       fetchThings: s.fetchThings,
@@ -96,9 +98,51 @@ function App() {
         </div>
       )}
       <OfflineIndicator />
-      <Sidebar />
-      <ChatPanel />
-      <DetailPanel />
+      {/* Desktop: side-by-side layout */}
+      <div className="hidden md:contents">
+        <Sidebar />
+        <ChatPanel />
+        <DetailPanel />
+      </div>
+      {/* Mobile: show one panel at a time based on mobileView */}
+      <div className="contents md:hidden">
+        <div className={`flex-1 flex flex-col min-w-0 ${mobileView === 'things' ? '' : 'hidden'}`}>
+          <Sidebar />
+        </div>
+        <div className={`flex-1 flex flex-col min-w-0 ${mobileView === 'chat' ? '' : 'hidden'}`}>
+          <ChatPanel />
+        </div>
+        <DetailPanel />
+      </div>
+      {/* Mobile bottom tab bar */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 flex border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 safe-area-pb">
+        <button
+          onClick={() => setMobileView('things')}
+          className={`flex-1 flex flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors ${
+            mobileView === 'things'
+              ? 'text-indigo-600 dark:text-indigo-400'
+              : 'text-gray-400 dark:text-gray-500'
+          }`}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+          </svg>
+          Things
+        </button>
+        <button
+          onClick={() => setMobileView('chat')}
+          className={`flex-1 flex flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors ${
+            mobileView === 'chat'
+              ? 'text-indigo-600 dark:text-indigo-400'
+              : 'text-gray-400 dark:text-gray-500'
+          }`}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
+          </svg>
+          Chat
+        </button>
+      </nav>
       {settingsOpen && <SettingsPanel />}
     </div>
   )

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -518,7 +518,7 @@ export function ChatPanel() {
   }
 
   return (
-    <div className="flex-1 flex flex-col bg-gray-50 dark:bg-gray-900 min-w-0">
+    <div className="flex-1 flex flex-col bg-gray-50 dark:bg-gray-900 min-w-0 pb-14 md:pb-0">
       {/* Title bar */}
       <div className="px-5 py-3 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shrink-0 flex items-start justify-between">
         <div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -223,12 +223,12 @@ export function Sidebar() {
 
   return (
     <>
-      {/* Toggle button — visible when sidebar is closed */}
+      {/* Toggle button — visible on desktop when sidebar is closed */}
       {!isOpen && (
         <button
           onClick={() => setIsOpen(true)}
           aria-label="Open sidebar"
-          className="fixed top-3 left-3 z-50 p-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors md:static md:m-0 md:border-0 md:shadow-none md:rounded-none md:bg-gray-50 md:dark:bg-gray-950 md:border-r md:border-gray-200 md:dark:border-gray-800 md:px-2 md:py-3"
+          className="hidden md:block md:static md:m-0 md:border-0 md:shadow-none md:rounded-none md:bg-gray-50 md:dark:bg-gray-950 md:border-r md:border-gray-200 md:dark:border-gray-800 md:px-2 md:py-3 p-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -236,23 +236,14 @@ export function Sidebar() {
         </button>
       )}
 
-      {/* Backdrop — mobile only, when sidebar is open */}
-      {isOpen && (
-        <div
-          onClick={() => { if (window.innerWidth < 768) setIsOpen(false) }}
-          className="fixed inset-0 z-40 bg-black/30 transition-opacity md:hidden"
-        />
-      )}
-
       {/* Sidebar panel */}
       <aside
         style={{ width: window.innerWidth >= 768 ? sidebarWidth : undefined }}
         className={`
-          fixed inset-y-0 left-0 z-50 w-72 md:w-auto flex flex-col border-r border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 overflow-y-auto
-          transform transition-transform duration-200 ease-in-out
-          ${isOpen ? 'translate-x-0' : '-translate-x-full'}
-          md:static md:z-auto md:shrink-0 md:relative
-          ${isOpen ? '' : 'md:-translate-x-full md:hidden'}
+          flex flex-col border-r border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 overflow-y-auto
+          w-full pb-14
+          md:pb-0 md:w-auto md:shrink-0 md:relative
+          ${isOpen ? '' : 'md:hidden'}
         `}
       >
         {/* Header */}
@@ -304,7 +295,7 @@ export function Sidebar() {
             <button
               onClick={() => setIsOpen(false)}
               aria-label="Close sidebar"
-              className="p-1.5 rounded-lg text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              className="hidden md:block p-1.5 rounded-lg text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -205,6 +205,10 @@ interface ReliState {
   connectCalendar: () => Promise<void>
   disconnectCalendar: () => Promise<void>
 
+  // Mobile navigation
+  mobileView: 'things' | 'chat'
+  setMobileView: (view: 'things' | 'chat') => void
+
   // Settings
   settingsOpen: boolean
   modelSettings: ModelSettings | null
@@ -681,6 +685,10 @@ export const useStore = create<ReliState>((set, get) => ({
   },
 
   clearError: () => set({ error: null }),
+
+  // Mobile navigation
+  mobileView: 'things',
+  setMobileView: (view) => set({ mobileView: view }),
 
   // Settings
   settingsOpen: false,


### PR DESCRIPTION
## Summary
- Adds tab navigation for mobile layout so chat panel is accessible on phones
- Fixes bug where chat panel was not visible on small screens

## Source
- Issue: re-88d
- Polecat: toast

## Quality Gates
- All gates passed (typecheck, lint, test, build)
- 110 frontend tests passed, 199 backend tests passed