### PR TITLE
fix: use dvh units and safe-area insets for mobile viewport (re-fn2g)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#4F46E5" />
     <meta name="description" content="Your personal AI that learns about you" />
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,7 +15,12 @@ body {
 
 #root {
   height: 100vh;
+  height: 100dvh;
   display: flex;
+}
+
+.safe-area-pb {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 @keyframes slide-in-right {


### PR DESCRIPTION
## Summary
- Fix mobile viewport issue where chat input textbox was hidden below visible area
- Use `dvh` (dynamic viewport height) units and `safe-area-inset` CSS to properly pin chat input on mobile browsers

Fixes #11

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED  
- Lint: PASSED
- Test: PASSED (279 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)