### PR TITLE
fix: resolve 'Thing not found' 404 for context things with NULL user_id

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -64,4 +64,4 @@ def user_filter(user_id: str, table_alias: str = "") -> tuple[str, list[str]]:
     if not user_id:
         return "", []
     prefix = f"{table_alias}." if table_alias else ""
-    return f" AND {prefix}user_id = ?", [user_id]
+    return f" AND ({prefix}user_id = ? OR {prefix}user_id IS NULL)", [user_id]

--- a/backend/database.py
+++ b/backend/database.py
@@ -178,6 +178,20 @@ def _migrate_google_tokens_multi_user(conn: sqlite3.Connection) -> None:
         )
 
 
+def _migrate_backfill_null_user_ids(conn: sqlite3.Connection) -> None:
+    """Backfill NULL user_id in things/chat_history/sweep_findings to the first user.
+
+    Things created before multi-user auth have user_id=NULL, which causes
+    user_filter queries to miss them (404 on context thing links).
+    """
+    first_user = conn.execute("SELECT id FROM users LIMIT 1").fetchone()
+    if not first_user:
+        return  # No users yet — nothing to backfill
+    uid = first_user["id"]
+    for table in ("things", "chat_history", "sweep_findings"):
+        conn.execute(f"UPDATE {table} SET user_id = ? WHERE user_id IS NULL", (uid,))
+
+
 def clean_orphan_relationships() -> tuple[int, list[str]]:
     """Delete relationships where from_thing_id or to_thing_id doesn't exist.
 
@@ -330,4 +344,5 @@ def init_db() -> None:
         _migrate_sweep_findings_snooze(conn)
         _migrate_add_users(conn)
         _migrate_google_tokens_multi_user(conn)
+        _migrate_backfill_null_user_ids(conn)
         _seed_thing_types(conn)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -209,7 +209,8 @@ def _fetch_with_family(conn: sqlite3.Connection, seed_ids: list[str]) -> list[di
 
 
 def _fetch_relevant_things(
-    conn: sqlite3.Connection, search_queries: list[str], filter_params: dict[str, Any]
+    conn: sqlite3.Connection, search_queries: list[str], filter_params: dict[str, Any],
+    user_id: str = "",
 ) -> list[dict[str, Any]]:
     """Retrieve relevant Things using vector search (≥500 Things) or SQL LIKE fallback (<500).
 
@@ -217,6 +218,7 @@ def _fetch_relevant_things(
     """
     active_only = filter_params.get("active_only", True)
     type_hint = filter_params.get("type_hint")
+    uf_sql, uf_params = user_filter(user_id)
 
     # Choose retrieval strategy based on indexed count
     vc = vector_count()
@@ -255,6 +257,8 @@ def _fetch_relevant_things(
             pattern = f"%{query}%"
             sql = "SELECT id FROM things WHERE (title LIKE ? OR data LIKE ?)"
             params: list = [pattern, pattern]
+            sql += uf_sql
+            params.extend(uf_params)
             if active_only:
                 sql += " AND active = 1"
             if type_hint:
@@ -277,8 +281,8 @@ def _fetch_relevant_things(
     # Always include recent active things when there aren't enough results
     if len(results) < 5:
         seen_ids = {r["id"] for r in results}
-        sql = "SELECT * FROM things WHERE active = 1 ORDER BY updated_at DESC LIMIT 10"
-        for row in conn.execute(sql).fetchall():
+        recent_sql = "SELECT * FROM things WHERE active = 1" + uf_sql + " ORDER BY updated_at DESC LIMIT 10"
+        for row in conn.execute(recent_sql, uf_params).fetchall():
             if row["id"] not in seen_ids:
                 seen_ids.add(row["id"])
                 results.append(dict(row))
@@ -351,7 +355,7 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
 
     # Retrieve relevant Things and update last_referenced
     with db() as conn:
-        relevant_things = _fetch_relevant_things(conn, search_queries, filter_params)
+        relevant_things = _fetch_relevant_things(conn, search_queries, filter_params, user_id=user_id)
         logger.info(
             "Retrieved %d relevant Things for queries %r (vector_count=%d, threshold=%d)",
             len(relevant_things),


### PR DESCRIPTION
## Summary
- Fixes context thing links showing "Thing not found" due to NULL user_id mismatch
- `user_filter()` now includes `OR user_id IS NULL` to match pre-auth Things
- Adds `_migrate_backfill_null_user_ids()` to assign first user to orphaned records
- Passes `user_id` through `_fetch_relevant_things()` for proper filtering
- Closes re-aj8

## Test plan
- [ ] Quality Gates pass (lint, typecheck, tests)
- [ ] Context thing links resolve correctly for pre-auth Things

🤖 Generated with [Claude Code](https://claude.com/claude-code)