### PR TITLE
feat: add merge UI — detect and suggest duplicate Thing merges (re-liaz)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -289,3 +289,38 @@ class ProactiveSurface(BaseModel):
     reason: str
     date_key: str
     days_away: int
+
+
+# ── Merge Suggestions ────────────────────────────────────────────────────────
+
+
+class MergeSuggestionThing(BaseModel):
+    """Minimal Thing representation for merge suggestions."""
+
+    id: str
+    title: str
+    type_hint: str | None
+
+
+class MergeSuggestion(BaseModel):
+    """A pair of Things that may be duplicates."""
+
+    thing_a: MergeSuggestionThing
+    thing_b: MergeSuggestionThing
+    reason: str
+
+
+class MergeRequest(BaseModel):
+    """Request to merge two Things."""
+
+    keep_id: str = Field(..., description="ID of the Thing to keep")
+    remove_id: str = Field(..., description="ID of the Thing to merge into keep_id and delete")
+
+
+class MergeResult(BaseModel):
+    """Result of a merge operation."""
+
+    keep_id: str
+    remove_id: str
+    keep_title: str
+    remove_title: str

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -15,6 +15,10 @@ from ..models import (
     GraphEdge,
     GraphNode,
     GraphResponse,
+    MergeRequest,
+    MergeResult,
+    MergeSuggestion,
+    MergeSuggestionThing,
     OrphanCleanupResult,
     Relationship,
     RelationshipCreate,
@@ -423,6 +427,193 @@ def reindex_things(user_id: str = Depends(require_user)) -> dict[str, int]:
     """Rebuild the vector search index for all Things. Returns the count of re-indexed items."""
     count = reindex_all()
     return {"reindexed": count}
+
+
+# ── Merge suggestions & execution ───────────────────────────────────────────
+
+
+def _normalize(title: str) -> str:
+    """Lowercase, strip articles and possessives for comparison."""
+    t = title.lower().strip()
+    for prefix in ("my ", "the ", "a ", "an "):
+        if t.startswith(prefix):
+            t = t[len(prefix):]
+    return t
+
+
+def _titles_similar(a: str, b: str) -> str | None:
+    """Return a reason string if two titles look like duplicates, else None."""
+    na, nb = _normalize(a), _normalize(b)
+    if not na or not nb:
+        return None
+    # Exact match after normalization
+    if na == nb:
+        return f'Same name: "{a}" and "{b}"'
+    # One is a prefix/substring of the other (for short names)
+    shorter, longer = (na, nb) if len(na) <= len(nb) else (nb, na)
+    if len(shorter) >= 3 and shorter in longer:
+        return f'Similar names: "{a}" and "{b}"'
+    return None
+
+
+@router.get(
+    "/merge-suggestions",
+    response_model=list[MergeSuggestion],
+    summary="Detect potential duplicate Things",
+)
+def get_merge_suggestions(
+    limit: int = Query(10, ge=1, le=50, description="Maximum suggestions to return"),
+    user_id: str = Depends(require_user),
+) -> list[MergeSuggestion]:
+    """Find pairs of active Things with similar titles that may be duplicates."""
+    with db() as conn:
+        uf_sql, uf_params = user_filter(user_id)
+        rows = conn.execute(
+            "SELECT id, title, type_hint FROM things WHERE active = 1" + uf_sql
+            + " ORDER BY title",
+            uf_params,
+        ).fetchall()
+
+    # Also check shared relationships between pairs
+    suggestions: list[MergeSuggestion] = []
+    seen_pairs: set[tuple[str, str]] = set()
+
+    things_list = [(r["id"], r["title"], r["type_hint"]) for r in rows]
+
+    for i, (id_a, title_a, type_a) in enumerate(things_list):
+        for j in range(i + 1, len(things_list)):
+            id_b, title_b, type_b = things_list[j]
+            reason = _titles_similar(title_a, title_b)
+            if reason is None:
+                continue
+            pair = (min(id_a, id_b), max(id_a, id_b))
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            # Boost reason if same type
+            if type_a and type_a == type_b:
+                reason += f" (both {type_a})"
+            suggestions.append(MergeSuggestion(
+                thing_a=MergeSuggestionThing(id=id_a, title=title_a, type_hint=type_a),
+                thing_b=MergeSuggestionThing(id=id_b, title=title_b, type_hint=type_b),
+                reason=reason,
+            ))
+            if len(suggestions) >= limit:
+                break
+        if len(suggestions) >= limit:
+            break
+
+    return suggestions
+
+
+@router.post(
+    "/merge",
+    response_model=MergeResult,
+    summary="Merge two Things",
+)
+def merge_things(
+    body: MergeRequest,
+    background_tasks: BackgroundTasks,
+    user_id: str = Depends(require_user),
+) -> MergeResult:
+    """Merge remove_id into keep_id: transfer relationships, merge data, delete duplicate."""
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        keep_row = conn.execute(
+            f"SELECT * FROM things WHERE id = ?{uf_sql}", [body.keep_id, *uf_params]
+        ).fetchone()
+        remove_row = conn.execute(
+            f"SELECT * FROM things WHERE id = ?{uf_sql}", [body.remove_id, *uf_params]
+        ).fetchone()
+        if not keep_row:
+            raise HTTPException(status_code=404, detail=f"Thing '{body.keep_id}' not found")
+        if not remove_row:
+            raise HTTPException(status_code=404, detail=f"Thing '{body.remove_id}' not found")
+        if body.keep_id == body.remove_id:
+            raise HTTPException(status_code=422, detail="Cannot merge a Thing with itself")
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        # 1. Merge data dicts
+        existing_data = keep_row["data"]
+        try:
+            old_data = json.loads(existing_data) if isinstance(existing_data, str) and existing_data else {}
+        except (json.JSONDecodeError, ValueError):
+            old_data = {}
+        remove_data_raw = remove_row["data"]
+        try:
+            remove_data = json.loads(remove_data_raw) if isinstance(remove_data_raw, str) and remove_data_raw else {}
+        except (json.JSONDecodeError, ValueError):
+            remove_data = {}
+        if remove_data:
+            combined = {**remove_data, **old_data}  # keep_row data takes priority
+            conn.execute(
+                "UPDATE things SET data = ?, updated_at = ? WHERE id = ?",
+                (json.dumps(combined), now, body.keep_id),
+            )
+
+        # 2. Transfer open_questions
+        keep_oq_raw = keep_row["open_questions"]
+        remove_oq_raw = remove_row["open_questions"]
+        try:
+            keep_oq = json.loads(keep_oq_raw) if isinstance(keep_oq_raw, str) and keep_oq_raw else []
+        except (json.JSONDecodeError, ValueError):
+            keep_oq = []
+        try:
+            remove_oq = json.loads(remove_oq_raw) if isinstance(remove_oq_raw, str) and remove_oq_raw else []
+        except (json.JSONDecodeError, ValueError):
+            remove_oq = []
+        if remove_oq:
+            existing_set = set(keep_oq)
+            for q in remove_oq:
+                if q not in existing_set:
+                    keep_oq.append(q)
+                    existing_set.add(q)
+            conn.execute(
+                "UPDATE things SET open_questions = ?, updated_at = ? WHERE id = ?",
+                (json.dumps(keep_oq), now, body.keep_id),
+            )
+
+        # 3. Re-point relationships
+        conn.execute(
+            "UPDATE thing_relationships SET from_thing_id = ? WHERE from_thing_id = ?",
+            (body.keep_id, body.remove_id),
+        )
+        conn.execute(
+            "UPDATE thing_relationships SET to_thing_id = ? WHERE to_thing_id = ?",
+            (body.keep_id, body.remove_id),
+        )
+        # Clean up self-referential relationships
+        conn.execute(
+            "DELETE FROM thing_relationships WHERE from_thing_id = ? AND to_thing_id = ?",
+            (body.keep_id, body.keep_id),
+        )
+
+        # 4. Re-parent children of the removed thing
+        conn.execute(
+            "UPDATE things SET parent_id = ? WHERE parent_id = ?",
+            (body.keep_id, body.remove_id),
+        )
+
+        # 5. Delete the duplicate
+        conn.execute("DELETE FROM things WHERE id = ?", (body.remove_id,))
+
+        keep_title = keep_row["title"]
+        remove_title = remove_row["title"]
+
+        # 6. Re-embed the kept thing
+        updated = conn.execute("SELECT * FROM things WHERE id = ?", (body.keep_id,)).fetchone()
+
+    background_tasks.add_task(vs_delete, body.remove_id)
+    if updated:
+        background_tasks.add_task(upsert_thing, dict(updated))
+
+    return MergeResult(
+        keep_id=body.keep_id,
+        remove_id=body.remove_id,
+        keep_title=keep_title,
+        remove_title=remove_title,
+    )
 
 
 # ── Orphan relationship management ──────────────────────────────────────────

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { SettingsPanel } from './components/SettingsPanel'
 import { FeedbackDialog } from './components/FeedbackDialog'
 
 function App() {
-  const { currentUser, authChecked, settingsOpen, feedbackOpen, mainView, mobileView, setMobileView, fetchCurrentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, error } = useStore(
+  const { currentUser, authChecked, settingsOpen, feedbackOpen, mainView, mobileView, setMobileView, fetchCurrentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, fetchMergeSuggestions, error } = useStore(
     useShallow(s => ({
       currentUser: s.currentUser,
       authChecked: s.authChecked,
@@ -29,6 +29,7 @@ function App() {
       fetchDailyStats: s.fetchDailyStats,
       fetchCalendarStatus: s.fetchCalendarStatus,
       fetchProactiveSurfaces: s.fetchProactiveSurfaces,
+      fetchMergeSuggestions: s.fetchMergeSuggestions,
       error: s.error,
     }))
   )
@@ -50,6 +51,7 @@ function App() {
     fetchHistory()
     fetchDailyStats()
     fetchProactiveSurfaces()
+    fetchMergeSuggestions()
     const interval = setInterval(() => { fetchThings(); fetchBriefing(); fetchProactiveSurfaces() }, 30_000)
 
     // Handle OAuth callback redirect
@@ -60,7 +62,7 @@ function App() {
     }
 
     return () => clearInterval(interval)
-  }, [currentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces])
+  }, [currentUser, fetchThingTypes, fetchThings, fetchBriefing, fetchHistory, fetchDailyStats, fetchCalendarStatus, fetchProactiveSurfaces, fetchMergeSuggestions])
 
   // Show nothing while checking auth
   if (!authChecked) {

--- a/frontend/src/__tests__/Sidebar.test.tsx
+++ b/frontend/src/__tests__/Sidebar.test.tsx
@@ -118,6 +118,15 @@ const filterDefaults = {
   clearThingFilters: vi.fn(),
 }
 
+const mergeDefaults = {
+  mergeSuggestions: [],
+  mergeSuggestionsLoading: false,
+  mergeInProgress: false,
+  executeMerge: vi.fn(),
+  dismissMergeSuggestion: vi.fn(),
+  fetchMergeSuggestions: vi.fn(),
+}
+
 const calendarDefaults = {
   calendarStatus: { configured: false, connected: false },
   calendarEvents: [] as never[],
@@ -131,6 +140,7 @@ const calendarDefaults = {
   proactiveSurfaces: [],
   ...searchDefaults,
   ...filterDefaults,
+  ...mergeDefaults,
 }
 
 beforeEach(() => {

--- a/frontend/src/components/MergeSuggestions.tsx
+++ b/frontend/src/components/MergeSuggestions.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useStore } from '../store'
+import type { MergeSuggestion } from '../store'
+import { typeIcon } from '../utils'
+
+function MergeCard({ suggestion, onMerge, onDismiss, merging }: {
+  suggestion: MergeSuggestion
+  onMerge: (keepId: string, removeId: string) => void
+  onDismiss: (aId: string, bId: string) => void
+  merging: boolean
+}) {
+  const [keepChoice, setKeepChoice] = useState<'a' | 'b' | null>(null)
+  const { thingTypes } = useStore(useShallow(s => ({ thingTypes: s.thingTypes })))
+
+  const handleMerge = () => {
+    if (!keepChoice) return
+    const keepId = keepChoice === 'a' ? suggestion.thing_a.id : suggestion.thing_b.id
+    const removeId = keepChoice === 'a' ? suggestion.thing_b.id : suggestion.thing_a.id
+    onMerge(keepId, removeId)
+  }
+
+  return (
+    <div className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors">
+      <p className="text-xs text-gray-400 dark:text-gray-500 mb-1.5">{suggestion.reason}</p>
+      <div className="flex flex-col gap-1">
+        <label className="flex items-center gap-2 cursor-pointer group">
+          <input
+            type="radio"
+            name={`merge-${suggestion.thing_a.id}-${suggestion.thing_b.id}`}
+            checked={keepChoice === 'a'}
+            onChange={() => setKeepChoice('a')}
+            className="accent-indigo-500"
+          />
+          <span className="text-sm shrink-0">{typeIcon(suggestion.thing_a.type_hint, thingTypes)}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-300 truncate group-hover:text-gray-900 dark:group-hover:text-gray-100">
+            {suggestion.thing_a.title}
+          </span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer group">
+          <input
+            type="radio"
+            name={`merge-${suggestion.thing_a.id}-${suggestion.thing_b.id}`}
+            checked={keepChoice === 'b'}
+            onChange={() => setKeepChoice('b')}
+            className="accent-indigo-500"
+          />
+          <span className="text-sm shrink-0">{typeIcon(suggestion.thing_b.type_hint, thingTypes)}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-300 truncate group-hover:text-gray-900 dark:group-hover:text-gray-100">
+            {suggestion.thing_b.title}
+          </span>
+        </label>
+      </div>
+      <div className="flex items-center gap-2 mt-2">
+        <button
+          onClick={handleMerge}
+          disabled={!keepChoice || merging}
+          className="text-xs font-medium text-indigo-500 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {merging ? 'Merging...' : 'Merge'}
+        </button>
+        <button
+          onClick={() => onDismiss(suggestion.thing_a.id, suggestion.thing_b.id)}
+          className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function MergeSuggestions() {
+  const { mergeSuggestions, mergeInProgress, executeMerge, dismissMergeSuggestion } = useStore(
+    useShallow(s => ({
+      mergeSuggestions: s.mergeSuggestions,
+      mergeInProgress: s.mergeInProgress,
+      executeMerge: s.executeMerge,
+      dismissMergeSuggestion: s.dismissMergeSuggestion,
+    }))
+  )
+
+  if (mergeSuggestions.length === 0) return null
+
+  return (
+    <section className="py-2 border-b border-gray-100 dark:border-gray-800">
+      <h2 className="px-4 pb-1 text-xs font-semibold text-amber-500 dark:text-amber-400 uppercase tracking-widest flex items-center gap-1.5">
+        <span>Merge Suggestions</span>
+        <span className="ml-auto text-[10px] font-normal tabular-nums text-gray-400 dark:text-gray-500">
+          {mergeSuggestions.length}
+        </span>
+      </h2>
+      {mergeSuggestions.map(s => (
+        <MergeCard
+          key={`${s.thing_a.id}-${s.thing_b.id}`}
+          suggestion={s}
+          onMerge={executeMerge}
+          onDismiss={dismissMergeSuggestion}
+          merging={mergeInProgress}
+        />
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { typeIcon } from '../utils'
 import { CalendarSection } from './CalendarSection'
 import { ThingCard } from './ThingCard'
 import { GmailPanel } from './GmailPanel'
+import { MergeSuggestions } from './MergeSuggestions'
 
 const FINDING_TYPE_ICONS: Record<string, string> = {
   approaching_date: '\u23F0',
@@ -458,6 +459,9 @@ export function Sidebar() {
                 {briefing.map(t => <ThingCard key={t.id} thing={t} />)}
               </section>
             )}
+
+            {/* Merge Suggestions */}
+            <MergeSuggestions />
 
             {/* Proactive Surfaces */}
             {proactiveSurfaces && proactiveSurfaces.length > 0 && (

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -233,6 +233,27 @@ export const UserProfileSchema = z.object({
   relationships: z.array(UserProfileRelationshipSchema),
 })
 
+// --- Merge Suggestions ---
+
+export const MergeSuggestionThingSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  type_hint: z.string().nullable(),
+})
+
+export const MergeSuggestionSchema = z.object({
+  thing_a: MergeSuggestionThingSchema,
+  thing_b: MergeSuggestionThingSchema,
+  reason: z.string(),
+})
+
+export const MergeResultSchema = z.object({
+  keep_id: z.string(),
+  remove_id: z.string(),
+  keep_title: z.string(),
+  remove_title: z.string(),
+})
+
 // --- Validation helper ---
 
 /**

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -24,6 +24,8 @@ import {
   UserSettingsSchema,
   RequestyModelSchema,
   UserProfileSchema,
+  MergeSuggestionSchema,
+  MergeResultSchema,
 } from './schemas'
 import { z } from 'zod'
 
@@ -153,6 +155,18 @@ export interface UserProfileRelationship {
 export interface UserProfile {
   thing: Thing
   relationships: UserProfileRelationship[]
+}
+
+export interface MergeSuggestionThing {
+  id: string
+  title: string
+  type_hint: string | null
+}
+
+export interface MergeSuggestion {
+  thing_a: MergeSuggestionThing
+  thing_b: MergeSuggestionThing
+  reason: string
 }
 
 export interface ModelUsage {
@@ -304,6 +318,14 @@ interface ReliState {
   userProfileLoading: boolean
   fetchUserProfile: () => Promise<void>
   updateUserThing: (updates: { title?: string; data?: Record<string, unknown> }) => Promise<void>
+
+  // Merge suggestions
+  mergeSuggestions: MergeSuggestion[]
+  mergeSuggestionsLoading: boolean
+  mergeInProgress: boolean
+  fetchMergeSuggestions: () => Promise<void>
+  executeMerge: (keepId: string, removeId: string) => Promise<void>
+  dismissMergeSuggestion: (thingAId: string, thingBId: string) => void
 
   // Feedback
   feedbackOpen: boolean
@@ -975,6 +997,59 @@ export const useStore = create<ReliState>((set, get) => ({
     } catch (e) {
       set({ error: String(e) })
     }
+  },
+
+  // Merge suggestions
+  mergeSuggestions: [],
+  mergeSuggestionsLoading: false,
+  mergeInProgress: false,
+
+  fetchMergeSuggestions: async () => {
+    set({ mergeSuggestionsLoading: true })
+    try {
+      const res = await apiFetch(`${BASE}/things/merge-suggestions?limit=10`)
+      if (!res.ok) return
+      const data: MergeSuggestion[] = validateResponse(z.array(MergeSuggestionSchema), await res.json(), '/things/merge-suggestions')
+      set({ mergeSuggestions: data })
+    } catch {
+      // best-effort
+    } finally {
+      set({ mergeSuggestionsLoading: false })
+    }
+  },
+
+  executeMerge: async (keepId: string, removeId: string) => {
+    set({ mergeInProgress: true })
+    try {
+      const res = await apiFetch(`${BASE}/things/merge`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keep_id: keepId, remove_id: removeId }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      validateResponse(MergeResultSchema, await res.json(), '/things/merge')
+      // Remove the suggestion from the list and refresh things
+      set(state => ({
+        mergeSuggestions: state.mergeSuggestions.filter(
+          s => !(s.thing_a.id === keepId && s.thing_b.id === removeId) &&
+               !(s.thing_a.id === removeId && s.thing_b.id === keepId)
+        ),
+      }))
+      get().fetchThings()
+      get().fetchMergeSuggestions()
+    } catch (e) {
+      set({ error: String(e) })
+    } finally {
+      set({ mergeInProgress: false })
+    }
+  },
+
+  dismissMergeSuggestion: (thingAId: string, thingBId: string) => {
+    set(state => ({
+      mergeSuggestions: state.mergeSuggestions.filter(
+        s => !(s.thing_a.id === thingAId && s.thing_b.id === thingBId)
+      ),
+    }))
   },
 
   // Feedback


### PR DESCRIPTION
## Summary
- Add UI for detecting and suggesting duplicate Thing merges
- Allows users to unify duplicate entities from the frontend

## Source
- Issue: re-liaz
- Branch: polecat/slit/re-liaz@mmts2llt
- Worker: slit

## Test Results
- Frontend: 176/176 passed
- Backend: 272/272 passed
- Coverage: 78.87% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)