### PR TITLE
feat: handle compound possessives — 'my sister's husband' (re-9qc8)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -729,6 +729,28 @@ Examples:
 - "my project Helios" → create Thing(title="Helios", type_hint="project",
   surface=true, data={"notes": "User's project"}) +
   relationship(user→Helios, type="owner_of")
+
+Compound Possessives:
+When the user chains possessives ("my sister's husband Bob", "my boss's wife"),
+create each entity in the chain and link them with relationships:
+- "my sister's husband Bob" →
+  create[0] Thing(title="Sister", type_hint="person", surface=false,
+    data={"notes": "User's sister"})
+  create[1] Thing(title="Bob", type_hint="person", surface=false,
+    data={"notes": "User's sister's husband"})
+  relationship(user→NEW:0, type="sister")
+  relationship(NEW:0→NEW:1, type="husband")
+- "my boss's assistant" →
+  create[0] Thing(title="Boss", type_hint="person", surface=false,
+    data={"notes": "User's boss"})
+  create[1] Thing(title="Assistant", type_hint="person", surface=false,
+    data={"notes": "User's boss's assistant"})
+  relationship(user→NEW:0, type="boss")
+  relationship(NEW:0→NEW:1, type="assistant")
+
+If an entity in the chain already exists (e.g. the user already has a "sister"),
+reuse the existing one (dedup will handle this automatically). Always order
+create entries so that earlier links in the chain come first (lower indices).
 """
 
 
@@ -858,8 +880,20 @@ def apply_storage_changes(
                 for crel in companion_rels:
                     rel_type = crel.get("relationship_type", "").strip()
                     from_id = crel.get("from_thing_id", "").strip()
-                    if not rel_type or not from_id or from_id.startswith("NEW:"):
+                    if not rel_type or not from_id:
                         continue
+                    # Resolve NEW:<index> placeholders for compound possessives
+                    # (e.g. "my sister's husband" — sister is NEW:0, already resolved)
+                    if from_id.startswith("NEW:"):
+                        try:
+                            from_idx = int(from_id.split(":")[1])
+                            resolved = create_index_to_id.get(from_idx)
+                            if resolved:
+                                from_id = resolved
+                            else:
+                                continue  # not yet resolved, skip
+                        except (ValueError, IndexError):
+                            continue
                     # Check if from_id already has a relationship of this type
                     match = conn.execute(
                         "SELECT t.* FROM things t"

--- a/backend/tests/test_possessive_dedup.py
+++ b/backend/tests/test_possessive_dedup.py
@@ -290,3 +290,165 @@ class TestPossessiveDedup:
         with db() as conn:
             row = conn.execute("SELECT title FROM things WHERE id = ?", (friend_id,)).fetchone()
             assert row["title"] == "Alex"
+
+
+class TestCompoundPossessives:
+    """Tests for compound/chained possessives like 'my sister's husband Bob'."""
+
+    def test_compound_possessive_creates_chain(self, patched_db):
+        """'my sister's husband Bob' creates sister, Bob, and both relationships."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Sister",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister"},
+                        },
+                        {
+                            "title": "Bob",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister's husband"},
+                        },
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "sister",
+                        },
+                        {
+                            "from_thing_id": "NEW:0",
+                            "to_thing_id": "NEW:1",
+                            "relationship_type": "husband",
+                        },
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Both entities should be created
+        assert len(result["created"]) == 2
+        assert result["created"][0]["title"] == "Sister"
+        assert result["created"][1]["title"] == "Bob"
+        # Both relationships should be created
+        assert len(result["relationships_created"]) == 2
+        rel_types = {r["relationship_type"] for r in result["relationships_created"]}
+        assert rel_types == {"sister", "husband"}
+
+    def test_compound_possessive_reuses_existing_first_link(self, patched_db):
+        """'my sister's husband Bob' reuses existing sister entity."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            sister_id = _insert_thing(conn, "Sarah", data={"notes": "User's sister"})
+            _insert_relationship(conn, user_id, sister_id, "sister")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Sister",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister"},
+                        },
+                        {
+                            "title": "Bob",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister's husband"},
+                        },
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "sister",
+                        },
+                        {
+                            "from_thing_id": "NEW:0",
+                            "to_thing_id": "NEW:1",
+                            "relationship_type": "husband",
+                        },
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Sister should be deduped (reused), Bob should be created
+        assert len(result["created"]) == 1
+        assert result["created"][0]["title"] == "Bob"
+        assert len(result["updated"]) == 1
+        assert result["updated"][0]["id"] == sister_id
+
+        # The husband relationship should link sister → Bob
+        husband_rels = [r for r in result["relationships_created"] if r["relationship_type"] == "husband"]
+        assert len(husband_rels) == 1
+        assert husband_rels[0]["from_thing_id"] == sister_id
+
+    def test_compound_possessive_dedup_second_link(self, patched_db):
+        """If sister already has a husband entity, reuse it via possessive dedup."""
+        from backend.agents import apply_storage_changes
+
+        with db() as conn:
+            user_id = _insert_thing(conn, "Me")
+            sister_id = _insert_thing(conn, "Sarah", data={"notes": "User's sister"})
+            husband_id = _insert_thing(conn, "Husband", data={"notes": "Sarah's husband"})
+            _insert_relationship(conn, user_id, sister_id, "sister")
+            _insert_relationship(conn, sister_id, husband_id, "husband")
+            conn.commit()
+
+        with db() as conn:
+            result = apply_storage_changes(
+                {
+                    "create": [
+                        {
+                            "title": "Sister",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister"},
+                        },
+                        {
+                            "title": "Bob",
+                            "type_hint": "person",
+                            "data": {"notes": "User's sister's husband"},
+                        },
+                    ],
+                    "relationships": [
+                        {
+                            "from_thing_id": user_id,
+                            "to_thing_id": "NEW:0",
+                            "relationship_type": "sister",
+                        },
+                        {
+                            "from_thing_id": "NEW:0",
+                            "to_thing_id": "NEW:1",
+                            "relationship_type": "husband",
+                        },
+                    ],
+                },
+                conn,
+            )
+            conn.commit()
+
+        # Both should be deduped
+        assert len(result["created"]) == 0
+        assert len(result["updated"]) == 2
+
+        # Husband title should be updated to "Bob"
+        with db() as conn:
+            row = conn.execute("SELECT title FROM things WHERE id = ?", (husband_id,)).fetchone()
+            assert row["title"] == "Bob"
+
+        # No new relationships created (both already exist)
+        assert len(result["relationships_created"]) == 0


### PR DESCRIPTION
## Summary
- Handle compound possessive patterns like "my sister's husband"
- Creates chained relationships through intermediate entities

## Source
- Issue: re-9qc8
- Branch: polecat/nux/re-9qc8@mmtu28wa
- Worker: nux

## Test Results
- Frontend: 184/184 passed
- Backend: 275/275 passed
- Coverage: 78.97% (threshold: 70%)

🤖 Merged by Refinery (Gas Town)