### PR TITLE
feat: invite-only access control with email allowlist (re-5pd)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -52,6 +52,14 @@ class Settings(BaseSettings):
 
     # --- Auth ---
     SECRET_KEY: str = ""
+    ALLOWED_EMAILS: str = ""  # Comma-separated allowlist; empty = allow all
+
+    @property
+    def allowed_emails_set(self) -> set[str]:
+        """Parse ALLOWED_EMAILS into a lowercase set. Empty string means allow all."""
+        if not self.ALLOWED_EMAILS.strip():
+            return set()
+        return {e.strip().lower() for e in self.ALLOWED_EMAILS.split(",") if e.strip()}
 
     # --- Token encryption ---
     TOKEN_ENCRYPTION_KEY: str = ""

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -171,6 +171,12 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
     name = id_info.get("name", email)
     picture = id_info.get("picture")
 
+    # Enforce invite-only allowlist
+    allowed = settings.allowed_emails_set
+    if allowed and email.lower() not in allowed:
+        logger.warning("OAuth rejected: %s not in ALLOWED_EMAILS", email)
+        return RedirectResponse(url="/?error=invite_only")
+
     user_id = _upsert_user(google_id, email, name, picture)
     token = _create_jwt(user_id, email)
 

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react'
 
 export function LoginPage() {
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const params = new URLSearchParams(window.location.search)
+  const [error, setError] = useState<string | null>(
+    params.get('error') === 'invite_only'
+      ? 'This app is invite-only. Your Google account is not on the access list.'
+      : null
+  )
 
   const handleLogin = async () => {
     setLoading(true)


### PR DESCRIPTION
## Summary

- Add allowlist of Google email addresses that can sign up via `ALLOWED_EMAILS` env var
- Reject non-allowlisted users at OAuth callback with friendly 'invite-only' message
- Config supports comma-separated emails (e.g. `ALLOWED_EMAILS=a@x.com,b@y.com`)

## Test plan

- [x] All 415 tests passing (176 frontend + 239 backend)
- [x] Build passes (Docker image builds cleanly)
- [x] Typecheck passes

---
*Merged by Gas Town Refinery*