### PR TITLE
Add OpenAPI/Swagger docs generation for backend API (re-6k2)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,15 +38,66 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     stop_scheduler()
 
 
+_TAG_METADATA = [
+    {
+        "name": "auth",
+        "description": "Google OAuth2 login, JWT session management, and user profile.",
+    },
+    {
+        "name": "things",
+        "description": "CRUD operations for Things — the universal data model (tasks, notes, projects, ideas, goals).",
+    },
+    {
+        "name": "thing-types",
+        "description": "Manage custom Thing Types with icons and colors.",
+    },
+    {
+        "name": "chat",
+        "description": "Multi-agent chat pipeline and chat history management.",
+    },
+    {
+        "name": "briefing",
+        "description": "Daily briefing: checkin-due Things and sweep findings.",
+    },
+    {
+        "name": "gmail",
+        "description": "Gmail read-only integration: OAuth2 connection and message access.",
+    },
+    {
+        "name": "calendar",
+        "description": "Google Calendar read-only integration: OAuth2 connection and upcoming events.",
+    },
+    {
+        "name": "proactive",
+        "description": "Proactive surfaces — Things with upcoming time-relevant dates.",
+    },
+    {
+        "name": "settings",
+        "description": "Application settings: LLM model configuration via Requesty.",
+    },
+    {
+        "name": "sweep",
+        "description": "Nightly sweep: SQL candidate collection and LLM-powered reflection.",
+    },
+    {
+        "name": "health",
+        "description": "Health check endpoint.",
+    },
+]
+
 app = FastAPI(
     title="Reli API",
     description=(
         "Reli is a conversation-driven personal information manager. "
         "All data is stored locally in SQLite. "
-        "The Universal Thing model represents tasks, notes, projects, ideas, and goals."
+        "The Universal Thing model represents tasks, notes, projects, ideas, and goals.\n\n"
+        "## Authentication\n\n"
+        "Most endpoints require a valid JWT session cookie (`reli_session`). "
+        "Obtain one by completing the Google OAuth2 flow via `/api/auth/google`."
     ),
     version="0.1.0",
     lifespan=lifespan,
+    openapi_tags=_TAG_METADATA,
 )
 
 app.add_middleware(
@@ -77,8 +128,9 @@ app.include_router(settings.router, prefix="/api", dependencies=_api_deps)
 app.include_router(sweep.router, prefix="/api", dependencies=_api_deps)
 
 
-@app.get("/healthz", tags=["health"])
+@app.get("/healthz", tags=["health"], summary="Health check", description="Returns service health status.")
 def health() -> dict[str, str]:
+    """Returns service health status."""
     return {"status": "ok", "service": "reli"}
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -9,9 +9,11 @@ from pydantic import BaseModel, Field
 
 
 class ThingTypeCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=100)
-    icon: str = Field(default="📌", max_length=10)
-    color: str | None = Field(default=None, max_length=50)
+    """Create a new Thing Type with a name, icon, and optional color."""
+
+    name: str = Field(..., min_length=1, max_length=100, examples=["person"])
+    icon: str = Field(default="📌", max_length=10, examples=["👤"])
+    color: str | None = Field(default=None, max_length=50, examples=["blue"])
 
 
 class ThingTypeUpdate(BaseModel):
@@ -34,27 +36,35 @@ class ThingType(BaseModel):
 
 
 class ThingCreate(BaseModel):
-    title: str = Field(..., min_length=1, max_length=500)
-    type_hint: str | None = None
-    parent_id: str | None = None
-    checkin_date: datetime | None = None
-    priority: int = Field(default=3, ge=1, le=5)
-    active: bool = True
-    surface: bool = True
-    data: dict[str, Any] | None = None
-    open_questions: list[str] | None = None
+    """Create a new Thing (task, note, project, idea, goal, person, etc.)."""
+
+    title: str = Field(..., min_length=1, max_length=500, examples=["Buy groceries"])
+    type_hint: str | None = Field(default=None, examples=["task"])
+    parent_id: str | None = Field(default=None, description="Parent Thing ID for hierarchical nesting")
+    checkin_date: datetime | None = Field(
+        default=None, description="Date when this Thing should surface in the briefing"
+    )
+    priority: int = Field(default=3, ge=1, le=5, description="1 (highest) to 5 (lowest)")
+    active: bool = Field(default=True, description="Inactive = completed/archived")
+    surface: bool = Field(default=True, description="Whether to show in default views")
+    data: dict[str, Any] | None = Field(default=None, description="Arbitrary JSON data (e.g. birthday, email, notes)")
+    open_questions: list[str] | None = Field(default=None, description="Unresolved questions about this Thing")
 
 
 class ThingUpdate(BaseModel):
+    """Partial update for a Thing. Only provided fields are changed."""
+
     title: str | None = Field(default=None, min_length=1, max_length=500)
     type_hint: str | None = None
-    parent_id: str | None = None
-    checkin_date: datetime | None = None
-    priority: int | None = Field(default=None, ge=1, le=5)
-    active: bool | None = None
-    surface: bool | None = None
-    data: dict[str, Any] | None = None
-    open_questions: list[str] | None = None
+    parent_id: str | None = Field(default=None, description="Parent Thing ID for hierarchical nesting")
+    checkin_date: datetime | None = Field(
+        default=None, description="Date when this Thing should surface in the briefing"
+    )
+    priority: int | None = Field(default=None, ge=1, le=5, description="1 (highest) to 5 (lowest)")
+    active: bool | None = Field(default=None, description="Inactive = completed/archived")
+    surface: bool | None = Field(default=None, description="Whether to show in default views")
+    data: dict[str, Any] | None = Field(default=None, description="Arbitrary JSON data")
+    open_questions: list[str] | None = Field(default=None, description="Unresolved questions about this Thing")
 
 
 class Thing(BaseModel):
@@ -81,10 +91,14 @@ class Thing(BaseModel):
 
 
 class RelationshipCreate(BaseModel):
-    from_thing_id: str
-    to_thing_id: str
-    relationship_type: str = Field(..., min_length=1, max_length=100)
-    metadata: dict[str, Any] | None = None
+    """Create a typed relationship between two Things."""
+
+    from_thing_id: str = Field(..., description="Source Thing ID")
+    to_thing_id: str = Field(..., description="Target Thing ID")
+    relationship_type: str = Field(
+        ..., min_length=1, max_length=100, examples=["works_with"], description="Relationship label"
+    )
+    metadata: dict[str, Any] | None = Field(default=None, description="Optional metadata for this relationship")
 
 
 class Relationship(BaseModel):
@@ -127,8 +141,10 @@ class ChatMessage(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    session_id: str = Field(..., min_length=1)
-    message: str = Field(..., min_length=1)
+    """Send a message through the multi-agent chat pipeline."""
+
+    session_id: str = Field(..., min_length=1, description="Chat session identifier", examples=["session-abc123"])
+    message: str = Field(..., min_length=1, description="User message text", examples=["What tasks are due this week?"])
 
 
 class UsageInfo(BaseModel):
@@ -190,15 +206,21 @@ class SweepFinding(BaseModel):
 
 
 class SweepFindingCreate(BaseModel):
-    thing_id: str | None = None
-    finding_type: str = Field(..., min_length=1, max_length=100)
-    message: str = Field(..., min_length=1)
-    priority: int = Field(default=2, ge=0, le=4)
-    expires_at: datetime | None = None
+    """Create a sweep finding (insight from the nightly sweep)."""
+
+    thing_id: str | None = Field(default=None, description="Related Thing ID, if applicable")
+    finding_type: str = Field(
+        ..., min_length=1, max_length=100, examples=["stale_task"], description="Category of finding"
+    )
+    message: str = Field(..., min_length=1, description="Human-readable finding message")
+    priority: int = Field(default=2, ge=0, le=4, description="0 (critical) to 4 (backlog)")
+    expires_at: datetime | None = Field(default=None, description="Auto-dismiss after this time")
 
 
 class SweepFindingSnooze(BaseModel):
-    until: datetime
+    """Snooze a finding until a given date."""
+
+    until: datetime = Field(..., description="Hide the finding from the briefing until this time")
 
 
 class BriefingResponse(BaseModel):

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -129,6 +129,7 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
 
     # Google returns scopes in expanded URI form; tell oauthlib to accept it
     import os as _os
+
     _os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
 
     try:

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -96,9 +96,9 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
     )
 
 
-@router.post("/findings", response_model=SweepFinding, status_code=201)
+@router.post("/findings", response_model=SweepFinding, status_code=201, summary="Create a sweep finding")
 def create_finding(body: SweepFindingCreate, user_id: str = Depends(require_user)) -> SweepFinding:
-    """Create a new sweep finding."""
+    """Create a new sweep finding, optionally linked to a Thing."""
     finding_id = f"sf-{uuid.uuid4().hex[:8]}"
     now = datetime.utcnow().isoformat()
 
@@ -131,9 +131,9 @@ def create_finding(body: SweepFindingCreate, user_id: str = Depends(require_user
     return _row_to_finding(row)
 
 
-@router.patch("/findings/{finding_id}/dismiss", response_model=SweepFinding)
+@router.patch("/findings/{finding_id}/dismiss", response_model=SweepFinding, summary="Dismiss a sweep finding")
 def dismiss_finding(finding_id: str, user_id: str = Depends(require_user)) -> SweepFinding:
-    """Dismiss a sweep finding."""
+    """Dismiss a sweep finding so it no longer appears in the daily briefing."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT * FROM sweep_findings WHERE id = ?{uf_sql}", [finding_id, *uf_params]).fetchone()
@@ -146,9 +146,9 @@ def dismiss_finding(finding_id: str, user_id: str = Depends(require_user)) -> Sw
     return _row_to_finding(row)
 
 
-@router.post("/findings/{finding_id}/snooze", response_model=SweepFinding)
+@router.post("/findings/{finding_id}/snooze", response_model=SweepFinding, summary="Snooze a sweep finding")
 def snooze_finding(finding_id: str, body: SweepFindingSnooze, user_id: str = Depends(require_user)) -> SweepFinding:
-    """Snooze a sweep finding — hide it from the briefing until the given date."""
+    """Snooze a sweep finding — hide it from the daily briefing until the given date."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT * FROM sweep_findings WHERE id = ?{uf_sql}", [finding_id, *uf_params]).fetchone()

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -57,10 +57,11 @@ def _row_to_msg(row: sqlite3.Row) -> ChatMessage:
 @router.get("/history/{session_id}", response_model=list[ChatMessage], summary="Get chat history for a session")
 def get_history(
     session_id: str,
-    limit: int = Query(50, ge=1, le=500),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of messages to return"),
     before: int | None = Query(None, description="Return messages with id < before (for loading older messages)"),
     user_id: str = Depends(require_user),
 ) -> list[ChatMessage]:
+    """Retrieve chat messages for a session, ordered chronologically. Supports cursor-based pagination via `before`."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         if before is not None:
@@ -82,6 +83,7 @@ def get_history(
     "/history", response_model=ChatMessage, status_code=status.HTTP_201_CREATED, summary="Append a chat message"
 )
 def append_message(body: ChatMessageCreate, user_id: str = Depends(require_user)) -> ChatMessage:
+    """Append a single chat message to a session's history."""
     changes_json = json.dumps(body.applied_changes) if body.applied_changes is not None else None
     with db() as conn:
         cursor = conn.execute(
@@ -96,6 +98,7 @@ def append_message(body: ChatMessageCreate, user_id: str = Depends(require_user)
     "/history/{session_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a session's chat history"
 )
 def delete_history(session_id: str, user_id: str = Depends(require_user)) -> None:
+    """Delete all messages in a chat session."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         result = conn.execute(f"DELETE FROM chat_history WHERE session_id = ?{uf_sql}", [session_id, *uf_params])

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -69,7 +69,7 @@ def _reload_agent_vars(models: dict[str, str]) -> None:
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 
-@router.get("/models", response_model=list[RequestyModel])
+@router.get("/models", response_model=list[RequestyModel], summary="List available LLM models")
 def list_models(_user_id: str = Depends(require_user)) -> list[RequestyModel]:
     """Proxy the Requesty /v1/models endpoint and return available model IDs."""
     cfg = _read_config()
@@ -85,9 +85,9 @@ def list_models(_user_id: str = Depends(require_user)) -> list[RequestyModel]:
         raise HTTPException(status_code=502, detail="Could not fetch models from Requesty API") from exc
 
 
-@router.get("", response_model=ModelSettings)
+@router.get("", response_model=ModelSettings, summary="Get current model settings")
 def get_settings(_user_id: str = Depends(require_user)) -> ModelSettings:
-    """Return current model configuration."""
+    """Return current model configuration for the context, reasoning, and response agents."""
     cfg = _read_config()
     models = cfg.get("llm", {}).get("models", {})
     return ModelSettings(
@@ -97,12 +97,12 @@ def get_settings(_user_id: str = Depends(require_user)) -> ModelSettings:
     )
 
 
-@router.put("", response_model=ModelSettings)
+@router.put("", response_model=ModelSettings, summary="Update model settings")
 def update_settings(
     body: ModelSettingsUpdate,
     _user_id: str = Depends(require_user),
 ) -> ModelSettings:
-    """Update model configuration in config.yaml and reload in-memory vars."""
+    """Update model configuration in config.yaml and reload in-memory vars. Only provided fields are changed."""
     cfg = _read_config()
 
     if "llm" not in cfg:

--- a/backend/routers/thing_types.py
+++ b/backend/routers/thing_types.py
@@ -32,9 +32,10 @@ def _row_to_thing_type(row: Any) -> ThingType:
 
 @router.get("", response_model=list[ThingType], summary="List all Thing Types")
 def list_thing_types(
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500, description="Maximum number of results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
 ) -> list[ThingType]:
+    """List all Thing Types, sorted alphabetically by name."""
     with db() as conn:
         rows = conn.execute(
             "SELECT * FROM thing_types ORDER BY name ASC LIMIT ? OFFSET ?",
@@ -45,6 +46,7 @@ def list_thing_types(
 
 @router.get("/{type_id}", response_model=ThingType, summary="Get a Thing Type")
 def get_thing_type(type_id: str) -> ThingType:
+    """Retrieve a single Thing Type by ID."""
     with db() as conn:
         row = conn.execute("SELECT * FROM thing_types WHERE id = ?", (type_id,)).fetchone()
     if not row:
@@ -54,6 +56,7 @@ def get_thing_type(type_id: str) -> ThingType:
 
 @router.post("", response_model=ThingType, status_code=status.HTTP_201_CREATED, summary="Create a Thing Type")
 def create_thing_type(body: ThingTypeCreate) -> ThingType:
+    """Create a new Thing Type. Names must be unique."""
     type_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat()
     with db() as conn:
@@ -74,6 +77,7 @@ def create_thing_type(body: ThingTypeCreate) -> ThingType:
 
 @router.patch("/{type_id}", response_model=ThingType, summary="Update a Thing Type")
 def update_thing_type(type_id: str, body: ThingTypeUpdate) -> ThingType:
+    """Partially update a Thing Type. Names must remain unique."""
     with db() as conn:
         row = conn.execute("SELECT * FROM thing_types WHERE id = ?", (type_id,)).fetchone()
         if not row:
@@ -109,6 +113,7 @@ def update_thing_type(type_id: str, body: ThingTypeUpdate) -> ThingType:
 
 @router.delete("/{type_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a Thing Type")
 def delete_thing_type(type_id: str) -> None:
+    """Delete a Thing Type by ID."""
     with db() as conn:
         row = conn.execute("SELECT id FROM thing_types WHERE id = ?", (type_id,)).fetchone()
         if not row:

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -83,12 +83,13 @@ def _row_to_thing(row: sqlite3.Row) -> Thing:
 
 @router.get("/search", response_model=list[Thing], summary="Search Things across the full graph")
 def search_things(
-    q: str = Query("", description="Search query"),
+    q: str = Query("", description="Free-text search query matched against title, data, type_hint, and relationships"),
     active_only: bool = Query(False, description="Filter to active Things only"),
-    type_hint: str | None = Query(None, description="Filter by type_hint"),
-    limit: int = Query(50, ge=1, le=200),
+    type_hint: str | None = Query(None, description="Filter by type_hint (e.g. 'task', 'project', 'person')"),
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
     user_id: str = Depends(require_user),
 ) -> list[Thing]:
+    """Search Things by text query across title, data, type_hint, and related Things."""
     if not q.strip():
         return []
 
@@ -155,10 +156,11 @@ def search_things(
 @router.get("", response_model=list[Thing], summary="List Things")
 def list_things(
     active_only: bool = Query(True, description="Filter to active Things only"),
-    limit: int = Query(100, ge=1, le=1000),
-    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of results"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
     user_id: str = Depends(require_user),
 ) -> list[Thing]:
+    """List all Things with optional filtering and pagination. Projects include child counts."""
     with db() as conn:
         where = "WHERE 1=1"
         params: list[str | int] = []
@@ -198,6 +200,7 @@ def list_things(
 
 @router.post("", response_model=Thing, status_code=status.HTTP_201_CREATED, summary="Create a Thing")
 def create_thing(body: ThingCreate, background_tasks: BackgroundTasks, user_id: str = Depends(require_user)) -> Thing:
+    """Create a new Thing and index it for vector search."""
     thing_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat()
     data_json = json.dumps(body.data) if body.data is not None else None
@@ -239,6 +242,7 @@ def create_thing(body: ThingCreate, background_tasks: BackgroundTasks, user_id: 
 
 @router.get("/{thing_id}", response_model=Thing, summary="Get a Thing")
 def get_thing(thing_id: str, user_id: str = Depends(require_user)) -> Thing:
+    """Retrieve a single Thing by ID."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT * FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
@@ -251,6 +255,7 @@ def get_thing(thing_id: str, user_id: str = Depends(require_user)) -> Thing:
 def update_thing(
     thing_id: str, body: ThingUpdate, background_tasks: BackgroundTasks, user_id: str = Depends(require_user)
 ) -> Thing:
+    """Partially update a Thing. Only provided fields are changed."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT * FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
@@ -295,6 +300,7 @@ def update_thing(
 
 @router.delete("/{thing_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a Thing")
 def delete_thing(thing_id: str, background_tasks: BackgroundTasks, user_id: str = Depends(require_user)) -> None:
+    """Delete a Thing and remove it from the vector index."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT id FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
@@ -306,6 +312,7 @@ def delete_thing(thing_id: str, background_tasks: BackgroundTasks, user_id: str 
 
 @router.post("/reindex", summary="Re-embed all Things with the current embedding model")
 def reindex_things(user_id: str = Depends(require_user)) -> dict[str, int]:
+    """Rebuild the vector search index for all Things. Returns the count of re-indexed items."""
     count = reindex_all()
     return {"reindexed": count}
 
@@ -334,6 +341,7 @@ def _parse_rel_row(row: sqlite3.Row) -> Relationship:
 
 @router.get("/{thing_id}/relationships", response_model=list[Relationship], summary="List relationships for a Thing")
 def list_relationships(thing_id: str, user_id: str = Depends(require_user)) -> list[Relationship]:
+    """List all relationships where the given Thing is either the source or target."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
         row = conn.execute(f"SELECT id FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
@@ -350,6 +358,7 @@ def list_relationships(thing_id: str, user_id: str = Depends(require_user)) -> l
     "/relationships", response_model=Relationship, status_code=status.HTTP_201_CREATED, summary="Create a relationship"
 )
 def create_relationship(body: RelationshipCreate, user_id: str = Depends(require_user)) -> Relationship:
+    """Create a typed relationship between two Things."""
     rel_id = str(uuid.uuid4())
     meta_json = json.dumps(body.metadata) if body.metadata is not None else None
     uf_sql, uf_params = user_filter(user_id)
@@ -371,6 +380,7 @@ def create_relationship(body: RelationshipCreate, user_id: str = Depends(require
 
 @router.delete("/relationships/{rel_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a relationship")
 def delete_relationship(rel_id: str) -> None:
+    """Delete a relationship by ID."""
     with db() as conn:
         row = conn.execute("SELECT id FROM thing_relationships WHERE id = ?", (rel_id,)).fetchone()
         if not row:

--- a/backend/tests/test_api_contracts.py
+++ b/backend/tests/test_api_contracts.py
@@ -409,6 +409,61 @@ class TestHealthContract:
 
 
 # ===========================================================================
+# Contract tests — OpenAPI schema
+# ===========================================================================
+
+
+class TestOpenAPIContract:
+    """Verify OpenAPI schema is accessible and properly structured."""
+
+    def test_openapi_json_accessible(self, client):
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        assert schema["info"]["title"] == "Reli API"
+        assert schema["info"]["version"] == "0.1.0"
+
+    def test_openapi_has_tag_metadata(self, client):
+        schema = client.get("/openapi.json").json()
+        tag_names = [t["name"] for t in schema.get("tags", [])]
+        expected = [
+            "auth",
+            "things",
+            "thing-types",
+            "chat",
+            "briefing",
+            "gmail",
+            "calendar",
+            "proactive",
+            "settings",
+            "sweep",
+            "health",
+        ]
+        for name in expected:
+            assert name in tag_names, f"Tag '{name}' missing from OpenAPI schema"
+
+    def test_openapi_tags_have_descriptions(self, client):
+        schema = client.get("/openapi.json").json()
+        for tag in schema.get("tags", []):
+            assert tag.get("description"), f"Tag '{tag['name']}' has no description"
+
+    def test_openapi_endpoints_have_summaries(self, client):
+        schema = client.get("/openapi.json").json()
+        paths_without_summary = []
+        for path, methods in schema.get("paths", {}).items():
+            for method, details in methods.items():
+                if method in ("get", "post", "put", "patch", "delete"):
+                    if not details.get("summary") and details.get("include_in_schema", True):
+                        paths_without_summary.append(f"{method.upper()} {path}")
+        assert not paths_without_summary, f"Endpoints missing summary: {paths_without_summary}"
+
+    def test_docs_endpoint_accessible(self, client):
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+        assert "swagger-ui" in resp.text.lower() or "openapi" in resp.text.lower()
+
+
+# ===========================================================================
 # Security tests — SPA fallback directory traversal (re-tam)
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Add OpenAPI/Swagger documentation generation for the backend API
- Enables auto-generated API docs accessible via FastAPI's built-in endpoints

**Issue**: re-6k2
**Polecat**: toast
**Tests**: 314 passed (110 frontend, 204 backend)

---
*Created by Gas Town Refinery*