### PR TITLE
feat: support direct Thing ID lookup in context agent (re-o1hw)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -310,6 +310,7 @@ so we can provide full context.
 Respond with ONLY valid JSON matching this schema (no markdown, no explanation):
 {
   "search_queries": ["query 1", "query 2"],
+  "fetch_ids": [],
   "filter_params": {
     "active_only": true,
     "type_hint": null
@@ -320,6 +321,10 @@ Respond with ONLY valid JSON matching this schema (no markdown, no explanation):
   "include_calendar": false
 }
 - search_queries: 1-3 short text fragments to match against Thing titles/data
+- fetch_ids: optional list of Thing UUIDs to fetch directly. Use this when the
+  conversation history contains specific Thing IDs that should be looked up
+  (e.g. following relationships, referencing previously mentioned Things by ID).
+  Empty array when not needed.
 - filter_params.active_only: true unless user asks about archived/all items
 - filter_params.type_hint: null or one of task|note|idea|project|goal|journal|person|place|event|concept|reference
 - needs_web_search: true if the user is asking about external/real-world info

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -511,13 +511,15 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
         api_key=user_api_key, model=user_models["context"],
     )
     search_queries = context_result.get("search_queries", [message])
+    fetch_ids = context_result.get("fetch_ids", [])
     filter_params = context_result.get("filter_params", {})
     gmail_query = context_result.get("gmail_query")
 
     logger.info(
-        "Context agent result — search_queries=%r, filter_params=%r, gmail_query=%r, "
+        "Context agent result — search_queries=%r, fetch_ids=%r, filter_params=%r, gmail_query=%r, "
         "needs_web_search=%r, include_calendar=%r",
         search_queries,
+        fetch_ids,
         filter_params,
         gmail_query,
         context_result.get("needs_web_search"),
@@ -529,13 +531,23 @@ async def chat(body: ChatRequest, user_id: str = Depends(require_user)) -> ChatR
     seen_thing_ids: set[str] = set()
     relevant_things: list[dict[str, Any]] = []
 
-    # Initial fetch
+    # Initial fetch — text queries + direct ID lookups
     with db() as conn:
         initial_things = _fetch_relevant_things(conn, search_queries, filter_params, user_id=user_id)
         for t in initial_things:
             if t["id"] not in seen_thing_ids:
                 seen_thing_ids.add(t["id"])
                 relevant_things.append(t)
+
+        # Direct Thing ID lookups from context agent
+        if fetch_ids:
+            id_things = _fetch_with_family(conn, [
+                tid for tid in fetch_ids if tid not in seen_thing_ids
+            ])
+            for t in id_things:
+                if t["id"] not in seen_thing_ids:
+                    seen_thing_ids.add(t["id"])
+                    relevant_things.append(t)
 
     logger.info(
         "Initial retrieval: %d Things for queries %r",


### PR DESCRIPTION
## Summary
- Support direct Thing ID lookup in the context agent
- Enables precise entity retrieval by ID alongside semantic search

## Source
- Issue: re-o1hw
- Branch: polecat/nux/re-o1hw@mmtssawy
- Worker: nux

## Test Results
- Frontend: 184/184 passed
- Backend: 272/272 passed
- Coverage: 78.84% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)