### PR TITLE
feat: add GET /api/things/graph endpoint for nodes+edges

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -87,6 +87,28 @@ class Thing(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# ── Graph ────────────────────────────────────────────────────────────────────
+
+
+class GraphNode(BaseModel):
+    id: str
+    title: str
+    type_hint: str | None
+    icon: str | None
+
+
+class GraphEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    relationship_type: str
+
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+
+
 # ── Relationships ────────────────────────────────────────────────────────────
 
 

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -10,7 +10,16 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 
 from ..auth import require_user, user_filter
 from ..database import db
-from ..models import Relationship, RelationshipCreate, Thing, ThingCreate, ThingUpdate
+from ..models import (
+    GraphEdge,
+    GraphNode,
+    GraphResponse,
+    Relationship,
+    RelationshipCreate,
+    Thing,
+    ThingCreate,
+    ThingUpdate,
+)
 from ..vector_store import delete_thing as vs_delete
 from ..vector_store import reindex_all, upsert_thing
 
@@ -196,6 +205,38 @@ def list_things(
                     t.completed_count = counts[1]
 
     return things
+
+
+@router.get("/graph", response_model=GraphResponse, summary="Get Things as a graph of nodes and edges")
+def get_graph(user_id: str = Depends(require_user)) -> GraphResponse:
+    """Return all active Things and relationships as nodes and edges, avoiding N+1 queries."""
+    with db() as conn:
+        uf_sql, uf_params = user_filter(user_id, "t")
+        node_rows = conn.execute(
+            "SELECT t.id, t.title, t.type_hint, tt.icon"
+            " FROM things t"
+            " LEFT JOIN thing_types tt ON t.type_hint = tt.name"
+            " WHERE t.active = 1" + uf_sql,
+            uf_params,
+        ).fetchall()
+        edge_rows = conn.execute(
+            "SELECT r.id, r.from_thing_id, r.to_thing_id, r.relationship_type"
+            " FROM thing_relationships r"
+            " JOIN things t ON r.from_thing_id = t.id"
+            " WHERE t.active = 1" + uf_sql,
+            uf_params,
+        ).fetchall()
+
+    nodes = [GraphNode(id=r["id"], title=r["title"], type_hint=r["type_hint"], icon=r["icon"]) for r in node_rows]
+    active_ids = {n.id for n in nodes}
+    edges = [
+        GraphEdge(
+            id=r["id"], source=r["from_thing_id"], target=r["to_thing_id"], relationship_type=r["relationship_type"]
+        )
+        for r in edge_rows
+        if r["to_thing_id"] in active_ids
+    ]
+    return GraphResponse(nodes=nodes, edges=edges)
 
 
 @router.post("", response_model=Thing, status_code=status.HTTP_201_CREATED, summary="Create a Thing")

--- a/backend/tests/test_things.py
+++ b/backend/tests/test_things.py
@@ -196,3 +196,70 @@ class TestDeleteThing:
         mock_vector_store["delete"].reset_mock()
         client.delete(f"/api/things/{thing['id']}")
         mock_vector_store["delete"].assert_called_once_with(thing["id"])
+
+
+# ---------------------------------------------------------------------------
+# Graph
+# ---------------------------------------------------------------------------
+
+
+class TestGetGraph:
+    def test_graph_empty(self, client):
+        resp = client.get("/api/things/graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["nodes"] == []
+        assert data["edges"] == []
+
+    def test_graph_returns_active_nodes(self, client):
+        t1 = create_thing(client, title="Active Node", type_hint="task")
+        t2 = create_thing(client, title="Inactive Node")
+        client.patch(f"/api/things/{t2['id']}", json={"active": False})
+
+        resp = client.get("/api/things/graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        node_ids = [n["id"] for n in data["nodes"]]
+        assert t1["id"] in node_ids
+        assert t2["id"] not in node_ids
+
+    def test_graph_returns_edges(self, client):
+        t1 = create_thing(client, title="Node A")
+        t2 = create_thing(client, title="Node B")
+        rel = client.post(
+            "/api/things/relationships",
+            json={"from_thing_id": t1["id"], "to_thing_id": t2["id"], "relationship_type": "related_to"},
+        )
+        assert rel.status_code == 201
+
+        resp = client.get("/api/things/graph")
+        data = resp.json()
+        assert len(data["edges"]) == 1
+        edge = data["edges"][0]
+        assert edge["source"] == t1["id"]
+        assert edge["target"] == t2["id"]
+        assert edge["relationship_type"] == "related_to"
+
+    def test_graph_excludes_edges_to_inactive_nodes(self, client):
+        t1 = create_thing(client, title="Active")
+        t2 = create_thing(client, title="Will Deactivate")
+        client.post(
+            "/api/things/relationships",
+            json={"from_thing_id": t1["id"], "to_thing_id": t2["id"], "relationship_type": "knows"},
+        )
+        client.patch(f"/api/things/{t2['id']}", json={"active": False})
+
+        resp = client.get("/api/things/graph")
+        data = resp.json()
+        assert len(data["edges"]) == 0
+
+    def test_graph_node_has_icon_from_thing_type(self, client):
+        # Create a thing type first
+        client.post("/api/thing-types", json={"name": "person", "icon": "👤"})
+        t = create_thing(client, title="Alice", type_hint="person")
+
+        resp = client.get("/api/things/graph")
+        data = resp.json()
+        node = next(n for n in data["nodes"] if n["id"] == t["id"])
+        assert node["icon"] == "👤"
+        assert node["type_hint"] == "person"


### PR DESCRIPTION
## Summary
- Adds `GET /api/things/graph` endpoint returning all active Things as nodes and relationships as edges
- Two queries (nodes + edges), no N+1 — includes icon from thing_types via LEFT JOIN
- Filters inactive nodes and edges pointing to inactive targets
- Adds `GraphNode`, `GraphEdge`, `GraphResponse` models
- Includes 5 tests covering empty graph, active/inactive filtering, edges, and icon resolution
- Closes re-gkt

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] `GET /api/things/graph` returns correct nodes and edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)