### PR TITLE
fix: backfill usage_log.user_id from chat_history in migration

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -111,6 +111,16 @@ def _migrate_add_users(conn: sqlite3.Connection) -> None:
             conn.execute(f"ALTER TABLE {table} ADD COLUMN user_id TEXT REFERENCES users(id)")
             conn.execute(f"CREATE INDEX IF NOT EXISTS idx_{table}_user_id ON {table}(user_id)")
 
+    # 3. Backfill usage_log.user_id from chat_history for pre-migration rows
+    conn.execute("""
+        UPDATE usage_log SET user_id = (
+            SELECT ch.user_id FROM chat_history ch
+            WHERE ch.session_id = usage_log.session_id
+              AND ch.user_id IS NOT NULL
+            LIMIT 1
+        ) WHERE usage_log.user_id IS NULL
+    """)
+
 
 def _migrate_google_tokens_multi_user(conn: sqlite3.Connection) -> None:
     """Refactor google_tokens to support multiple users and services.


### PR DESCRIPTION
## Summary
- Fixes "Today's Usage" showing empty because pre-migration `usage_log` rows have `NULL` `user_id`
- Adds a backfill step in `_migrate_add_users()` that populates `usage_log.user_id` from matching `chat_history` sessions
- Closes re-4hn

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Verify usage_log rows get backfilled user_id after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)