### PR TITLE
feat: per-call token breakdown in UsagePill

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -215,6 +215,15 @@ class UsageStats:
             "cost_usd": round(self.cost_usd, 6),
             "api_calls": self.api_calls,
             "model": self.model,
+            "per_call_usage": [
+                {
+                    "model": c.model,
+                    "prompt_tokens": c.prompt_tokens,
+                    "completion_tokens": c.completion_tokens,
+                    "cost_usd": round(c.cost_usd, 6),
+                }
+                for c in self.calls
+            ],
         }
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -122,6 +122,15 @@ class ChatMessageCreate(BaseModel):
     applied_changes: dict[str, Any] | None = None
 
 
+class CallUsage(BaseModel):
+    """Usage for a single API call."""
+
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float = 0.0
+
+
 class ChatMessage(BaseModel):
     id: int
     session_id: str
@@ -132,6 +141,7 @@ class ChatMessage(BaseModel):
     completion_tokens: int = 0
     cost_usd: float = 0.0
     model: str | None = None
+    per_call_usage: list[CallUsage] = []
     timestamp: datetime
 
     model_config = {"from_attributes": True}
@@ -154,6 +164,7 @@ class UsageInfo(BaseModel):
     cost_usd: float = 0.0
     api_calls: int = 0
     model: str = ""
+    per_call_usage: list[CallUsage] = []
 
 
 class ModelUsage(BaseModel):

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -41,6 +41,10 @@ def _row_to_msg(row: sqlite3.Row) -> ChatMessage:
     changes = row["applied_changes"]
     if isinstance(changes, str):
         changes = json.loads(changes) if changes else None
+    # Extract per-call usage from applied_changes if present
+    per_call_usage = []
+    if isinstance(changes, dict) and "per_call_usage" in changes:
+        per_call_usage = changes["per_call_usage"]
     return ChatMessage(
         id=row["id"],
         session_id=row["session_id"],
@@ -51,6 +55,7 @@ def _row_to_msg(row: sqlite3.Row) -> ChatMessage:
         completion_tokens=row["completion_tokens"] or 0,
         cost_usd=row["cost_usd"] or 0.0,
         model=row["model"],
+        per_call_usage=per_call_usage,
         timestamp=_parse_dt(row["timestamp"]) or datetime.min,
     )
 
@@ -393,6 +398,17 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
     applied_with_sources["context_things"] = context_things
     if web_results:
         applied_with_sources["web_results"] = web_results
+    # Store per-call usage breakdown so it's available when loading history
+    if usage.calls:
+        applied_with_sources["per_call_usage"] = [
+            {
+                "model": c.model,
+                "prompt_tokens": c.prompt_tokens,
+                "completion_tokens": c.completion_tokens,
+                "cost_usd": round(c.cost_usd, 6),
+            }
+            for c in usage.calls
+        ]
     changes_json = json.dumps(applied_with_sources)
     with db() as conn:
         conn.execute(

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -171,6 +171,7 @@ function UsagePill({ msg }: { msg: ChatMessage }) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const totalTokens = (msg.prompt_tokens ?? 0) + (msg.completion_tokens ?? 0)
+  const calls = msg.per_call_usage ?? []
 
   useEffect(() => {
     if (!open) return
@@ -192,30 +193,75 @@ function UsagePill({ msg }: { msg: ChatMessage }) {
         {formatTokens(totalTokens)} tokens
       </button>
       {open && (
-        <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 min-w-[180px] font-mono text-[11px] text-gray-500 dark:text-gray-400">
-          {msg.model && (
-            <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1.5 truncate">
-              {msg.model.split('/').pop()}
-            </p>
-          )}
-          <div className="space-y-0.5">
-            <div className="flex justify-between">
-              <span>Prompt</span>
-              <span className="tabular-nums">{formatTokens(msg.prompt_tokens ?? 0)}</span>
-            </div>
-            <div className="flex justify-between">
-              <span>Completion</span>
-              <span className="tabular-nums">{formatTokens(msg.completion_tokens ?? 0)}</span>
-            </div>
-            <div className="flex justify-between border-t border-gray-200 dark:border-gray-700 pt-0.5 mt-0.5 font-medium text-gray-700 dark:text-gray-300">
-              <span>Total</span>
-              <span className="tabular-nums">{formatTokens(totalTokens)}</span>
-            </div>
-          </div>
-          {msg.cost_usd != null && msg.cost_usd > 0 && (
-            <p className="mt-1.5 text-right text-gray-600 dark:text-gray-300 font-medium">
-              {formatCost(msg.cost_usd)}
-            </p>
+        <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 min-w-[200px] font-mono text-[11px] text-gray-500 dark:text-gray-400">
+          {calls.length > 1 ? (
+            <>
+              <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">Per-call breakdown</p>
+              <div className="space-y-2">
+                {calls.map((call, i) => (
+                  <div key={i}>
+                    <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 truncate">
+                      {call.model.split('/').pop()}
+                    </p>
+                    <div className="space-y-0.5 mt-0.5">
+                      <div className="flex justify-between gap-3">
+                        <span>Prompt</span>
+                        <span className="tabular-nums">{formatTokens(call.prompt_tokens)}</span>
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <span>Completion</span>
+                        <span className="tabular-nums">{formatTokens(call.completion_tokens)}</span>
+                      </div>
+                      {call.cost_usd > 0 && (
+                        <div className="flex justify-between gap-3 text-gray-600 dark:text-gray-300">
+                          <span>Cost</span>
+                          <span className="tabular-nums">{formatCost(call.cost_usd)}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="border-t border-gray-200 dark:border-gray-700 pt-1.5 mt-1.5 font-medium text-gray-700 dark:text-gray-300">
+                <div className="flex justify-between">
+                  <span>Total</span>
+                  <span className="tabular-nums">{formatTokens(totalTokens)}</span>
+                </div>
+                {msg.cost_usd != null && msg.cost_usd > 0 && (
+                  <div className="flex justify-between mt-0.5">
+                    <span>Cost</span>
+                    <span className="tabular-nums">{formatCost(msg.cost_usd)}</span>
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              {msg.model && (
+                <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1.5 truncate">
+                  {msg.model.split('/').pop()}
+                </p>
+              )}
+              <div className="space-y-0.5">
+                <div className="flex justify-between">
+                  <span>Prompt</span>
+                  <span className="tabular-nums">{formatTokens(msg.prompt_tokens ?? 0)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Completion</span>
+                  <span className="tabular-nums">{formatTokens(msg.completion_tokens ?? 0)}</span>
+                </div>
+                <div className="flex justify-between border-t border-gray-200 dark:border-gray-700 pt-0.5 mt-0.5 font-medium text-gray-700 dark:text-gray-300">
+                  <span>Total</span>
+                  <span className="tabular-nums">{formatTokens(totalTokens)}</span>
+                </div>
+              </div>
+              {msg.cost_usd != null && msg.cost_usd > 0 && (
+                <p className="mt-1.5 text-right text-gray-600 dark:text-gray-300 font-medium">
+                  {formatCost(msg.cost_usd)}
+                </p>
+              )}
+            </>
           )}
         </div>
       )}

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -52,6 +52,13 @@ export const AppliedChangesSchema = z.object({
   web_results: z.array(WebSearchResultSchema).optional(),
 })
 
+const CallUsageSchema = z.object({
+  model: z.string(),
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  cost_usd: z.number(),
+})
+
 export const ChatMessageSchema = z.object({
   id: z.union([z.number(), z.string()]),
   session_id: z.string(),
@@ -63,6 +70,7 @@ export const ChatMessageSchema = z.object({
   completion_tokens: z.number().optional(),
   cost_usd: z.number().optional(),
   model: z.string().nullable().optional(),
+  per_call_usage: z.array(CallUsageSchema).optional(),
   timestamp: z.string(),
 })
 
@@ -75,6 +83,7 @@ export const ChatResponseSchema = z.object({
     completion_tokens: z.number(),
     cost_usd: z.number(),
     model: z.string().nullable(),
+    per_call_usage: z.array(CallUsageSchema).optional(),
   }).optional(),
   session_usage: z.object({
     prompt_tokens: z.number(),

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -138,6 +138,13 @@ export interface SessionStats {
   per_model: ModelUsage[]
 }
 
+export interface CallUsage {
+  model: string
+  prompt_tokens: number
+  completion_tokens: number
+  cost_usd: number
+}
+
 export interface ChatMessage {
   id: number | string
   session_id: string
@@ -149,6 +156,7 @@ export interface ChatMessage {
   completion_tokens?: number
   cost_usd?: number
   model?: string | null
+  per_call_usage?: CallUsage[]
   timestamp: string
   streaming?: boolean
 }
@@ -630,6 +638,7 @@ export const useStore = create<ReliState>((set, get) => ({
         completion_tokens: data.usage?.completion_tokens ?? 0,
         cost_usd: data.usage?.cost_usd ?? 0,
         model: data.usage?.model ?? null,
+        per_call_usage: data.usage?.per_call_usage ?? [],
         timestamp: new Date().toISOString(),
       }
 


### PR DESCRIPTION
## Summary
- Shows per-API-call token breakdown (model, prompt/completion tokens, cost) in the UsagePill tooltip instead of just the aggregate
- Stores `per_call_usage` array in `applied_changes` JSON in chat_history
- Backend serializes `UsageStats.calls` into chat response and persisted data
- Frontend renders multi-model breakdown when >1 API call, falls back to single-model view otherwise
- Closes re-zsm

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Verify UsagePill shows per-call breakdown for multi-model chat responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)