### PR TITLE
feat: derive chat session ID from authenticated user ID

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -186,6 +186,13 @@ class ChatRequest(BaseModel):
     message: str = Field(..., min_length=1, description="User message text", examples=["What tasks are due this week?"])
 
 
+class MigrateSessionRequest(BaseModel):
+    """Migrate chat history from an old session ID to a new one."""
+
+    old_session_id: str = Field(..., min_length=1, description="The old session ID to migrate from")
+    new_session_id: str = Field(..., min_length=1, description="The new session ID to migrate to")
+
+
 class UsageInfo(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -22,7 +22,16 @@ from ..database import db
 from .settings import get_chat_context_window
 from ..google_calendar import fetch_upcoming_events
 from ..google_calendar import is_connected as gcal_connected
-from ..models import ChatMessage, ChatMessageCreate, ChatRequest, ChatResponse, ModelUsage, SessionUsage, UsageInfo
+from ..models import (
+    ChatMessage,
+    ChatMessageCreate,
+    ChatRequest,
+    ChatResponse,
+    MigrateSessionRequest,
+    ModelUsage,
+    SessionUsage,
+    UsageInfo,
+)
 from ..vector_store import VECTOR_SEARCH_THRESHOLD, vector_count, vector_search
 from ..web_search import google_search, is_search_configured
 
@@ -110,6 +119,24 @@ def delete_history(session_id: str, user_id: str = Depends(require_user)) -> Non
         result = conn.execute(f"DELETE FROM chat_history WHERE session_id = ?{uf_sql}", [session_id, *uf_params])
     if result.rowcount == 0:
         raise HTTPException(status_code=404, detail=f"No chat history found for session '{session_id}'")
+
+
+@router.post("/migrate-session", status_code=status.HTTP_200_OK, summary="Migrate chat history to a new session ID")
+def migrate_session(body: MigrateSessionRequest, user_id: str = Depends(require_user)) -> dict:
+    """Migrate all chat history and usage records from old_session_id to new_session_id for the current user."""
+    if body.old_session_id == body.new_session_id:
+        return {"migrated": 0}
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        chat_result = conn.execute(
+            f"UPDATE chat_history SET session_id = ? WHERE session_id = ?{uf_sql}",
+            [body.new_session_id, body.old_session_id, *uf_params],
+        )
+        usage_result = conn.execute(
+            f"UPDATE usage_log SET session_id = ? WHERE session_id = ?{uf_sql}",
+            [body.new_session_id, body.old_session_id, *uf_params],
+        )
+    return {"migrated": chat_result.rowcount + usage_result.rowcount}
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -267,16 +267,11 @@ interface ReliState {
 
 const HISTORY_PAGE_SIZE = 20
 
-function getOrCreateSessionId(): string {
-  const key = 'reli-session-id'
-  const stored = localStorage.getItem(key)
-  if (stored) return stored
-  const id = `reli-${Math.random().toString(36).slice(2)}`
-  localStorage.setItem(key, id)
-  return id
-}
+const LEGACY_SESSION_KEY = 'reli-session-id'
 
-const SESSION_ID = getOrCreateSessionId()
+function getLegacySessionId(): string | null {
+  return localStorage.getItem(LEGACY_SESSION_KEY)
+}
 
 const BASE = '/api'
 
@@ -311,7 +306,21 @@ export const useStore = create<ReliState>((set, get) => ({
       const res = await apiFetch(`${BASE}/auth/me`)
       if (res.ok) {
         const user: AuthUser = validateResponse(AuthUserSchema, await res.json(), '/auth/me')
-        set({ currentUser: user, authChecked: true })
+        set({ currentUser: user, authChecked: true, sessionId: user.id })
+
+        // Migrate legacy random session ID to user-based session ID
+        const legacyId = getLegacySessionId()
+        if (legacyId && legacyId !== user.id) {
+          apiFetch(`${BASE}/chat/migrate-session`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ old_session_id: legacyId, new_session_id: user.id }),
+          }).then(() => {
+            localStorage.removeItem(LEGACY_SESSION_KEY)
+          }).catch(() => {
+            // Migration is best-effort; old history may be orphaned
+          })
+        }
       } else {
         set({ currentUser: null, authChecked: true })
       }
@@ -335,7 +344,7 @@ export const useStore = create<ReliState>((set, get) => ({
   briefing: [],
   findings: [],
   messages: [],
-  sessionId: SESSION_ID,
+  sessionId: '',
   sessionStats: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, api_calls: 0, cost_usd: 0, per_model: [] },
   loading: false,
   chatLoading: false,
@@ -563,7 +572,8 @@ export const useStore = create<ReliState>((set, get) => ({
   fetchHistory: async () => {
     set({ historyLoading: true })
     try {
-      const res = await apiFetch(`${BASE}/chat/history/${SESSION_ID}?limit=${HISTORY_PAGE_SIZE}`)
+      const sessionId = get().sessionId
+      const res = await apiFetch(`${BASE}/chat/history/${sessionId}?limit=${HISTORY_PAGE_SIZE}`)
       if (!res.ok) return
       const data: ChatMessage[] = validateResponse(z.array(ChatMessageSchema), await res.json(), '/chat/history')
       set({
@@ -586,8 +596,9 @@ export const useStore = create<ReliState>((set, get) => ({
 
     set({ historyLoading: true })
     try {
+      const sessionId = get().sessionId
       const res = await apiFetch(
-        `${BASE}/chat/history/${SESSION_ID}?limit=${HISTORY_PAGE_SIZE}&before=${oldestMsg.id}`
+        `${BASE}/chat/history/${sessionId}?limit=${HISTORY_PAGE_SIZE}&before=${oldestMsg.id}`
       )
       if (!res.ok) return
       const data: ChatMessage[] = validateResponse(z.array(ChatMessageSchema), await res.json(), '/chat/history')
@@ -605,7 +616,7 @@ export const useStore = create<ReliState>((set, get) => ({
   sendMessage: async (text: string) => {
     const userMsg: ChatMessage = {
       id: `local-${Date.now()}`,
-      session_id: SESSION_ID,
+      session_id: get().sessionId,
       role: 'user',
       content: text,
       applied_changes: null,
@@ -614,7 +625,7 @@ export const useStore = create<ReliState>((set, get) => ({
     }
     const placeholderMsg: ChatMessage = {
       id: `pending-${Date.now()}`,
-      session_id: SESSION_ID,
+      session_id: get().sessionId,
       role: 'assistant',
       content: '',
       applied_changes: null,
@@ -632,14 +643,14 @@ export const useStore = create<ReliState>((set, get) => ({
       const res = await apiFetch(`${BASE}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: SESSION_ID, message: text }),
+        body: JSON.stringify({ session_id: get().sessionId, message: text }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = validateResponse(ChatResponseSchema, await res.json(), '/chat')
 
       const assistantMsg: ChatMessage = {
         id: `assistant-${Date.now()}`,
-        session_id: SESSION_ID,
+        session_id: get().sessionId,
         role: 'assistant',
         content: data.reply,
         applied_changes: data.applied_changes ?? null,


### PR DESCRIPTION
## Summary
- Replaces random localStorage session ID with authenticated user ID
- Adds `POST /api/chat/migrate-session` endpoint to migrate legacy session history
- Frontend auto-migrates on login, then removes legacy key
- Closes re-66f

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Verify chat history persists across sessions for authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)