### PR TITLE
feat: add dark mode toggle with light/dark/system support (re-mte9)

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
 import type { ModelSettings, UserSettings } from '../store'
+import { useTheme, setTheme } from '../hooks/useTheme'
 
 export function SettingsPanel() {
   const {
@@ -234,6 +235,7 @@ function SettingsForm({
           />
         </div>
       </div>
+      <ThemeSection />
       <div className="flex items-center justify-end gap-3 mt-5 pt-4 border-t border-gray-200 dark:border-gray-700">
         {saved && (
           <span className="text-sm text-green-600 dark:text-green-400">Saved</span>
@@ -253,6 +255,40 @@ function SettingsForm({
         </button>
       </div>
     </>
+  )
+}
+
+const themeOptions = [
+  { value: 'light' as const, label: 'Light', icon: 'M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z' },
+  { value: 'dark' as const, label: 'Dark', icon: 'M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z' },
+  { value: 'system' as const, label: 'System', icon: 'M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25A2.25 2.25 0 0 1 5.25 3h13.5A2.25 2.25 0 0 1 21 5.25Z' },
+]
+
+function ThemeSection() {
+  const { theme } = useTheme()
+
+  return (
+    <div className="mt-6 pt-5 border-t border-gray-200 dark:border-gray-700">
+      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Appearance</h3>
+      <div className="flex gap-2">
+        {themeOptions.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => setTheme(opt.value)}
+            className={`flex-1 flex flex-col items-center gap-1.5 px-3 py-2.5 rounded-lg border text-sm transition-colors ${
+              theme === opt.value
+                ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300'
+                : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+            }`}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d={opt.icon} />
+            </svg>
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,76 @@
+import { useEffect, useSyncExternalStore } from 'react'
+
+type Theme = 'light' | 'dark' | 'system'
+
+const STORAGE_KEY = 'reli-theme'
+
+function prefersColorSchemeDark(): boolean {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+    : false
+}
+
+function getStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  } catch { /* SSR / test env */ }
+  return 'system'
+}
+
+function resolveTheme(theme: Theme): 'light' | 'dark' {
+  if (theme !== 'system') return theme
+  return prefersColorSchemeDark() ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return
+  const resolved = resolveTheme(theme)
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+  document.documentElement.style.colorScheme = resolved
+}
+
+let currentTheme: Theme = getStoredTheme()
+const listeners = new Set<() => void>()
+
+function notify() {
+  listeners.forEach(l => l())
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+function getSnapshot(): Theme {
+  return currentTheme
+}
+
+export function setTheme(theme: Theme) {
+  currentTheme = theme
+  try { localStorage.setItem(STORAGE_KEY, theme) } catch { /* test env */ }
+  applyTheme(theme)
+  notify()
+}
+
+// Apply on load
+applyTheme(currentTheme)
+
+// Listen for system preference changes
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (currentTheme === 'system') {
+      applyTheme('system')
+    }
+  })
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot)
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  return { theme, setTheme }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   color-scheme: light dark;
 }


### PR DESCRIPTION
## Summary
- Add dark mode toggle with light/dark/system theme support

## Source
- Issue: re-mte9
- Branch: polecat/slit/re-mte9@mmtjg34s
- Worker: slit

## Test Results
- Frontend: 176/176 passed
- Backend: 246/246 passed
- Coverage: 79.64% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)