### PR TITLE
Usage dashboard — per-user token usage, cost estimate, model breakdown (re-hn0)

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,15 +1,18 @@
-"""Settings endpoints: model configuration via Requesty."""
+"""Settings endpoints: model configuration and usage dashboard via Requesty."""
 
 import logging
+from datetime import date, datetime, timedelta
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
 import httpx
 import yaml
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from ..auth import require_user
+from ..auth import require_user, user_filter
+from ..database import db
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +41,42 @@ class ModelSettingsUpdate(BaseModel):
 class RequestyModel(BaseModel):
     id: str
     name: str | None = None
+
+
+class UsagePeriod(str, Enum):
+    today = "today"
+    week = "7d"
+    month = "30d"
+    all = "all"
+
+
+class DailyUsage(BaseModel):
+    date: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    api_calls: int = 0
+    cost_usd: float = 0.0
+
+
+class ModelBreakdown(BaseModel):
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    api_calls: int = 0
+    cost_usd: float = 0.0
+
+
+class UsageDashboard(BaseModel):
+    period: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    api_calls: int = 0
+    cost_usd: float = 0.0
+    per_model: list[ModelBreakdown] = []
+    daily: list[DailyUsage] = []
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -145,4 +184,91 @@ def update_settings(
         reasoning=models.get("reasoning", "google/gemini-3-flash-preview"),
         response=models.get("response", "google/gemini-2.5-flash-lite"),
         chat_context_window=cfg.get("chat", {}).get("context_window", 3),
+    )
+
+
+@router.get("/usage", response_model=UsageDashboard, summary="Get usage dashboard data")
+def get_usage(
+    period: UsagePeriod = Query(UsagePeriod.month),
+    user_id: str = Depends(require_user),
+) -> UsageDashboard:
+    """Return token usage, cost, and model breakdown for the given period."""
+    now = date.today()
+    if period == UsagePeriod.today:
+        start = datetime.combine(now, datetime.min.time()).isoformat()
+    elif period == UsagePeriod.week:
+        start = datetime.combine(now - timedelta(days=6), datetime.min.time()).isoformat()
+    elif period == UsagePeriod.month:
+        start = datetime.combine(now - timedelta(days=29), datetime.min.time()).isoformat()
+    else:
+        start = None
+
+    uf_sql, uf_params = user_filter(user_id)
+    time_filter = " AND timestamp >= ?" if start else ""
+    time_params: list[str] = [start] if start else []
+
+    with db() as conn:
+        base_where = f"WHERE 1=1{time_filter}{uf_sql}"
+        params = [*time_params, *uf_params]
+
+        totals = conn.execute(
+            "SELECT COALESCE(SUM(prompt_tokens), 0) as pt, "
+            "COALESCE(SUM(completion_tokens), 0) as ct, "
+            "COUNT(*) as calls, COALESCE(SUM(cost_usd), 0) as cost "
+            f"FROM usage_log {base_where}",
+            params,
+        ).fetchone()
+
+        model_rows = conn.execute(
+            "SELECT model, COALESCE(SUM(prompt_tokens), 0) as pt, "
+            "COALESCE(SUM(completion_tokens), 0) as ct, "
+            "COUNT(*) as calls, COALESCE(SUM(cost_usd), 0) as cost "
+            f"FROM usage_log {base_where} "
+            "GROUP BY model ORDER BY cost DESC",
+            params,
+        ).fetchall()
+
+        daily_rows = conn.execute(
+            "SELECT DATE(timestamp) as day, "
+            "COALESCE(SUM(prompt_tokens), 0) as pt, "
+            "COALESCE(SUM(completion_tokens), 0) as ct, "
+            "COUNT(*) as calls, COALESCE(SUM(cost_usd), 0) as cost "
+            f"FROM usage_log {base_where} "
+            "GROUP BY DATE(timestamp) ORDER BY day",
+            params,
+        ).fetchall()
+
+    per_model = [
+        ModelBreakdown(
+            model=r["model"],
+            prompt_tokens=r["pt"],
+            completion_tokens=r["ct"],
+            total_tokens=r["pt"] + r["ct"],
+            api_calls=r["calls"],
+            cost_usd=round(r["cost"], 6),
+        )
+        for r in model_rows
+    ]
+
+    daily = [
+        DailyUsage(
+            date=r["day"],
+            prompt_tokens=r["pt"],
+            completion_tokens=r["ct"],
+            total_tokens=r["pt"] + r["ct"],
+            api_calls=r["calls"],
+            cost_usd=round(r["cost"], 6),
+        )
+        for r in daily_rows
+    ]
+
+    return UsageDashboard(
+        period=period.value,
+        prompt_tokens=totals["pt"],
+        completion_tokens=totals["ct"],
+        total_tokens=totals["pt"] + totals["ct"],
+        api_calls=totals["calls"],
+        cost_usd=round(totals["cost"], 6),
+        per_model=per_model,
+        daily=daily,
     )

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
-import type { ModelSettings } from '../store'
+import type { ModelSettings, UsageDashboard } from '../store'
+
+type SettingsTab = 'models' | 'usage'
 
 export function SettingsPanel() {
   const {
@@ -12,6 +14,11 @@ export function SettingsPanel() {
     fetchModelSettings,
     fetchAvailableModels,
     closeSettings,
+    usageDashboard,
+    usageLoading,
+    usagePeriod,
+    fetchUsageDashboard,
+    setUsagePeriod,
   } = useStore(
     useShallow(s => ({
       modelSettings: s.modelSettings,
@@ -21,13 +28,26 @@ export function SettingsPanel() {
       fetchModelSettings: s.fetchModelSettings,
       fetchAvailableModels: s.fetchAvailableModels,
       closeSettings: s.closeSettings,
+      usageDashboard: s.usageDashboard,
+      usageLoading: s.usageLoading,
+      usagePeriod: s.usagePeriod,
+      fetchUsageDashboard: s.fetchUsageDashboard,
+      setUsagePeriod: s.setUsagePeriod,
     })),
   )
+
+  const [tab, setTab] = useState<SettingsTab>('models')
 
   useEffect(() => {
     fetchModelSettings()
     fetchAvailableModels()
   }, [fetchModelSettings, fetchAvailableModels])
+
+  useEffect(() => {
+    if (tab === 'usage' && !usageDashboard) {
+      fetchUsageDashboard()
+    }
+  }, [tab, usageDashboard, fetchUsageDashboard])
 
   const modelOptions = availableModels.map(m => m.id).sort()
   const isLoading = settingsLoading || modelsLoading
@@ -35,49 +55,77 @@ export function SettingsPanel() {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
-          <button
-            onClick={closeSettings}
-            className="p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-            aria-label="Close settings"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+        {/* Header with tabs */}
+        <div className="px-6 pt-4 pb-0 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Settings</h2>
+            <button
+              onClick={closeSettings}
+              className="p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              aria-label="Close settings"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div className="flex gap-4">
+            <TabButton active={tab === 'models'} onClick={() => setTab('models')}>Models</TabButton>
+            <TabButton active={tab === 'usage'} onClick={() => setTab('usage')}>Usage</TabButton>
+          </div>
         </div>
 
         {/* Content */}
         <div className="px-6 py-5 space-y-5">
-          <div>
-            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">AI Models</h3>
-            <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
-              Select which models to use for each stage of the chat pipeline.
-            </p>
+          {tab === 'models' && (
+            <div>
+              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">AI Models</h3>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
+                Select which models to use for each stage of the chat pipeline.
+              </p>
 
-            {isLoading ? (
-              <div className="space-y-3 animate-pulse">
-                <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
-                <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
-                <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
-              </div>
-            ) : modelSettings ? (
-              <SettingsForm
-                key={`${modelSettings.context}|${modelSettings.reasoning}|${modelSettings.response}|${modelSettings.chat_context_window}`}
-                initial={modelSettings}
-                modelOptions={modelOptions}
-                onClose={closeSettings}
-              />
-            ) : (
-              <p className="text-sm text-gray-400">Failed to load settings.</p>
-            )}
-          </div>
+              {isLoading ? (
+                <div className="space-y-3 animate-pulse">
+                  <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded" />
+                </div>
+              ) : modelSettings ? (
+                <SettingsForm
+                  key={`${modelSettings.context}|${modelSettings.reasoning}|${modelSettings.response}|${modelSettings.chat_context_window}`}
+                  initial={modelSettings}
+                  modelOptions={modelOptions}
+                  onClose={closeSettings}
+                />
+              ) : (
+                <p className="text-sm text-gray-400">Failed to load settings.</p>
+              )}
+            </div>
+          )}
+
+          {tab === 'usage' && (
+            <UsageTab
+              dashboard={usageDashboard}
+              loading={usageLoading}
+              period={usagePeriod}
+              onPeriodChange={setUsagePeriod}
+            />
+          )}
         </div>
 
-        {/* Footer rendered inside SettingsForm when loaded, or simple close when not */}
-        {(isLoading || !modelSettings) && (
+        {/* Footer for models tab when loading/failed, or usage tab */}
+        {tab === 'models' && (isLoading || !modelSettings) && (
+          <div className="flex items-center justify-end px-6 py-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              onClick={closeSettings}
+              className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        )}
+
+        {tab === 'usage' && (
           <div className="flex items-center justify-end px-6 py-4 border-t border-gray-200 dark:border-gray-700">
             <button
               onClick={closeSettings}
@@ -88,6 +136,157 @@ export function SettingsPanel() {
           </div>
         )}
       </div>
+    </div>
+  )
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`pb-2 text-sm font-medium border-b-2 transition-colors ${
+        active
+          ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+          : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+const PERIOD_OPTIONS = [
+  { value: 'today', label: 'Today' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: 'all', label: 'All time' },
+]
+
+function UsageTab({
+  dashboard,
+  loading,
+  period,
+  onPeriodChange,
+}: {
+  dashboard: UsageDashboard | null
+  loading: boolean
+  period: string
+  onPeriodChange: (p: string) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">Token Usage</h3>
+        <select
+          value={period}
+          onChange={e => onPeriodChange(e.target.value)}
+          className="px-2 py-1 text-xs rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+        >
+          {PERIOD_OPTIONS.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3 animate-pulse">
+          <div className="h-20 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      ) : dashboard ? (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-3 gap-3 mb-5">
+            <StatCard label="Total Tokens" value={formatNumber(dashboard.total_tokens)} />
+            <StatCard label="API Calls" value={formatNumber(dashboard.api_calls)} />
+            <StatCard label="Est. Cost" value={formatCost(dashboard.cost_usd)} />
+          </div>
+
+          {/* Model breakdown */}
+          {dashboard.per_model.length > 0 && (
+            <div className="mb-5">
+              <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Model Breakdown
+              </h4>
+              <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+                      <th className="text-left px-3 py-2 font-medium">Model</th>
+                      <th className="text-right px-3 py-2 font-medium">Tokens</th>
+                      <th className="text-right px-3 py-2 font-medium">Calls</th>
+                      <th className="text-right px-3 py-2 font-medium">Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                    {dashboard.per_model.map(m => (
+                      <tr key={m.model} className="text-gray-700 dark:text-gray-300">
+                        <td className="px-3 py-2 truncate max-w-[180px]" title={m.model}>
+                          {shortModelName(m.model)}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatNumber(m.total_tokens)}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatNumber(m.api_calls)}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatCost(m.cost_usd)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Daily breakdown */}
+          {dashboard.daily.length > 0 && (
+            <div>
+              <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                Daily Usage
+              </h4>
+              <div className="space-y-1">
+                {dashboard.daily.map(d => {
+                  const maxTokens = Math.max(...dashboard.daily.map(dd => dd.total_tokens), 1)
+                  const pct = (d.total_tokens / maxTokens) * 100
+                  return (
+                    <div key={d.date} className="flex items-center gap-2 text-xs">
+                      <span className="w-16 text-gray-500 dark:text-gray-400 shrink-0">
+                        {formatDate(d.date)}
+                      </span>
+                      <div className="flex-1 h-4 bg-gray-100 dark:bg-gray-800 rounded overflow-hidden">
+                        <div
+                          className="h-full bg-indigo-500/70 rounded"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span className="w-16 text-right text-gray-600 dark:text-gray-300 tabular-nums shrink-0">
+                        {formatNumber(d.total_tokens)}
+                      </span>
+                      <span className="w-14 text-right text-gray-400 dark:text-gray-500 tabular-nums shrink-0">
+                        {formatCost(d.cost_usd)}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {dashboard.per_model.length === 0 && dashboard.daily.length === 0 && (
+            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">
+              No usage data for this period.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-gray-400">Failed to load usage data.</p>
+      )}
+    </div>
+  )
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-3 text-center">
+      <div className="text-lg font-semibold text-gray-900 dark:text-white tabular-nums">{value}</div>
+      <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{label}</div>
     </div>
   )
 }
@@ -229,4 +428,26 @@ function ModelSelect({
       </select>
     </div>
   )
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return n.toString()
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`
+  return `$${usd.toFixed(2)}`
+}
+
+function shortModelName(model: string): string {
+  // Strip common prefixes like "google/" or "openai/"
+  const parts = model.split('/')
+  return parts.length > 1 ? parts.slice(1).join('/') : model
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -208,6 +208,31 @@ export const RequestyModelSchema = z.object({
   name: z.string().nullable(),
 })
 
+export const UsageDashboardSchema = z.object({
+  period: z.string(),
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  total_tokens: z.number(),
+  api_calls: z.number(),
+  cost_usd: z.number(),
+  per_model: z.array(z.object({
+    model: z.string(),
+    prompt_tokens: z.number(),
+    completion_tokens: z.number(),
+    total_tokens: z.number(),
+    api_calls: z.number(),
+    cost_usd: z.number(),
+  })),
+  daily: z.array(z.object({
+    date: z.string(),
+    prompt_tokens: z.number(),
+    completion_tokens: z.number(),
+    total_tokens: z.number(),
+    api_calls: z.number(),
+    cost_usd: z.number(),
+  })),
+})
+
 // --- Validation helper ---
 
 /**

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -22,6 +22,7 @@ import {
   CalendarEventSchema,
   ModelSettingsSchema,
   RequestyModelSchema,
+  UsageDashboardSchema,
 } from './schemas'
 import { z } from 'zod'
 
@@ -128,6 +129,26 @@ export interface ModelSettings {
 export interface RequestyModel {
   id: string
   name: string | null
+}
+
+export interface DailyUsage {
+  date: string
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  api_calls: number
+  cost_usd: number
+}
+
+export interface UsageDashboard {
+  period: string
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  api_calls: number
+  cost_usd: number
+  per_model: ModelUsage[]
+  daily: DailyUsage[]
 }
 
 export interface ModelUsage {
@@ -267,6 +288,13 @@ interface ReliState {
   fetchModelSettings: () => Promise<void>
   fetchAvailableModels: () => Promise<void>
   updateModelSettings: (settings: Partial<ModelSettings>) => Promise<void>
+
+  // Usage dashboard
+  usageDashboard: UsageDashboard | null
+  usageLoading: boolean
+  usagePeriod: string
+  fetchUsageDashboard: (period?: string) => Promise<void>
+  setUsagePeriod: (period: string) => void
 }
 
 const HISTORY_PAGE_SIZE = 20
@@ -815,5 +843,30 @@ export const useStore = create<ReliState>((set, get) => ({
     } catch (e) {
       set({ error: String(e) })
     }
+  },
+
+  // Usage dashboard
+  usageDashboard: null,
+  usageLoading: false,
+  usagePeriod: '30d',
+
+  fetchUsageDashboard: async (period?: string) => {
+    const p = period ?? get().usagePeriod
+    set({ usageLoading: true })
+    try {
+      const res = await apiFetch(`${BASE}/settings/usage?period=${encodeURIComponent(p)}`)
+      if (!res.ok) return
+      const data: UsageDashboard = validateResponse(UsageDashboardSchema, await res.json(), '/settings/usage')
+      set({ usageDashboard: data })
+    } catch {
+      // best-effort
+    } finally {
+      set({ usageLoading: false })
+    }
+  },
+
+  setUsagePeriod: (period: string) => {
+    set({ usagePeriod: period })
+    get().fetchUsageDashboard(period)
   },
 }))


### PR DESCRIPTION
## Summary

- Adds usage dashboard to settings page showing per-user token usage, estimated cost, and model breakdown
- Backend: new settings endpoints for usage data aggregation
- Frontend: new UI components for usage visualization on settings page

- **Issue**: re-hn0
- **Polecat**: nux
- **Branch**: polecat/nux/re-hn0@mmt1j18g
- **Tests**: 413 passed (176 frontend + 237 backend)

---
*Created by Gas Town Refinery*