### PR TITLE
feat: depth-limited relationship loading in Context Agent (re-dnp)

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -217,6 +217,73 @@ def _fetch_with_family(conn: sqlite3.Connection, seed_ids: list[str]) -> list[di
     return results
 
 
+def _fetch_user_relationships(
+    conn: sqlite3.Connection,
+    user_thing_id: str,
+    search_queries: list[str],
+    user_id: str = "",
+) -> list[dict[str, Any]]:
+    """Fetch 1-hop relationships from the user Thing, filtered by search query relevance.
+
+    Only returns related Things whose title or data match at least one search
+    query (case-insensitive LIKE).  Results are ordered by last_referenced DESC
+    (recently-mentioned first) so the most relevant connections surface first.
+    This prevents context bloat for power users with hundreds of relationships.
+    """
+    if not user_thing_id or not search_queries:
+        return []
+
+    # Fetch all relationship edges touching the user Thing
+    rels = conn.execute(
+        "SELECT * FROM thing_relationships WHERE from_thing_id = ? OR to_thing_id = ?",
+        (user_thing_id, user_thing_id),
+    ).fetchall()
+    if not rels:
+        return []
+
+    # Collect the IDs of the "other" side of each relationship
+    other_ids: list[str] = []
+    for rel in rels:
+        other_id = rel["to_thing_id"] if rel["from_thing_id"] == user_thing_id else rel["from_thing_id"]
+        other_ids.append(other_id)
+
+    if not other_ids:
+        return []
+
+    # Fetch the related Things that match any search query
+    placeholders = ",".join("?" for _ in other_ids)
+    uf_sql, uf_params = user_filter(user_id)
+
+    # Build LIKE clauses for each query
+    like_clauses: list[str] = []
+    like_params: list[str] = []
+    for query in search_queries[:3]:
+        pattern = f"%{query}%"
+        like_clauses.append("(title LIKE ? OR data LIKE ?)")
+        like_params.extend([pattern, pattern])
+
+    query_filter = " OR ".join(like_clauses)
+    sql = (
+        f"SELECT * FROM things WHERE id IN ({placeholders})"
+        f"{uf_sql}"
+        f" AND ({query_filter})"
+        " ORDER BY"
+        " CASE WHEN last_referenced IS NOT NULL THEN 0 ELSE 1 END,"
+        " last_referenced DESC,"
+        " updated_at DESC"
+        " LIMIT 10"
+    )
+    params: list = [*other_ids, *uf_params, *like_params]
+    rows = conn.execute(sql, params).fetchall()
+    logger.info(
+        "User relationship search: %d edges, %d query-matched (queries=%r)",
+        len(other_ids),
+        len(rows),
+        search_queries[:3],
+    )
+    return [dict(r) for r in rows]
+
+
 def _fetch_user_thing(conn: sqlite3.Connection, user_id: str) -> dict[str, Any] | None:
     """Fetch the user's own Thing (type_hint='person', matching user_id).
 
@@ -255,6 +322,17 @@ def _fetch_relevant_things(
     if user_thing:
         seen_ids.add(user_thing["id"])
         results.append(user_thing)
+
+        # Load 1-hop relationships that match the search queries, ordered by
+        # last_referenced recency.  This keeps relevant connections accessible
+        # without preloading all relationships (which could be hundreds).
+        user_rels = _fetch_user_relationships(
+            conn, user_thing["id"], search_queries, user_id
+        )
+        for rel_thing in user_rels:
+            if rel_thing["id"] not in seen_ids:
+                seen_ids.add(rel_thing["id"])
+                results.append(rel_thing)
 
     # Choose retrieval strategy based on indexed count
     vc = vector_count()

--- a/backend/tests/test_chat_pipeline.py
+++ b/backend/tests/test_chat_pipeline.py
@@ -320,3 +320,119 @@ class TestChatPipeline:
     async def test_chat_invalid_request_returns_422(self, async_client):
         resp = await async_client.post("/api/chat", json={"session_id": "", "message": ""})
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _fetch_user_relationships
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUserRelationships:
+    """Test depth-limited relationship loading from the user Thing."""
+
+    def test_returns_matching_relationships(self, patched_db):
+        """Only relationships whose related Thing matches a search query are returned."""
+        from backend.database import db
+        from backend.routers.chat import _fetch_user_relationships
+
+        with db() as conn:
+            # Create user Thing
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("user-1", "Alice", "person", 3, 1, 1),
+            )
+            # Create related Things
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("sister-1", "Bob (sister)", "person", 3, 1, 1),
+            )
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("project-1", "Acme Project", "project", 3, 1, 1),
+            )
+            # Create relationships from user to both
+            conn.execute(
+                "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type) "
+                "VALUES (?, ?, ?, ?)",
+                ("rel-1", "user-1", "sister-1", "sister"),
+            )
+            conn.execute(
+                "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type) "
+                "VALUES (?, ?, ?, ?)",
+                ("rel-2", "user-1", "project-1", "works-on"),
+            )
+
+            # Search for "Bob" — should only return sister, not project
+            results = _fetch_user_relationships(conn, "user-1", ["Bob"])
+            assert len(results) == 1
+            assert results[0]["id"] == "sister-1"
+
+            # Search for "Acme" — should only return project
+            results = _fetch_user_relationships(conn, "user-1", ["Acme"])
+            assert len(results) == 1
+            assert results[0]["id"] == "project-1"
+
+    def test_empty_queries_returns_nothing(self, patched_db):
+        """No search queries means no relationship loading."""
+        from backend.database import db
+        from backend.routers.chat import _fetch_user_relationships
+
+        with db() as conn:
+            results = _fetch_user_relationships(conn, "user-1", [])
+            assert results == []
+
+    def test_no_relationships_returns_empty(self, patched_db):
+        """User with no relationships returns empty list."""
+        from backend.database import db
+        from backend.routers.chat import _fetch_user_relationships
+
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("user-1", "Alice", "person", 3, 1, 1),
+            )
+            results = _fetch_user_relationships(conn, "user-1", ["anything"])
+            assert results == []
+
+    def test_recently_referenced_sorted_first(self, patched_db):
+        """Things with recent last_referenced should appear before older ones."""
+        from backend.database import db
+        from backend.routers.chat import _fetch_user_relationships
+
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("user-1", "Alice", "person", 3, 1, 1),
+            )
+            # Two related Things both matching "Task"
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface, last_referenced) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("task-old", "Old Task", "task", 3, 1, 1, "2025-01-01T00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO things (id, title, type_hint, priority, active, surface, last_referenced) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("task-new", "New Task", "task", 3, 1, 1, "2026-03-16T00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type) "
+                "VALUES (?, ?, ?, ?)",
+                ("rel-1", "user-1", "task-old", "assigned"),
+            )
+            conn.execute(
+                "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type) "
+                "VALUES (?, ?, ?, ?)",
+                ("rel-2", "user-1", "task-new", "assigned"),
+            )
+
+            results = _fetch_user_relationships(conn, "user-1", ["Task"])
+            assert len(results) == 2
+            # Recently referenced should come first
+            assert results[0]["id"] == "task-new"
+            assert results[1]["id"] == "task-old"


### PR DESCRIPTION
## Summary
- Load 1-hop relationships when loading user Thing into context, but only when matching search queries
- Use last_referenced timestamps to boost recently-mentioned relationships
- Prevents context bloat while keeping relevant connections accessible

## Source
- Issue: re-dnp
- Branch: polecat/furiosa/re-dnp@mmtnrhxr
- Worker: furiosa

## Test Results
- Frontend: 176/176 passed
- Backend: 252/252 passed
- Coverage: 77.05% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)