### PR TITLE
fix: add chat_context_window to ModelSettingsSchema

### DIFF
--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -191,6 +191,7 @@ export const ModelSettingsSchema = z.object({
   context: z.string(),
   reasoning: z.string(),
   response: z.string(),
+  chat_context_window: z.number(),
 })
 
 export const RequestyModelSchema = z.object({


### PR DESCRIPTION
## Summary
- Settings screen PR (re-qgt) added `chat_context_window` to the `ModelSettings` interface but missed updating the Zod schema
- This broke typecheck on master, blocking all PR merges

## Test plan
- [x] `npx tsc -b` passes
- [x] `./scripts/gates.sh typecheck` passes (frontend + backend mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)