### PR TITLE
feat: show cost in UsagePill collapsed button

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -272,7 +272,7 @@ function UsagePill({ msg }: { msg: ChatMessage }) {
         onClick={() => setOpen(o => !o)}
         className="text-[10px] text-gray-400 dark:text-gray-500 font-mono hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer"
       >
-        {formatTokens(totalTokens)} tokens
+        {formatTokens(totalTokens)} tokens{msg.cost_usd != null && msg.cost_usd > 0 ? ` · ${formatCost(msg.cost_usd)}` : ''}
       </button>
       {open && (
         <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 min-w-[200px] font-mono text-[11px] text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- Shows cost alongside token count in the collapsed UsagePill button (e.g. "1.2K tokens · $0.02")
- Cost only shown when `cost_usd > 0`
- Closes re-3hh

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Verify cost appears in collapsed pill when cost > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)