### PR TITLE
feat: validate and clean up orphan relationships in Thing graph

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -699,6 +699,16 @@ def apply_storage_changes(storage_changes: dict[str, Any], conn: sqlite3.Connect
         from_row = conn.execute("SELECT id FROM things WHERE id = ?", (from_id,)).fetchone()
         to_row = conn.execute("SELECT id FROM things WHERE id = ?", (to_id,)).fetchone()
         if not from_row or not to_row:
+            missing = []
+            if not from_row:
+                missing.append(f"from_thing_id={from_id}")
+            if not to_row:
+                missing.append(f"to_thing_id={to_id}")
+            logger.warning(
+                "Skipping relationship '%s': referenced thing(s) not found (%s)",
+                rel_type,
+                ", ".join(missing),
+            )
             continue
         rel_id = str(uuid.uuid4())
         meta = rel.get("metadata")
@@ -708,6 +718,14 @@ def apply_storage_changes(storage_changes: dict[str, Any], conn: sqlite3.Connect
             " VALUES (?, ?, ?, ?, ?)",
             (rel_id, from_id, to_id, rel_type, meta_json),
         )
+        # Verify the row was actually created
+        verify = conn.execute("SELECT id FROM thing_relationships WHERE id = ?", (rel_id,)).fetchone()
+        if not verify:
+            logger.error(
+                "Relationship INSERT succeeded but row not found: id=%s, %s -> %s (%s)",
+                rel_id, from_id, to_id, rel_type,
+            )
+            continue
         applied["relationships_created"].append(
             {
                 "id": rel_id,

--- a/backend/database.py
+++ b/backend/database.py
@@ -178,6 +178,28 @@ def _migrate_google_tokens_multi_user(conn: sqlite3.Connection) -> None:
         )
 
 
+def clean_orphan_relationships() -> tuple[int, list[str]]:
+    """Delete relationships where from_thing_id or to_thing_id doesn't exist.
+
+    Returns (deleted_count, list_of_deleted_ids).
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    with db() as conn:
+        orphan_rows = conn.execute(
+            "SELECT r.id FROM thing_relationships r"
+            " WHERE r.from_thing_id NOT IN (SELECT id FROM things)"
+            "    OR r.to_thing_id NOT IN (SELECT id FROM things)"
+        ).fetchall()
+        orphan_ids = [row["id"] for row in orphan_rows]
+        if orphan_ids:
+            placeholders = ",".join("?" * len(orphan_ids))
+            conn.execute(f"DELETE FROM thing_relationships WHERE id IN ({placeholders})", orphan_ids)
+            logger.info("Cleaned %d orphan relationship(s): %s", len(orphan_ids), orphan_ids)
+    return len(orphan_ids), orphan_ids
+
+
 def init_db() -> None:
     """Create tables if they don't exist."""
     with db() as conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ from fastapi.staticfiles import StaticFiles  # noqa: E402
 from starlette.responses import Response as StarletteResponse  # noqa: E402
 
 from .auth import require_user  # noqa: E402
-from .database import init_db  # noqa: E402
+from .database import clean_orphan_relationships, init_db  # noqa: E402
 from .metrics import MetricsMiddleware, metrics_response  # noqa: E402
 from .rate_limit import RateLimitMiddleware, get_rate_limit_config  # noqa: E402
 from .response_metrics import ResponseMetricsMiddleware, metrics_store  # noqa: E402
@@ -36,6 +36,7 @@ _FRONTEND_DIST = pathlib.Path(__file__).parent.parent / "frontend" / "dist"
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     init_db()
+    clean_orphan_relationships()
     start_scheduler()
     yield
     stop_scheduler()

--- a/backend/models.py
+++ b/backend/models.py
@@ -109,6 +109,13 @@ class GraphResponse(BaseModel):
     edges: list[GraphEdge]
 
 
+class OrphanCleanupResult(BaseModel):
+    """Result of orphan relationship cleanup."""
+
+    deleted_count: int
+    deleted_ids: list[str]
+
+
 # ── Relationships ────────────────────────────────────────────────────────────
 
 

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -9,11 +9,12 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 
 from ..auth import require_user, user_filter
-from ..database import db
+from ..database import clean_orphan_relationships, db
 from ..models import (
     GraphEdge,
     GraphNode,
     GraphResponse,
+    OrphanCleanupResult,
     Relationship,
     RelationshipCreate,
     Thing,
@@ -356,6 +357,36 @@ def reindex_things(user_id: str = Depends(require_user)) -> dict[str, int]:
     """Rebuild the vector search index for all Things. Returns the count of re-indexed items."""
     count = reindex_all()
     return {"reindexed": count}
+
+
+# ── Orphan relationship management ──────────────────────────────────────────
+
+
+@router.get(
+    "/relationships/orphans",
+    response_model=list[Relationship],
+    summary="Find orphan relationships",
+)
+def get_orphan_relationships(user_id: str = Depends(require_user)) -> list[Relationship]:
+    """Return relationships where from_thing_id or to_thing_id doesn't exist in the things table."""
+    with db() as conn:
+        rows = conn.execute(
+            "SELECT r.* FROM thing_relationships r"
+            " WHERE r.from_thing_id NOT IN (SELECT id FROM things)"
+            "    OR r.to_thing_id NOT IN (SELECT id FROM things)"
+        ).fetchall()
+    return [_parse_rel_row(r) for r in rows]
+
+
+@router.post(
+    "/relationships/cleanup",
+    response_model=OrphanCleanupResult,
+    summary="Delete orphan relationships",
+)
+def cleanup_orphan_relationships(user_id: str = Depends(require_user)) -> OrphanCleanupResult:
+    """Delete all relationships where from_thing_id or to_thing_id doesn't exist."""
+    deleted_count, deleted_ids = clean_orphan_relationships()
+    return OrphanCleanupResult(deleted_count=deleted_count, deleted_ids=deleted_ids)
 
 
 # ── Relationships ────────────────────────────────────────────────────────────

--- a/backend/tests/test_things.py
+++ b/backend/tests/test_things.py
@@ -2,6 +2,8 @@
 
 from fastapi.testclient import TestClient
 
+from backend.database import db
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -263,3 +265,100 @@ class TestGetGraph:
         node = next(n for n in data["nodes"] if n["id"] == t["id"])
         assert node["icon"] == "👤"
         assert node["type_hint"] == "person"
+
+
+# ---------------------------------------------------------------------------
+# Orphan Relationships
+# ---------------------------------------------------------------------------
+
+
+def _insert_orphan_relationship(from_id: str, to_id: str, rel_type: str = "orphan_link") -> str:
+    """Directly insert a relationship bypassing FK validation (simulates orphan)."""
+    import uuid
+
+    rel_id = str(uuid.uuid4())
+    with db() as conn:
+        # Temporarily disable FK constraints to insert an orphan
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute(
+            "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type)"
+            " VALUES (?, ?, ?, ?)",
+            (rel_id, from_id, to_id, rel_type),
+        )
+        conn.execute("PRAGMA foreign_keys=ON")
+    return rel_id
+
+
+class TestOrphanRelationships:
+    def test_orphans_empty(self, client):
+        resp = client.get("/api/things/relationships/orphans")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_orphans_detects_missing_to_thing(self, client):
+        t1 = create_thing(client, title="Existing")
+        _insert_orphan_relationship(t1["id"], "nonexistent-id")
+
+        resp = client.get("/api/things/relationships/orphans")
+        assert resp.status_code == 200
+        orphans = resp.json()
+        assert len(orphans) == 1
+        assert orphans[0]["to_thing_id"] == "nonexistent-id"
+
+    def test_orphans_detects_missing_from_thing(self, client):
+        t1 = create_thing(client, title="Existing")
+        _insert_orphan_relationship("nonexistent-id", t1["id"])
+
+        resp = client.get("/api/things/relationships/orphans")
+        orphans = resp.json()
+        assert len(orphans) == 1
+        assert orphans[0]["from_thing_id"] == "nonexistent-id"
+
+    def test_valid_relationship_not_reported_as_orphan(self, client):
+        t1 = create_thing(client, title="A")
+        t2 = create_thing(client, title="B")
+        client.post(
+            "/api/things/relationships",
+            json={"from_thing_id": t1["id"], "to_thing_id": t2["id"], "relationship_type": "related_to"},
+        )
+
+        resp = client.get("/api/things/relationships/orphans")
+        assert resp.json() == []
+
+    def test_cleanup_deletes_orphans(self, client):
+        t1 = create_thing(client, title="Keeper")
+        orphan_id = _insert_orphan_relationship(t1["id"], "ghost-thing")
+
+        resp = client.post("/api/things/relationships/cleanup")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deleted_count"] == 1
+        assert orphan_id in data["deleted_ids"]
+
+        # Verify orphan is gone
+        resp2 = client.get("/api/things/relationships/orphans")
+        assert resp2.json() == []
+
+    def test_cleanup_preserves_valid_relationships(self, client):
+        t1 = create_thing(client, title="A")
+        t2 = create_thing(client, title="B")
+        rel = client.post(
+            "/api/things/relationships",
+            json={"from_thing_id": t1["id"], "to_thing_id": t2["id"], "relationship_type": "valid"},
+        )
+        assert rel.status_code == 201
+
+        _insert_orphan_relationship("ghost1", "ghost2")
+
+        resp = client.post("/api/things/relationships/cleanup")
+        assert resp.json()["deleted_count"] == 1
+
+        # Valid relationship still exists
+        rels = client.get(f"/api/things/{t1['id']}/relationships")
+        assert len(rels.json()) == 1
+
+    def test_cleanup_noop_when_no_orphans(self, client):
+        resp = client.post("/api/things/relationships/cleanup")
+        assert resp.status_code == 200
+        assert resp.json()["deleted_count"] == 0
+        assert resp.json()["deleted_ids"] == []

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -46,10 +46,13 @@ export function DetailPanel() {
       'spawned-from': 'spawned',
       'spawned': 'spawned-from',
     }
+    const thingIds = new Set(things.map(t => t.id))
     const groups = new Map<string, { rel: Relationship; otherId: string; direction: string }[]>()
     for (const rel of detailRelationships) {
       const isFrom = rel.from_thing_id === detailThingId
       const otherId = isFrom ? rel.to_thing_id : rel.from_thing_id
+      // Filter out relationships pointing to non-existent Things (orphans)
+      if (!thingIds.has(otherId)) continue
       const rawType = rel.relationship_type
       const displayType = isFrom ? rawType : (opposites[rawType] ?? rawType)
       const direction = '\u2192'
@@ -57,7 +60,7 @@ export function DetailPanel() {
       groups.get(displayType)!.push({ rel, otherId, direction })
     }
     return groups
-  }, [detailRelationships, detailThingId])
+  }, [detailRelationships, detailThingId, things])
 
   if (!detailThingId) return null
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/things/relationships/orphans` to find orphan relationships
- Adds `POST /api/things/relationships/cleanup` to delete orphan relationships
- Runs orphan cleanup on app startup via `clean_orphan_relationships()`
- Adds warning logging in `apply_storage_changes()` when referenced Things don't exist
- Frontend `DetailPanel` filters out relationships pointing to non-existent Things
- Includes 7 tests covering detection, cleanup, and edge cases
- Closes re-34q

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Orphan cleanup runs on startup without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)