### PR TITLE
Move full-view Thing sidebar to the left, pushing chat right (re-i11)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,8 +101,8 @@ function App() {
       {/* Desktop: side-by-side layout */}
       <div className="hidden md:contents">
         <Sidebar />
-        <ChatPanel />
         <DetailPanel />
+        <ChatPanel />
       </div>
       {/* Mobile: show one panel at a time based on mobileView */}
       <div className="contents md:hidden">

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -82,11 +82,11 @@ export function DetailPanel() {
       {/* Backdrop for mobile */}
       <div
         onClick={closeThingDetail}
-        className="fixed inset-0 z-50 bg-black/20 md:bg-transparent md:pointer-events-none"
+        className="fixed inset-0 z-50 bg-black/20 md:hidden"
       />
 
-      {/* Panel */}
-      <div className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-md bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 shadow-xl flex flex-col overflow-hidden animate-slide-in-right">
+      {/* Panel — desktop: inline flex child on left; mobile: fixed overlay from left */}
+      <div className="fixed left-0 top-0 bottom-0 z-50 w-full max-w-md bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 shadow-xl flex flex-col overflow-hidden animate-slide-in-left md:relative md:z-auto md:w-80 md:max-w-none md:shrink-0 md:shadow-none md:animate-none md:border-r">
         {/* Header */}
         <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-800 shrink-0">
           {canGoBack && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,3 +24,12 @@ body {
 .animate-slide-in-right {
   animation: slide-in-right 0.2s ease-out;
 }
+
+@keyframes slide-in-left {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+.animate-slide-in-left {
+  animation: slide-in-left 0.2s ease-out;
+}


### PR DESCRIPTION
## Summary

- Move the Thing sidebar to the left side of the layout
- Chat panel pushed to the right for better UX flow

**Issue**: re-i11
**Polecat**: furiosa
**Tests**: 309 passed (110 frontend, 199 backend)

---
*Created by Gas Town Refinery*