### PR TITLE
feat: auto-create User Thing on first OAuth login (re-6kt)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,8 @@
 """Google OAuth2 login + JWT session authentication."""
 
+import json
 import logging
+import sqlite3
 import uuid
 from datetime import datetime, timezone
 
@@ -12,6 +14,7 @@ from google_auth_oauthlib.flow import Flow
 
 from ..config import settings
 from ..database import db
+from ..vector_store import upsert_thing
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +88,27 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
                 (user_id, email, google_id, name, picture, now, now),
             )
+            _create_user_thing(conn, user_id, name, email, google_id, now)
     return user_id
+
+
+def _create_user_thing(conn: sqlite3.Connection, user_id: str, name: str, email: str, google_id: str, now: str) -> None:
+    """Create a Thing representing the user as their anchor node."""
+    thing_id = str(uuid.uuid4())
+    data_json = json.dumps({"email": email, "google_id": google_id})
+    conn.execute(
+        """INSERT INTO things
+           (id, title, type_hint, parent_id, checkin_date, priority, active, surface,
+            data, open_questions, created_at, updated_at, user_id)
+           VALUES (?, ?, 'person', NULL, NULL, 3, 1, 0, ?, NULL, ?, ?, ?)""",
+        (thing_id, name, data_json, now, now, user_id),
+    )
+    row = conn.execute("SELECT * FROM things WHERE id = ?", (thing_id,)).fetchone()
+    if row:
+        try:
+            upsert_thing(dict(row))
+        except Exception:
+            logger.warning("Failed to index user Thing %s in vector store", thing_id)
 
 
 @router.get("/google", summary="Start Google OAuth flow")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -51,6 +51,7 @@ def mock_vector_store():
         patch("backend.vector_store.delete_thing", return_value=None),
         patch("backend.vector_store.vector_count", return_value=0),
         patch("backend.vector_store.vector_search", return_value=[]),
+        patch("backend.routers.auth.upsert_thing", return_value=None),
         patch("backend.routers.things.upsert_thing", return_value=None) as mock_upsert,
         patch("backend.routers.things.vs_delete", return_value=None) as mock_delete,
         patch("backend.routers.chat.vector_count", return_value=0) as mock_count,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for JWT session authentication."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,45 @@ def authed_client(patched_db):
 
         with TestClient(app) as c:
             yield c
+
+
+class TestUserThingCreation:
+    """Test that a Thing is auto-created for new OAuth users."""
+
+    def test_upsert_user_creates_thing_for_new_user(self, patched_db):
+        from backend.database import db
+        from backend.routers.auth import _upsert_user
+
+        user_id = _upsert_user("google-123", "alice@example.com", "Alice", None)
+
+        with db() as conn:
+            thing = conn.execute(
+                "SELECT * FROM things WHERE user_id = ? AND type_hint = 'person'",
+                (user_id,),
+            ).fetchone()
+
+        assert thing is not None
+        assert thing["title"] == "Alice"
+        assert thing["surface"] == 0
+        data = json.loads(thing["data"])
+        assert data["email"] == "alice@example.com"
+        assert data["google_id"] == "google-123"
+
+    def test_upsert_user_no_duplicate_thing_on_repeat_login(self, patched_db):
+        from backend.database import db
+        from backend.routers.auth import _upsert_user
+
+        user_id = _upsert_user("google-123", "alice@example.com", "Alice", None)
+        _upsert_user("google-123", "alice@example.com", "Alice", None)
+
+        with db() as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) as c FROM things"
+                " WHERE user_id = ? AND type_hint = 'person'",
+                (user_id,),
+            ).fetchone()["c"]
+
+        assert count == 1
 
 
 class TestJWTAuth:


### PR DESCRIPTION
## Summary
- Auto-creates a User Thing when a user first logs in via OAuth
- Source issue: re-6kt
- Worker: furiosa

## Test plan
- [x] All 239 backend tests pass
- [x] Coverage 79.24% (above 70% threshold)
- [x] Clean rebase on master (already up to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)