### PR TITLE
docs: add screenshot test guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,20 @@ Current feature issues: https://github.com/alexsiri7/reli/issues
 If your bead description mentions a GitHub issue number, use it. If not, check the
 issues list to see if your work maps to an existing feature issue.
 
+## Screenshot Tests (Visual Regression)
+
+Screenshot tests ensure agents can assess UI quality. They live in `frontend/e2e/visual.spec.ts`.
+
+**Coverage strategy**: one screenshot per screen × {desktop 1280×720, mobile 390×844, dark-desktop 1280×720}. No loading states, no error states — just the normal populated view with mock data.
+
+**When your changes affect the UI:**
+1. Run `npm --prefix frontend run test:screenshots`
+2. If tests fail (expected after UI changes), run `npm --prefix frontend run test:screenshots:update`
+3. **Visually inspect every updated PNG** in `frontend/e2e/visual.spec.ts-snapshots/` — you are multimodal, read the image files and confirm the UI looks correct
+4. Commit the updated screenshots alongside your code changes
+
+**If you skip step 3, you are shipping blind.** The screenshots are the visual contract — updating them without inspection defeats the purpose.
+
 ## Key paths
 
 - Backend: `backend/` (FastAPI, Python)


### PR DESCRIPTION
## Summary
- Add screenshot test policy: one screenshot per screen × {desktop, mobile, dark-desktop}
- Agents must visually inspect updated PNGs before committing
- No loading/error states — just normal populated views

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)