### PR TITLE
feat: stream agent responses via SSE for real-time progress (re-u4w)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -5,6 +5,7 @@ import logging
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
+from collections.abc import AsyncIterator
 from typing import Any
 
 import yaml
@@ -257,6 +258,40 @@ async def _chat(
             model=response.model or used_model,
         )
     return response.choices[0].message.content or ""
+
+
+async def _chat_stream(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    usage_stats: UsageStats | None = None,
+    api_key: str | None = None,
+    **kwargs: Any,
+) -> AsyncIterator[str]:
+    """Stream LLM response tokens as an async iterator of text chunks."""
+    client = _client(api_key=api_key)
+    used_model = model or REQUESTY_MODEL
+    stream = await client.chat.completions.create(  # type: ignore[call-overload]
+        model=used_model,
+        messages=messages,  # type: ignore[arg-type]
+        stream=True,
+        stream_options={"include_usage": True},
+        **kwargs,
+    )
+    async for chunk in stream:
+        if chunk.choices and chunk.choices[0].delta.content:
+            yield chunk.choices[0].delta.content
+        # The final chunk with usage info has empty choices
+        if usage_stats is not None and chunk.usage:
+            cost = 0.0
+            if hasattr(chunk, "x_request_cost"):
+                cost = float(getattr(chunk, "x_request_cost", 0))
+            usage_stats.accumulate(
+                prompt=chunk.usage.prompt_tokens or 0,
+                completion=chunk.usage.completion_tokens or 0,
+                total=chunk.usage.total_tokens or 0,
+                cost=cost,
+                model=used_model,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1054,3 +1089,56 @@ async def run_response_agent(
         {"role": "user", "content": context},
     ]
     return await _chat(messages, model=model or REQUESTY_RESPONSE_MODEL, usage_stats=usage_stats, api_key=api_key)
+
+
+def _build_response_messages(
+    message: str,
+    reasoning_summary: str,
+    questions_for_user: list[str],
+    applied_changes: dict[str, Any],
+    web_results: list[dict[str, Any]] | None = None,
+    open_questions_by_thing: dict[str, list[str]] | None = None,
+) -> list[dict[str, Any]]:
+    """Build the message list for the response agent (shared by streaming and non-streaming)."""
+    context = (
+        f"<user_message>\n{message}\n</user_message>\n\n"
+        f"<reasoning_summary>\n{reasoning_summary}\n</reasoning_summary>\n\n"
+        f"Applied changes: {json.dumps(applied_changes, default=str)}\n\n"
+        f"Questions for user (if any): {json.dumps(questions_for_user)}"
+    )
+    if open_questions_by_thing:
+        context += (
+            f"\n\nOpen questions on Things (knowledge gaps to ask about conversationally):\n"
+            f"{json.dumps(open_questions_by_thing, default=str)}"
+        )
+    if web_results:
+        context += (
+            f"\n\nWeb search results (cite relevant sources in your response):\n{json.dumps(web_results, default=str)}"
+        )
+    return [
+        {"role": "system", "content": RESPONSE_AGENT_SYSTEM},
+        {"role": "user", "content": context},
+    ]
+
+
+async def run_response_agent_stream(
+    message: str,
+    reasoning_summary: str,
+    questions_for_user: list[str],
+    applied_changes: dict[str, Any],
+    web_results: list[dict[str, Any]] | None = None,
+    usage_stats: UsageStats | None = None,
+    open_questions_by_thing: dict[str, list[str]] | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[str]:
+    """Stage 4 (streaming): yield response tokens as they arrive."""
+    messages = _build_response_messages(
+        message, reasoning_summary, questions_for_user,
+        applied_changes, web_results, open_questions_by_thing,
+    )
+    async for token in _chat_stream(
+        messages, model=model or REQUESTY_RESPONSE_MODEL,
+        usage_stats=usage_stats, api_key=api_key,
+    ):
+        yield token

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -4,9 +4,11 @@ import json
 import logging
 import sqlite3
 from datetime import date, datetime
+from collections.abc import AsyncIterator
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +19,7 @@ from ..agents import (
     run_context_refinement,
     run_reasoning_agent,
     run_response_agent,
+    run_response_agent_stream,
 )
 from ..auth import require_user, user_filter
 from ..database import db
@@ -712,6 +715,292 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
         usage=UsageInfo(**usage.to_dict()),
         session_usage=daily_usage,
     )
+
+
+@router.post("/stream", summary="Stream a chat response via SSE")
+async def chat_stream(body: ChatRequest, user_id: str = Depends(require_user)) -> StreamingResponse:
+    """SSE streaming version of the chat pipeline.
+
+    Emits events:
+      - stage: {"stage": "<name>", "status": "started"|"complete"}
+      - token: {"text": "<chunk>"}
+      - complete: full ChatResponse JSON (same schema as POST /chat)
+      - error: {"message": "<error>"}
+    """
+
+    async def event_generator() -> AsyncIterator[str]:  # noqa: C901
+        try:
+            session_id = body.session_id
+            message = body.message
+
+            user_api_key = get_user_api_key(user_id)
+            user_models = get_user_models(user_id)
+            context_window = get_user_chat_context_window(user_id)
+
+            history_limit = context_window * 2
+            with db() as conn:
+                rows = conn.execute(
+                    "SELECT role, content, applied_changes FROM chat_history WHERE session_id = ? ORDER BY timestamp ASC LIMIT ?",
+                    (session_id, history_limit),
+                ).fetchall()
+            history = [{"role": r["role"], "content": _enrich_history_content(r)} for r in rows]
+
+            usage = UsageStats()
+
+            # Stage 1: Context Agent
+            yield _sse("stage", {"stage": "context", "status": "started"})
+
+            MAX_CONTEXT_ITERATIONS = 4
+            context_result = await run_context_agent(
+                message, history, usage_stats=usage, context_window=context_window,
+                api_key=user_api_key, model=user_models["context"],
+            )
+            search_queries = context_result.get("search_queries", [message])
+            filter_params = context_result.get("filter_params", {})
+            gmail_query = context_result.get("gmail_query")
+
+            # Iterative context gathering
+            all_queries: list[str] = list(search_queries)
+            seen_thing_ids: set[str] = set()
+            relevant_things: list[dict[str, Any]] = []
+
+            with db() as conn:
+                initial_things = _fetch_relevant_things(conn, search_queries, filter_params, user_id=user_id)
+                for t in initial_things:
+                    if t["id"] not in seen_thing_ids:
+                        seen_thing_ids.add(t["id"])
+                        relevant_things.append(t)
+
+            for iteration in range(1, MAX_CONTEXT_ITERATIONS):
+                if not relevant_things:
+                    break
+                thing_relationships: list[dict[str, Any]] = []
+                with db() as conn:
+                    thing_id_list = list(seen_thing_ids)
+                    if thing_id_list:
+                        ph = ",".join("?" for _ in thing_id_list)
+                        rel_rows = conn.execute(
+                            f"SELECT from_thing_id, to_thing_id, relationship_type FROM thing_relationships "
+                            f"WHERE from_thing_id IN ({ph}) OR to_thing_id IN ({ph})",
+                            thing_id_list + thing_id_list,
+                        ).fetchall()
+                        thing_relationships = [dict(r) for r in rel_rows]
+
+                refinement = await run_context_refinement(
+                    message, history, relevant_things, all_queries,
+                    relationships=thing_relationships,
+                    usage_stats=usage, context_window=context_window,
+                    api_key=user_api_key, model=user_models["context"],
+                )
+                if refinement.get("done", True):
+                    break
+                new_queries = refinement.get("search_queries", [])
+                thing_ids_to_fetch = refinement.get("thing_ids", [])
+                refinement_filter = refinement.get("filter_params", filter_params)
+                if not new_queries and not thing_ids_to_fetch:
+                    break
+                prev_count = len(relevant_things)
+                if new_queries:
+                    all_queries.extend(new_queries)
+                    with db() as conn:
+                        new_things = _fetch_relevant_things(conn, new_queries, refinement_filter, user_id=user_id)
+                        for t in new_things:
+                            if t["id"] not in seen_thing_ids:
+                                seen_thing_ids.add(t["id"])
+                                relevant_things.append(t)
+                if thing_ids_to_fetch:
+                    with db() as conn:
+                        new_from_ids = _fetch_with_family(conn, [
+                            tid for tid in thing_ids_to_fetch if tid not in seen_thing_ids
+                        ])
+                        for t in new_from_ids:
+                            if t["id"] not in seen_thing_ids:
+                                seen_thing_ids.add(t["id"])
+                                relevant_things.append(t)
+                if len(relevant_things) - prev_count == 0:
+                    break
+
+            # Update last_referenced
+            if relevant_things:
+                with db() as conn:
+                    from datetime import timezone
+                    now = datetime.now(timezone.utc).isoformat()
+                    ids = [t["id"] for t in relevant_things]
+                    placeholders = ",".join("?" for _ in ids)
+                    conn.execute(
+                        f"UPDATE things SET last_referenced = ? WHERE id IN ({placeholders})",
+                        [now] + ids,
+                    )
+
+            yield _sse("stage", {"stage": "context", "status": "complete"})
+
+            # Web search
+            web_results: list[dict] | None = None
+            if context_result.get("needs_web_search") and is_search_configured():
+                web_query = context_result.get("web_search_query") or message
+                results = await google_search(web_query)
+                if results:
+                    web_results = [r.to_dict() for r in results]
+
+            gmail_context = _fetch_gmail_context(gmail_query, user_id=user_id) if gmail_query else []
+
+            calendar_events: list[dict] | None = None
+            if context_result.get("include_calendar") and gcal_connected(user_id=user_id):
+                try:
+                    calendar_events = fetch_upcoming_events(max_results=15, days_ahead=7, user_id=user_id)
+                except Exception:
+                    calendar_events = None
+
+            # Stage 2: Reasoning Agent
+            yield _sse("stage", {"stage": "reasoning", "status": "started"})
+
+            reasoning_result = await run_reasoning_agent(
+                message, history, relevant_things, web_results, gmail_context, calendar_events,
+                usage_stats=usage, context_window=context_window,
+                api_key=user_api_key, model=user_models["reasoning"],
+            )
+            storage_changes = reasoning_result.get("storage_changes", {})
+            questions_for_user = reasoning_result.get("questions_for_user", [])
+            reasoning_summary = reasoning_result.get("reasoning_summary", "")
+
+            # Stage 3: Validator
+            with db() as conn:
+                applied_changes = apply_storage_changes(storage_changes, conn, user_id=user_id)
+
+            open_questions_by_thing: dict[str, list[str]] = {}
+            for thing in relevant_things:
+                oq = thing.get("open_questions")
+                if oq:
+                    parsed = json.loads(oq) if isinstance(oq, str) else oq
+                    if parsed:
+                        open_questions_by_thing[thing.get("title", thing["id"])] = parsed
+            for thing in applied_changes.get("created", []) + applied_changes.get("updated", []):
+                oq = thing.get("open_questions")
+                if oq:
+                    parsed = json.loads(oq) if isinstance(oq, str) else oq
+                    if parsed:
+                        open_questions_by_thing[thing.get("title", thing.get("id", ""))] = parsed
+
+            yield _sse("stage", {"stage": "reasoning", "status": "complete"})
+
+            # Stage 4: Response Agent (streaming)
+            yield _sse("stage", {"stage": "response", "status": "started"})
+
+            reply_parts: list[str] = []
+            async for token in run_response_agent_stream(
+                message, reasoning_summary, questions_for_user, applied_changes,
+                web_results, usage_stats=usage,
+                open_questions_by_thing=open_questions_by_thing or None,
+                api_key=user_api_key, model=user_models["response"],
+            ):
+                reply_parts.append(token)
+                yield _sse("token", {"text": token})
+
+            reply = "".join(reply_parts)
+
+            yield _sse("stage", {"stage": "response", "status": "complete"})
+
+            # Persist to DB (same as non-streaming endpoint)
+            context_things = [
+                {"id": t["id"], "title": t.get("title", ""), "type_hint": t.get("type_hint")}
+                for t in relevant_things
+            ]
+            applied_with_sources = applied_changes.copy()
+            applied_with_sources["context_things"] = context_things
+            if web_results:
+                applied_with_sources["web_results"] = web_results
+            if usage.calls:
+                applied_with_sources["per_call_usage"] = [
+                    {
+                        "model": c.model,
+                        "prompt_tokens": c.prompt_tokens,
+                        "completion_tokens": c.completion_tokens,
+                        "cost_usd": round(c.cost_usd, 6),
+                    }
+                    for c in usage.calls
+                ]
+            if gmail_context:
+                applied_with_sources["gmail_context"] = gmail_context
+            if calendar_events:
+                applied_with_sources["calendar_events"] = calendar_events
+            changes_json = json.dumps(applied_with_sources)
+
+            with db() as conn:
+                conn.execute(
+                    "INSERT INTO chat_history (session_id, role, content, applied_changes, user_id) VALUES (?, ?, ?, ?, ?)",
+                    (session_id, "user", message, None, user_id or None),
+                )
+                cursor = conn.execute(
+                    "INSERT INTO chat_history"
+                    " (session_id, role, content, applied_changes,"
+                    " prompt_tokens, completion_tokens, cost_usd, api_calls, model, user_id)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        session_id, "assistant", reply, changes_json,
+                        usage.prompt_tokens, usage.completion_tokens,
+                        usage.cost_usd, usage.api_calls, usage.model, user_id or None,
+                    ),
+                )
+                assistant_msg_id = cursor.lastrowid
+
+                num_calls = len(usage.calls)
+                stage_labels: list[str | None] = []
+                if num_calls >= 1:
+                    stage_labels.append("context")
+                for _ in range(max(0, num_calls - 3)):
+                    stage_labels.append("context_refinement")
+                if num_calls >= 2:
+                    stage_labels.append("reasoning")
+                if num_calls >= 3:
+                    stage_labels.append("response")
+                while len(stage_labels) < num_calls:
+                    stage_labels.append(None)
+                for i, call in enumerate(usage.calls):
+                    stage = stage_labels[i] if i < len(stage_labels) else None
+                    conn.execute(
+                        "INSERT INTO chat_message_usage"
+                        " (chat_message_id, stage, model, prompt_tokens, completion_tokens, cost_usd)"
+                        " VALUES (?, ?, ?, ?, ?, ?)",
+                        (assistant_msg_id, stage, call.model, call.prompt_tokens, call.completion_tokens, call.cost_usd),
+                    )
+
+                for call in usage.calls:
+                    conn.execute(
+                        "INSERT INTO usage_log (session_id, model, prompt_tokens, completion_tokens, cost_usd, user_id)"
+                        " VALUES (?, ?, ?, ?, ?, ?)",
+                        (session_id, call.model, call.prompt_tokens, call.completion_tokens, call.cost_usd, user_id or None),
+                    )
+
+            daily_usage = _compute_daily_usage(user_id)
+
+            complete_data = ChatResponse(
+                session_id=session_id,
+                reply=reply,
+                applied_changes=applied_with_sources,
+                questions_for_user=questions_for_user,
+                usage=UsageInfo(**usage.to_dict()),
+                session_usage=daily_usage,
+            )
+            yield _sse("complete", complete_data.model_dump())
+
+        except Exception as e:
+            logger.exception("Streaming chat pipeline error")
+            yield _sse("error", {"message": str(e)})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+def _sse(event: str, data: Any) -> str:  # noqa: ANN401
+    """Format a Server-Sent Event."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
 
 def _compute_daily_usage(user_id: str = "") -> SessionUsage:

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { useStore, type AppliedChanges, type CalendarEvent, type ChatMessage, type ContextThing, type GmailMessage, type ModelUsage, type SessionStats, type WebSearchResult } from '../store'
+import { useStore, type AppliedChanges, type CalendarEvent, type ChatMessage, type ContextThing, type GmailMessage, type ModelUsage, type SessionStats, type StreamingStage, type WebSearchResult } from '../store'
 import { typeIcon } from '../utils'
 import { useVoiceInput, speechRecognitionSupported } from '../hooks/useVoiceInput'
 import { useTTS, ttsSupported, useAvailableVoices, getStoredVoiceURI, setStoredVoiceURI } from '../hooks/useTTS'
@@ -437,6 +437,37 @@ function VoiceSettings() {
   )
 }
 
+const STAGE_LABELS: Record<string, string> = {
+  context: 'Searching memory\u2026',
+  reasoning: 'Thinking\u2026',
+  response: 'Writing response\u2026',
+}
+
+function StreamingIndicator({ stage }: { stage: StreamingStage }) {
+  if (!stage) return null
+  const label = STAGE_LABELS[stage] ?? stage
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500 py-1">
+      <span className="flex gap-0.5">
+        {['context', 'reasoning', 'response'].map(s => (
+          <span
+            key={s}
+            className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+              s === stage
+                ? 'bg-indigo-500 animate-pulse'
+                : ['context', 'reasoning', 'response'].indexOf(s) < ['context', 'reasoning', 'response'].indexOf(stage)
+                  ? 'bg-indigo-400'
+                  : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+          />
+        ))}
+      </span>
+      <span>{label}</span>
+    </div>
+  )
+}
+
 function MessageBubble({ msg, speakingId, speak }: { msg: ChatMessage; speakingId: string | null; speak: (text: string, id: string) => void }) {
   const isUser = msg.role === 'user'
   const ts = formatTimestamp(msg.timestamp)
@@ -456,9 +487,15 @@ function MessageBubble({ msg, speakingId, speak }: { msg: ChatMessage; speakingI
               : 'bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-bl-sm'
           }`}
         >
-          {msg.content}
-          {msg.streaming && (
-            <span className="inline-block w-1.5 h-4 bg-current opacity-75 ml-0.5 animate-pulse align-middle" />
+          {msg.streaming && !msg.content && msg.streamingStage ? (
+            <StreamingIndicator stage={msg.streamingStage} />
+          ) : (
+            <>
+              {msg.content}
+              {msg.streaming && msg.content && (
+                <span className="inline-block w-1.5 h-4 bg-current opacity-75 ml-0.5 animate-pulse align-middle" />
+              )}
+            </>
           )}
           {!isUser && msg.applied_changes?.web_results && msg.applied_changes.web_results.length > 0 && (
             <WebSources results={msg.applied_changes.web_results} />

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -166,6 +166,8 @@ export interface CallUsage {
   cost_usd: number
 }
 
+export type StreamingStage = 'context' | 'reasoning' | 'response' | null
+
 export interface ChatMessage {
   id: number | string
   session_id: string
@@ -180,6 +182,7 @@ export interface ChatMessage {
   per_call_usage?: CallUsage[]
   timestamp: string
   streaming?: boolean
+  streamingStage?: StreamingStage
 }
 
 export interface Relationship {
@@ -650,6 +653,7 @@ export const useStore = create<ReliState>((set, get) => ({
       questions_for_user: [],
       timestamp: new Date().toISOString(),
       streaming: true,
+      streamingStage: 'context',
     }
 
     set(state => ({
@@ -658,36 +662,82 @@ export const useStore = create<ReliState>((set, get) => ({
     }))
 
     try {
-      const res = await apiFetch(`${BASE}/chat`, {
+      const res = await apiFetch(`${BASE}/chat/stream`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ session_id: get().sessionId, message: text }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data = validateResponse(ChatResponseSchema, await res.json(), '/chat')
 
-      const assistantMsg: ChatMessage = {
-        id: `assistant-${Date.now()}`,
-        session_id: get().sessionId,
-        role: 'assistant',
-        content: data.reply,
-        applied_changes: data.applied_changes ?? null,
-        questions_for_user: data.questions_for_user ?? [],
-        prompt_tokens: data.usage?.prompt_tokens ?? 0,
-        completion_tokens: data.usage?.completion_tokens ?? 0,
-        cost_usd: data.usage?.cost_usd ?? 0,
-        model: data.usage?.model ?? null,
-        per_call_usage: data.usage?.per_call_usage ?? [],
-        timestamp: new Date().toISOString(),
-      }
+      const reader = res.body?.getReader()
+      if (!reader) throw new Error('No response body')
 
-      const updates: Partial<ReliState> = {
-        messages: get().messages.map(m => m.streaming ? assistantMsg : m),
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        // Keep the last potentially incomplete line in the buffer
+        buffer = lines.pop() ?? ''
+
+        let eventType = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            eventType = line.slice(7).trim()
+          } else if (line.startsWith('data: ') && eventType) {
+            const data = JSON.parse(line.slice(6))
+
+            if (eventType === 'stage') {
+              const stage = data.stage as 'context' | 'reasoning' | 'response'
+              const status = data.status as 'started' | 'complete'
+              if (status === 'started') {
+                set(state => ({
+                  messages: state.messages.map(m =>
+                    m.streaming ? { ...m, streamingStage: stage } : m,
+                  ),
+                }))
+              }
+            } else if (eventType === 'token') {
+              set(state => ({
+                messages: state.messages.map(m =>
+                  m.streaming ? { ...m, content: m.content + data.text } : m,
+                ),
+              }))
+            } else if (eventType === 'complete') {
+              const chatData = validateResponse(ChatResponseSchema, data, '/chat/stream')
+              const assistantMsg: ChatMessage = {
+                id: `assistant-${Date.now()}`,
+                session_id: get().sessionId,
+                role: 'assistant',
+                content: chatData.reply,
+                applied_changes: chatData.applied_changes ?? null,
+                questions_for_user: chatData.questions_for_user ?? [],
+                prompt_tokens: chatData.usage?.prompt_tokens ?? 0,
+                completion_tokens: chatData.usage?.completion_tokens ?? 0,
+                cost_usd: chatData.usage?.cost_usd ?? 0,
+                model: chatData.usage?.model ?? null,
+                per_call_usage: chatData.usage?.per_call_usage ?? [],
+                timestamp: new Date().toISOString(),
+              }
+              const updates: Partial<ReliState> = {
+                messages: get().messages.map(m => m.streaming ? assistantMsg : m),
+              }
+              if (chatData.session_usage) {
+                updates.sessionStats = chatData.session_usage
+              }
+              set(updates as ReliState)
+            } else if (eventType === 'error') {
+              throw new Error(data.message || 'Pipeline error')
+            }
+
+            eventType = ''
+          }
+        }
       }
-      if (data.session_usage) {
-        updates.sessionStats = data.session_usage
-      }
-      set(updates as ReliState)
 
       // Refresh things in case the pipeline made changes
       get().fetchThings()
@@ -697,7 +747,7 @@ export const useStore = create<ReliState>((set, get) => ({
       set(state => ({
         messages: state.messages.map(m =>
           m.streaming
-            ? { ...m, content: 'Error communicating with server.', streaming: false }
+            ? { ...m, content: m.content || 'Error communicating with server.', streaming: false, streamingStage: null }
             : m,
         ),
         error: String(e),


### PR DESCRIPTION
## Summary
- Add Server-Sent Events (SSE) streaming for agent responses
- Enables real-time progress updates during context gathering and response generation

## Source
- Issue: re-u4w
- Branch: polecat/furiosa/re-u4w@mmtkr75y
- Worker: furiosa

## Test Results
- Frontend: 176/176 passed
- Backend: 248/248 passed
- Coverage: 76.92% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)