### PR TITLE
feat: deduplicate possessive entity creation against existing Things (re-v8xq)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -761,6 +761,19 @@ def apply_storage_changes(
     # Map from create-array index to resolved Thing ID (for NEW:<index> placeholders)
     create_index_to_id: dict[int, str] = {}
 
+    # Pre-index relationships by NEW:<index> target for possessive dedup.
+    # This lets us check if a create has a companion relationship from the user
+    # and whether the user already has that relationship type to an existing entity.
+    _rels_by_new_target: dict[int, list[dict[str, Any]]] = {}
+    for rel in storage_changes.get("relationships", []):
+        to_id = rel.get("to_thing_id", "")
+        if to_id.startswith("NEW:"):
+            try:
+                idx = int(to_id.split(":")[1])
+                _rels_by_new_target.setdefault(idx, []).append(rel)
+            except (ValueError, IndexError):
+                pass
+
     # ── Creates ──────────────────────────────────────────────────────────────
     for create_idx, item in enumerate(storage_changes.get("create", [])):
         title = item.get("title", "").strip()
@@ -771,6 +784,43 @@ def apply_storage_changes(
         existing = conn.execute(
             "SELECT * FROM things WHERE LOWER(title) = LOWER(?) AND active = 1 LIMIT 1", (title,)
         ).fetchone()
+
+        # Possessive dedup: if no exact title match, check whether the user already
+        # has a relationship of the same type (e.g. "sister") to an existing entity.
+        # This catches cases like: user has Thing "Sister", now LLM creates "Sarah"
+        # with relationship_type="sister" — we should reuse the existing entity.
+        if not existing:
+            type_hint = item.get("type_hint")
+            if type_hint in ENTITY_TYPES:
+                companion_rels = _rels_by_new_target.get(create_idx, [])
+                for crel in companion_rels:
+                    rel_type = crel.get("relationship_type", "").strip()
+                    from_id = crel.get("from_thing_id", "").strip()
+                    if not rel_type or not from_id or from_id.startswith("NEW:"):
+                        continue
+                    # Check if from_id already has a relationship of this type
+                    match = conn.execute(
+                        "SELECT t.* FROM things t"
+                        " JOIN thing_relationships r ON r.to_thing_id = t.id"
+                        " WHERE r.from_thing_id = ? AND r.relationship_type = ?"
+                        " AND t.active = 1 LIMIT 1",
+                        (from_id, rel_type),
+                    ).fetchone()
+                    if match:
+                        logger.info(
+                            "Possessive dedup: reusing existing '%s' (id=%s) for relationship '%s'"
+                            " instead of creating '%s'",
+                            match["title"], match["id"], rel_type, title,
+                        )
+                        existing = match
+                        # Update the title if the new one is more specific (a name vs a role)
+                        if title.lower() != match["title"].lower():
+                            conn.execute(
+                                "UPDATE things SET title = ?, updated_at = ? WHERE id = ?",
+                                (title, now, match["id"]),
+                            )
+                        break
+
         if existing:
             logger.info("Dedup: converting create for '%s' into update on %s", title, existing["id"])
             # Merge any new data from the create intent into the existing Thing
@@ -992,6 +1042,17 @@ def apply_storage_changes(
         from_id = created_id_map.get(from_id, from_id)
         to_id = created_id_map.get(to_id, to_id)
         if from_id == to_id:
+            continue
+        # Skip duplicate relationships (same from, to, and type already exists)
+        dup = conn.execute(
+            "SELECT id FROM thing_relationships"
+            " WHERE from_thing_id = ? AND to_thing_id = ? AND relationship_type = ? LIMIT 1",
+            (from_id, to_id, rel_type),
+        ).fetchone()
+        if dup:
+            logger.info(
+                "Skipping duplicate relationship: %s -> %s (%s)", from_id, to_id, rel_type,
+            )
             continue
         # Verify both things exist
         from_row = conn.execute("SELECT id FROM things WHERE id = ?", (from_id,)).fetchone()

--- a/backend/tests/test_possessive_dedup.py
+++ b/backend/tests/test_possessive_dedup.py
@@ -1,0 +1,292 @@
+"""Tests for possessive entity deduplication in apply_storage_changes."""
+
+import json
+import uuid
+
+from backend.database import db
+
+
+def _insert_thing(conn, title, type_hint="person", data=None):
+    """Insert a Thing directly and return its id."""
+    thing_id = str(uuid.uuid4())
+    conn.execute(
+        """INSERT INTO things (id, title, type_hint, priority, active, surface, data,
+           created_at, updated_at)
+           VALUES (?, ?, ?, 3, 1, 0, ?, datetime('now'), datetime('now'))""",
+        (thing_id, title, type_hint, json.dumps(data) if data else None),
+    )
+    return thing_id
+
+
+def _insert_relationship(conn, from_id, to_id, rel_type):
+    """Insert a relationship and return its id."""
+    rel_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type)"
+        " VALUES (?, ?, ?, ?)",
+        (rel_id, from_id, to_id, rel_type),
+    )
+    return rel_id
+
+
+class TestPossessiveDedup:
+    def test_reuses_existing_entity_by_relationship_type(self, patched_db):
+        """'my sister Sarah' should reuse existing 'Sister' entity linked by 'sister' rel."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            sister_id = _insert_thing(conn, "Sister", data={"notes": "User's sister"})
+            _insert_relationship(conn, user_id, sister_id, "sister")
+            conn.commit()
+
+        # LLM tries to create "Sarah" with a "sister" relationship from user
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Sarah",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "sister",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Should have updated existing entity, not created a new one
+        assert len(result["created"]) == 0
+        assert len(result["updated"]) == 1
+        assert result["updated"][0]["id"] == sister_id
+
+        # Title should be updated to the more specific name
+        with db() as conn:
+            row = conn.execute("SELECT title FROM things WHERE id = ?", (sister_id,)).fetchone()
+            assert row["title"] == "Sarah"
+
+    def test_no_duplicate_relationship_created(self, patched_db):
+        """When possessive dedup matches, the existing relationship should not be duplicated."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            doctor_id = _insert_thing(conn, "Dr. Smith")
+            _insert_relationship(conn, user_id, doctor_id, "doctor")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Dr. Smith",
+                            "type_hint": "person",
+                            "data": {"notes": "User's doctor"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "doctor",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Relationship should not be duplicated
+        assert len(result["relationships_created"]) == 0
+
+        with db() as conn:
+            rels = conn.execute(
+                "SELECT * FROM thing_relationships WHERE from_thing_id = ? AND relationship_type = 'doctor'",
+                (user_id,),
+            ).fetchall()
+            assert len(rels) == 1
+
+    def test_creates_new_entity_when_no_existing_relationship(self, patched_db):
+        """If no existing relationship of the type exists, create normally."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Alice",
+                            "type_hint": "person",
+                            "data": {"notes": "User's cousin"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "cousin",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Should create the new entity
+        assert len(result["created"]) == 1
+        assert result["created"][0]["title"] == "Alice"
+        # Relationship should be created
+        assert len(result["relationships_created"]) == 1
+        assert result["relationships_created"][0]["relationship_type"] == "cousin"
+
+    def test_title_dedup_still_works(self, patched_db):
+        """Exact title match dedup should still work independently of possessive dedup."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            existing_id = _insert_thing(conn, "Bob")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Bob",
+                            "type_hint": "person",
+                            "data": {"notes": "Friend"},
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        assert len(result["created"]) == 0
+        assert len(result["updated"]) == 1
+        assert result["updated"][0]["id"] == existing_id
+
+    def test_does_not_match_different_relationship_type(self, patched_db):
+        """User has 'sister' relationship; creating with 'doctor' should not match."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            sister_id = _insert_thing(conn, "Sister")
+            _insert_relationship(conn, user_id, sister_id, "sister")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Dr. Park",
+                            "type_hint": "person",
+                            "data": {"notes": "User's doctor"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "doctor",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Should create new entity since no "doctor" relationship exists
+        assert len(result["created"]) == 1
+        assert result["created"][0]["title"] == "Dr. Park"
+
+    def test_skips_possessive_dedup_for_non_entity_types(self, patched_db):
+        """Non-entity type_hints (task, etc.) should not trigger possessive dedup."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            project_id = _insert_thing(conn, "Work Project", type_hint="task")
+            _insert_relationship(conn, user_id, project_id, "owner_of")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "New Project",
+                            "type_hint": "task",
+                            "data": {"notes": "Another project"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "owner_of",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Should create new entity since type_hint is "task" (not an entity type)
+        assert len(result["created"]) == 1
+
+    def test_preserves_title_when_same(self, patched_db):
+        """When possessive dedup matches and titles are the same, don't update title."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            friend_id = _insert_thing(conn, "Alex")
+            _insert_relationship(conn, user_id, friend_id, "friend")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "alex",
+                            "type_hint": "person",
+                            "data": {"notes": "User's friend"},
+                        }
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "friend",
+                        }
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Should reuse existing entity
+        assert len(result["created"]) == 0
+        assert len(result["updated"]) == 1
+
+        # Title should remain "Alex" (original casing) since they match case-insensitively
+        with db() as conn:
+            row = conn.execute("SELECT title FROM things WHERE id = ?", (friend_id,)).fetchone()
+            assert row["title"] == "Alex"


### PR DESCRIPTION
## Summary
- Deduplicate possessive entity creation against existing Things
- Prevents creating duplicate entities when possessive references match existing Things

## Source
- Issue: re-v8xq
- Branch: polecat/furiosa/re-v8xq
- Worker: furiosa

## Test Results
- Frontend: 176/176 passed
- Backend: 264/264 passed (7 new possessive dedup tests)
- Coverage: 78.21% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)