### PR TITLE
feat: add Prometheus-compatible /metrics endpoint (re-bmg)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,9 +20,11 @@ from fastapi import Depends, FastAPI  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import FileResponse  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
+from starlette.responses import Response as StarletteResponse  # noqa: E402
 
 from .auth import require_user  # noqa: E402
 from .database import init_db  # noqa: E402
+from .metrics import MetricsMiddleware, metrics_response  # noqa: E402
 from .rate_limit import RateLimitMiddleware, get_rate_limit_config  # noqa: E402
 from .response_metrics import ResponseMetricsMiddleware, metrics_store  # noqa: E402
 from .routers import auth, briefing, calendar, chat, gmail, proactive, settings, sweep, thing_types, things  # noqa: E402
@@ -112,6 +114,7 @@ app.add_middleware(
 _rl_config = get_rate_limit_config()
 app.add_middleware(RateLimitMiddleware, **_rl_config)
 app.add_middleware(ResponseMetricsMiddleware)
+app.add_middleware(MetricsMiddleware)
 
 # Auth routes are public (login/callback/logout)
 app.include_router(auth.router, prefix="/api")
@@ -173,6 +176,11 @@ def health_detailed() -> dict:
         "avg_response_time_ms": round(avg_ms, 2) if avg_ms is not None else None,
         "recent_request_count": metrics_store.request_count(),
     }
+
+
+@app.get("/metrics", tags=["monitoring"], include_in_schema=False)
+def metrics() -> StarletteResponse:
+    return metrics_response()
 
 
 # Serve React SPA (only when the built dist directory exists)

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1,0 +1,142 @@
+"""Prometheus-compatible /metrics endpoint and request instrumentation."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import Request, Response
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response as StarletteResponse
+
+# Use a custom registry so we don't collide with default process/platform
+# collectors in tests (and to keep output focused on app metrics).
+REGISTRY = CollectorRegistry()
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests by method, path, and status code.",
+    ["method", "path", "status"],
+    registry=REGISTRY,
+)
+
+REQUEST_DURATION = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds.",
+    ["method", "path"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+    registry=REGISTRY,
+)
+
+CHROMA_VECTOR_COUNT = Gauge(
+    "chroma_vector_count",
+    "Number of vectors indexed in ChromaDB.",
+    registry=REGISTRY,
+)
+
+DB_THINGS_COUNT = Gauge(
+    "db_things_total",
+    "Total number of Things stored in SQLite.",
+    registry=REGISTRY,
+)
+
+DB_USERS_COUNT = Gauge(
+    "db_users_total",
+    "Total number of registered users.",
+    registry=REGISTRY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path normalization (avoid high-cardinality labels)
+# ---------------------------------------------------------------------------
+
+_KNOWN_PREFIXES = (
+    "/api/things",
+    "/api/thing-types",
+    "/api/briefing",
+    "/api/chat",
+    "/api/gmail",
+    "/api/calendar",
+    "/api/proactive",
+    "/api/settings",
+    "/api/sweep",
+    "/api/auth",
+)
+
+
+def _normalize_path(path: str) -> str:
+    """Collapse dynamic path segments to avoid label explosion."""
+    for prefix in _KNOWN_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return prefix
+    if path in ("/healthz", "/metrics"):
+        return path
+    return "/other"
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record request count and duration for every HTTP request."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = _normalize_path(request.url.path)
+        method = request.method
+
+        start = time.monotonic()
+        response = await call_next(request)
+        elapsed = time.monotonic() - start
+
+        REQUEST_COUNT.labels(method=method, path=path, status=str(response.status_code)).inc()
+        REQUEST_DURATION.labels(method=method, path=path).observe(elapsed)
+
+        return response
+
+
+# ---------------------------------------------------------------------------
+# /metrics endpoint helper
+# ---------------------------------------------------------------------------
+
+
+def _refresh_gauges() -> None:
+    """Update gauge values from live data sources."""
+    # ChromaDB vector count
+    try:
+        from .vector_store import vector_count
+
+        CHROMA_VECTOR_COUNT.set(vector_count())
+    except Exception:
+        pass
+
+    # SQLite stats (no connection pool — just counts)
+    try:
+        from .database import db
+
+        with db() as conn:
+            things = conn.execute("SELECT COUNT(*) FROM things").fetchone()[0]
+            DB_THINGS_COUNT.set(things)
+            users = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+            DB_USERS_COUNT.set(users)
+    except Exception:
+        pass
+
+
+def metrics_response() -> StarletteResponse:
+    """Generate the Prometheus text exposition response."""
+    _refresh_gauges()
+    body = generate_latest(REGISTRY)
+    return StarletteResponse(content=body, media_type="text/plain; version=0.0.4; charset=utf-8")

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -87,7 +87,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         path = request.url.path
 
         # Skip rate limiting for health checks and static assets
-        if path == "/healthz" or path.startswith("/assets") or not path.startswith("/api"):
+        if path in ("/healthz", "/metrics") or path.startswith("/assets") or not path.startswith("/api"):
             return await call_next(request)
 
         client_ip = self._get_client_ip(request)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ pytest-cov>=5.0.0
 google-auth>=2.29.0
 google-auth-oauthlib>=1.2.0
 google-api-python-client>=2.127.0
+prometheus-client>=0.16.0

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,94 @@
+"""Tests for the /metrics endpoint and Prometheus instrumentation."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+class TestMetricsEndpoint:
+    """The /metrics endpoint returns Prometheus text exposition."""
+
+    def test_returns_200(self, client: TestClient):
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert "text/plain" in resp.headers["content-type"]
+
+    def test_contains_request_count(self, client: TestClient):
+        # Hit healthz first to generate a counter
+        client.get("/healthz")
+        resp = client.get("/metrics")
+        body = resp.text
+        assert "http_requests_total" in body
+
+    def test_contains_request_duration(self, client: TestClient):
+        client.get("/healthz")
+        resp = client.get("/metrics")
+        assert "http_request_duration_seconds" in resp.text
+
+    def test_contains_chroma_vector_count(self, client: TestClient):
+        resp = client.get("/metrics")
+        assert "chroma_vector_count" in resp.text
+
+    def test_contains_db_things_total(self, client: TestClient):
+        resp = client.get("/metrics")
+        assert "db_things_total" in resp.text
+
+    def test_contains_db_users_total(self, client: TestClient):
+        resp = client.get("/metrics")
+        assert "db_users_total" in resp.text
+
+    def test_no_auth_required(self, patched_db):
+        """The /metrics endpoint must be accessible without a session cookie."""
+        from backend.main import app
+
+        with TestClient(app) as c:
+            resp = c.get("/metrics")
+            assert resp.status_code == 200
+
+
+class TestPathNormalization:
+    """Dynamic path segments are collapsed to avoid label explosion."""
+
+    def test_thing_detail_collapsed(self, client: TestClient):
+        # A thing detail URL should be collapsed to /api/things
+        client.get("/api/things/some-uuid-123")
+        resp = client.get("/metrics")
+        body = resp.text
+        assert 'path="/api/things"' in body
+
+    def test_unknown_paths_collapsed(self, client: TestClient):
+        client.get("/unknown/route")
+        resp = client.get("/metrics")
+        body = resp.text
+        assert 'path="/other"' in body
+
+
+class TestMetricsMiddleware:
+    """The middleware correctly increments counters."""
+
+    def test_status_codes_tracked(self, client: TestClient):
+        client.get("/healthz")
+        resp = client.get("/metrics")
+        body = resp.text
+        assert 'status="200"' in body
+
+    def test_methods_tracked(self, client: TestClient):
+        client.get("/healthz")
+        resp = client.get("/metrics")
+        body = resp.text
+        assert 'method="GET"' in body
+
+
+class TestGaugeRefresh:
+    """Gauge values are refreshed from live data on each /metrics call."""
+
+    def test_vector_count_uses_vector_store(self, client: TestClient):
+        with patch("backend.vector_store.vector_count", return_value=42):
+            resp = client.get("/metrics")
+        assert "chroma_vector_count 42.0" in resp.text
+
+    def test_db_counts_reflect_data(self, client: TestClient):
+        # The patched_db is empty, so counts should be 0
+        resp = client.get("/metrics")
+        assert "db_things_total 0.0" in resp.text
+        assert "db_users_total 0.0" in resp.text


### PR DESCRIPTION
## Summary
- Add Prometheus-compatible /metrics endpoint
- Add MetricsMiddleware for request tracking
- Conflict resolved: kept both ResponseMetrics and new Metrics middleware

Issue: re-bmg
Polecat: nux
Tests: All passed (176 frontend + 225 backend)

---
*Created by Gas Town Refinery*