### PR TITLE
feat: add settings screen with configurable chat context window size (re-qgt)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -321,7 +321,10 @@ async def _chat_ollama(
 
 
 async def run_context_agent(
-    message: str, history: list[dict[str, Any]], usage_stats: UsageStats | None = None
+    message: str,
+    history: list[dict[str, Any]],
+    usage_stats: UsageStats | None = None,
+    context_window: int = 10,
 ) -> dict[str, Any]:
     """Stage 1: decide what to search for.
 
@@ -329,7 +332,7 @@ async def run_context_agent(
     to Requesty if Ollama is unavailable.
     """
     messages = [{"role": "system", "content": CONTEXT_AGENT_SYSTEM}]
-    for h in history[-10:]:
+    for h in history[-context_window:]:
         messages.append({"role": h["role"], "content": h["content"]})
     messages.append({"role": "user", "content": message})
 
@@ -470,6 +473,7 @@ async def run_reasoning_agent(
     gmail_context: list[dict[str, Any]] | None = None,
     calendar_events: list[dict[str, Any]] | None = None,
     usage_stats: UsageStats | None = None,
+    context_window: int = 10,
 ) -> dict[str, Any]:
     """Stage 2: decide what changes to make."""
     from datetime import datetime, timezone
@@ -489,7 +493,7 @@ async def run_reasoning_agent(
         cal_json = json.dumps(calendar_events, default=str)
         user_content += f"\n\nUpcoming Google Calendar events:\n{cal_json}"
     messages = [{"role": "system", "content": REASONING_AGENT_SYSTEM}]
-    for h in history[-10:]:
+    for h in history[-context_window:]:
         messages.append({"role": h["role"], "content": h["content"]})
     messages.append({"role": "user", "content": user_content})
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -19,6 +19,7 @@ from ..agents import (
 )
 from ..auth import require_user, user_filter
 from ..database import db
+from .settings import get_chat_context_window
 from ..google_calendar import fetch_upcoming_events
 from ..google_calendar import is_connected as gcal_connected
 from ..models import ChatMessage, ChatMessageCreate, ChatRequest, ChatResponse, ModelUsage, SessionUsage, UsageInfo
@@ -263,11 +264,15 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
     session_id = body.session_id
     message = body.message
 
-    # Fetch conversation history
+    # Read configured context window size
+    context_window = get_chat_context_window()
+
+    # Fetch conversation history (2x window as buffer, agents slice to window size)
+    history_limit = context_window * 2
     with db() as conn:
         rows = conn.execute(
-            "SELECT role, content FROM chat_history WHERE session_id = ? ORDER BY timestamp ASC LIMIT 20",
-            (session_id,),
+            "SELECT role, content FROM chat_history WHERE session_id = ? ORDER BY timestamp ASC LIMIT ?",
+            (session_id, history_limit),
         ).fetchall()
     history = [{"role": r["role"], "content": r["content"]} for r in rows]
 
@@ -275,7 +280,7 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
     usage = UsageStats()
 
     # Stage 1: Context Agent
-    context_result = await run_context_agent(message, history, usage_stats=usage)
+    context_result = await run_context_agent(message, history, usage_stats=usage, context_window=context_window)
     search_queries = context_result.get("search_queries", [message])
     filter_params = context_result.get("filter_params", {})
     gmail_query = context_result.get("gmail_query")
@@ -332,7 +337,14 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
 
     # Stage 2: Reasoning Agent
     reasoning_result = await run_reasoning_agent(
-        message, history, relevant_things, web_results, gmail_context, calendar_events, usage_stats=usage
+        message,
+        history,
+        relevant_things,
+        web_results,
+        gmail_context,
+        calendar_events,
+        usage_stats=usage,
+        context_window=context_window,
     )
     storage_changes = reasoning_result.get("storage_changes", {})
     questions_for_user = reasoning_result.get("questions_for_user", [])

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -25,12 +25,14 @@ class ModelSettings(BaseModel):
     context: str
     reasoning: str
     response: str
+    chat_context_window: int = 10
 
 
 class ModelSettingsUpdate(BaseModel):
     context: str | None = None
     reasoning: str | None = None
     response: str | None = None
+    chat_context_window: int | None = None
 
 
 class RequestyModel(BaseModel):
@@ -66,6 +68,13 @@ def _reload_agent_vars(models: dict[str, str]) -> None:
         agents_mod.REQUESTY_RESPONSE_MODEL = models["response"]
 
 
+def get_chat_context_window() -> int:
+    """Return the configured chat context window size."""
+    cfg = _read_config()
+    val: int = cfg.get("chat", {}).get("context_window", 10)
+    return val
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 
@@ -94,6 +103,7 @@ def get_settings(_user_id: str = Depends(require_user)) -> ModelSettings:
         context=models.get("context", "google/gemini-2.5-flash-lite"),
         reasoning=models.get("reasoning", "google/gemini-3-flash-preview"),
         response=models.get("response", "google/gemini-2.5-flash-lite"),
+        chat_context_window=cfg.get("chat", {}).get("context_window", 10),
     )
 
 
@@ -121,6 +131,11 @@ def update_settings(
         cfg["llm"]["models"]["response"] = body.response
         updates["response"] = body.response
 
+    if body.chat_context_window is not None:
+        if "chat" not in cfg:
+            cfg["chat"] = {}
+        cfg["chat"]["context_window"] = max(1, min(body.chat_context_window, 50))
+
     _write_config(cfg)
     _reload_agent_vars(updates)
 
@@ -129,4 +144,5 @@ def update_settings(
         context=models.get("context", "google/gemini-2.5-flash-lite"),
         reasoning=models.get("reasoning", "google/gemini-3-flash-preview"),
         response=models.get("response", "google/gemini-2.5-flash-lite"),
+        chat_context_window=cfg.get("chat", {}).get("context_window", 10),
     )

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -65,7 +65,7 @@ export function SettingsPanel() {
               </div>
             ) : modelSettings ? (
               <SettingsForm
-                key={`${modelSettings.context}|${modelSettings.reasoning}|${modelSettings.response}`}
+                key={`${modelSettings.context}|${modelSettings.reasoning}|${modelSettings.response}|${modelSettings.chat_context_window}`}
                 initial={modelSettings}
                 modelOptions={modelOptions}
                 onClose={closeSettings}
@@ -105,18 +105,20 @@ function SettingsForm({
   const [context, setContext] = useState(initial.context)
   const [reasoning, setReasoning] = useState(initial.reasoning)
   const [response, setResponse] = useState(initial.response)
+  const [chatContextWindow, setChatContextWindow] = useState(initial.chat_context_window)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
 
   const hasChanges =
     context !== initial.context ||
     reasoning !== initial.reasoning ||
-    response !== initial.response
+    response !== initial.response ||
+    chatContextWindow !== initial.chat_context_window
 
   const handleSave = async () => {
     setSaving(true)
     setSaved(false)
-    await updateModelSettings({ context, reasoning, response })
+    await updateModelSettings({ context, reasoning, response, chat_context_window: chatContextWindow })
     setSaving(false)
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
@@ -146,6 +148,29 @@ function SettingsForm({
           options={modelOptions}
           onChange={setResponse}
         />
+      </div>
+
+      <div className="mt-6 pt-5 border-t border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Chat</h3>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Context Window Size
+          </label>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1.5">
+            Number of recent messages included as context for AI responses (1–50)
+          </p>
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={chatContextWindow}
+            onChange={e => {
+              const v = parseInt(e.target.value, 10)
+              if (!isNaN(v)) setChatContextWindow(Math.max(1, Math.min(50, v)))
+            }}
+            className="w-24 px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:focus:ring-indigo-500 focus:border-indigo-400 dark:focus:border-indigo-500"
+          />
+        </div>
       </div>
       <div className="flex items-center justify-end gap-3 mt-5 pt-4 border-t border-gray-200 dark:border-gray-700">
         {saved && (

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -95,6 +95,7 @@ export interface ModelSettings {
   context: string
   reasoning: string
   response: string
+  chat_context_window: number
 }
 
 export interface RequestyModel {


### PR DESCRIPTION
## Summary
- Add Settings screen to the app
- First setting: number of messages to include as context when calling chat agents (sliding window size)
- Persisted and used by backend when constructing agent prompts

Issue: re-qgt
Polecat: nux
Tests: All passed (110 frontend + 199 backend)

---
*Created by Gas Town Refinery*