### PR TITLE
feat: convert context agent to ADK LlmAgent (re-da29)

### DIFF
--- a/backend/context_agent.py
+++ b/backend/context_agent.py
@@ -1,0 +1,320 @@
+"""ADK LlmAgent-based context agent for the Reli chat pipeline.
+
+Replaces the raw OpenAI/LiteLLM calls in agents.py with a Google ADK LlmAgent
+backed by the LiteLlm connector routing through Requesty.  Preserves the same
+public interface (``run_context_agent``, ``run_context_refinement``) so callers
+in chat.py need only update their import path.
+"""
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from google.adk.agents import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types as genai_types
+
+from .agents import (
+    CONTEXT_AGENT_SYSTEM,
+    CONTEXT_REFINEMENT_SYSTEM,
+    OLLAMA_MODEL,
+    REQUESTY_API_KEY,
+    REQUESTY_BASE_URL,
+    REQUESTY_MODEL,
+    UsageStats,
+    _chat_ollama,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model factory
+# ---------------------------------------------------------------------------
+
+
+def _make_litellm_model(
+    model: str | None = None,
+    api_key: str | None = None,
+) -> LiteLlm:
+    """Create a LiteLlm model instance configured for Requesty."""
+    effective_model = model or REQUESTY_MODEL
+    # LiteLlm expects the openai/ prefix for OpenAI-compatible providers
+    if not effective_model.startswith("openai/"):
+        effective_model = f"openai/{effective_model}"
+    return LiteLlm(
+        model=effective_model,
+        api_key=api_key or REQUESTY_API_KEY,
+        api_base=REQUESTY_BASE_URL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — run an LlmAgent and extract text + usage
+# ---------------------------------------------------------------------------
+
+# Module-level session service shared across calls (stateless — sessions are
+# created per invocation and never reused).
+_session_service = InMemorySessionService()
+
+
+async def _run_agent_for_text(
+    agent: LlmAgent,
+    user_message: str,
+    usage_stats: UsageStats | None = None,
+) -> str:
+    """Run an LlmAgent and return the concatenated text response.
+
+    Creates a throwaway Runner / session for each call so there is no shared
+    mutable state between pipeline invocations.
+    """
+    runner = Runner(
+        agent=agent,
+        app_name="reli_context",
+        session_service=_session_service,
+    )
+
+    user_id = "context_pipeline"
+    session_id = str(uuid.uuid4())
+
+    session = await _session_service.create_session(
+        app_name="reli_context",
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    user_content = genai_types.Content(
+        role="user",
+        parts=[genai_types.Part.from_text(text=user_message)],
+    )
+
+    text_parts: list[str] = []
+    total_prompt = 0
+    total_completion = 0
+    total_tokens = 0
+    model_name = ""
+
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=user_content,
+    ):
+        # Collect text from non-partial model events
+        if event.content and event.content.parts:
+            for part in event.content.parts:
+                if part.text and not event.partial:
+                    text_parts.append(part.text)
+
+        # Accumulate usage metadata
+        if event.usage_metadata:
+            um = event.usage_metadata
+            total_prompt += um.prompt_token_count or 0
+            total_completion += um.candidates_token_count or 0
+            total_tokens += um.total_token_count or 0
+
+        if event.model_version:
+            model_name = event.model_version
+
+    response_text = "".join(text_parts)
+
+    if usage_stats is not None and total_tokens > 0:
+        usage_stats.accumulate(
+            prompt=total_prompt,
+            completion=total_completion,
+            total=total_tokens,
+            cost=0.0,  # LiteLlm/ADK doesn't provide cost directly
+            model=model_name or "unknown",
+        )
+
+    return response_text
+
+
+# ---------------------------------------------------------------------------
+# Public API — drop-in replacements for agents.run_context_agent/refinement
+# ---------------------------------------------------------------------------
+
+
+async def run_context_agent(
+    message: str,
+    history: list[dict[str, Any]],
+    usage_stats: UsageStats | None = None,
+    context_window: int = 10,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Stage 1: decide what to search for.
+
+    Uses local Ollama when OLLAMA_MODEL is configured, with graceful fallback
+    to Requesty via ADK LlmAgent.
+    """
+    # Build the user message that includes conversation history context
+    history_block = ""
+    for h in history[-context_window:]:
+        history_block += f"<{h['role']}>{h['content']}</{h['role']}>\n"
+
+    user_prompt = (
+        f"Conversation history:\n{history_block}\n"
+        f"Current user message: {message}"
+    ) if history_block else message
+
+    raw = None
+
+    # Try Ollama first if configured (unchanged — Ollama doesn't use ADK)
+    if OLLAMA_MODEL:
+        try:
+            messages = [{"role": "system", "content": CONTEXT_AGENT_SYSTEM}]
+            for h in history[-context_window:]:
+                messages.append({"role": h["role"], "content": h["content"]})
+            messages.append({"role": "user", "content": message})
+            raw = await _chat_ollama(
+                messages,
+                response_format={"type": "json_object"},
+                usage_stats=usage_stats,
+            )
+            logger.info(
+                "Context agent (Ollama/%s) raw response: %s",
+                OLLAMA_MODEL,
+                raw[:500] if raw else raw,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Ollama context agent failed, falling back to ADK/Requesty: %s",
+                exc,
+            )
+
+    # Fall back to ADK LlmAgent via Requesty
+    if raw is None:
+        litellm_model = _make_litellm_model(model=model, api_key=api_key)
+
+        context_agent = LlmAgent(
+            name="context_agent",
+            description="Generates search parameters to find relevant Things in the database.",
+            model=litellm_model,
+            instruction=CONTEXT_AGENT_SYSTEM,
+            generate_content_config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+            ),
+        )
+
+        raw = await _run_agent_for_text(context_agent, user_prompt, usage_stats)
+        logger.info(
+            "Context agent (ADK/Requesty/%s) raw response: %s",
+            model or REQUESTY_MODEL,
+            raw[:500] if raw else raw,
+        )
+
+    try:
+        result: dict[str, Any] = json.loads(raw)
+        logger.info(
+            "Context agent parsed — search_queries=%r, filter_params=%r",
+            result.get("search_queries"),
+            result.get("filter_params"),
+        )
+        return result
+    except json.JSONDecodeError:
+        logger.warning(
+            "Context agent returned invalid JSON, falling back to message as query: %s",
+            raw[:200] if raw else raw,
+        )
+        return {
+            "search_queries": [message],
+            "filter_params": {"active_only": True, "type_hint": None},
+        }
+
+
+async def run_context_refinement(
+    message: str,
+    history: list[dict[str, Any]],
+    found_things: list[dict[str, Any]],
+    previous_queries: list[str],
+    relationships: list[dict[str, Any]] | None = None,
+    usage_stats: UsageStats | None = None,
+    context_window: int = 10,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Ask the context agent if it needs more searches given what was found."""
+    things_summary = json.dumps(
+        [
+            {
+                "id": t.get("id"),
+                "title": t.get("title"),
+                "type_hint": t.get("type_hint"),
+                "data": t.get("data"),
+                "parent_id": t.get("parent_id"),
+                "active": t.get("active"),
+            }
+            for t in found_things
+        ],
+        default=str,
+    )
+
+    rels_section = ""
+    if relationships:
+        rels_section = f"\n\nRelationships between Things:\n{json.dumps(relationships, default=str)}\n"
+
+    refinement_prompt = (
+        f"User's message: {message}\n\n"
+        f"Previous search queries: {json.dumps(previous_queries)}\n\n"
+        f"Things found so far ({len(found_things)} results):\n{things_summary}"
+        f"{rels_section}\n\n"
+        f"Do you have enough context to understand the user's request, "
+        f"or do you need to search for more?"
+    )
+
+    # Include conversation history context
+    history_block = ""
+    for h in history[-context_window:]:
+        history_block += f"<{h['role']}>{h['content']}</{h['role']}>\n"
+
+    if history_block:
+        full_prompt = f"Conversation history:\n{history_block}\n{refinement_prompt}"
+    else:
+        full_prompt = refinement_prompt
+
+    raw = None
+
+    # Try Ollama first if configured
+    if OLLAMA_MODEL:
+        try:
+            messages = [{"role": "system", "content": CONTEXT_REFINEMENT_SYSTEM}]
+            for h in history[-context_window:]:
+                messages.append({"role": h["role"], "content": h["content"]})
+            messages.append({"role": "user", "content": refinement_prompt})
+            raw = await _chat_ollama(
+                messages,
+                response_format={"type": "json_object"},
+                usage_stats=usage_stats,
+            )
+        except Exception:
+            pass
+
+    # Fall back to ADK LlmAgent
+    if raw is None:
+        litellm_model = _make_litellm_model(model=model, api_key=api_key)
+
+        refinement_agent = LlmAgent(
+            name="context_refinement_agent",
+            description="Decides if more context searches are needed.",
+            model=litellm_model,
+            instruction=CONTEXT_REFINEMENT_SYSTEM,
+            generate_content_config=genai_types.GenerateContentConfig(
+                response_mime_type="application/json",
+            ),
+        )
+
+        raw = await _run_agent_for_text(refinement_agent, full_prompt, usage_stats)
+
+    logger.info(
+        "Context refinement raw response: %s",
+        raw[:500] if raw else raw,
+    )
+
+    try:
+        result: dict[str, Any] = json.loads(raw)
+        return result
+    except json.JSONDecodeError:
+        return {"done": True}

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -15,12 +15,11 @@ logger = logging.getLogger(__name__)
 from ..agents import (
     UsageStats,
     apply_storage_changes,
-    run_context_agent,
-    run_context_refinement,
     run_reasoning_agent,
     run_response_agent,
     run_response_agent_stream,
 )
+from ..context_agent import run_context_agent, run_context_refinement
 from ..auth import require_user, user_filter
 from ..database import db
 from .settings import get_user_api_key, get_user_chat_context_window, get_user_models

--- a/backend/tests/test_context_agent.py
+++ b/backend/tests/test_context_agent.py
@@ -1,0 +1,317 @@
+"""Tests for the ADK LlmAgent-based context agent."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_event(text: str, *, partial: bool = False, usage: bool = False):
+    """Build a mock ADK Event with text content and optional usage metadata."""
+    part = MagicMock()
+    part.text = text
+    content = MagicMock()
+    content.parts = [part]
+
+    event = MagicMock()
+    event.content = content
+    event.partial = partial
+    event.model_version = "google/gemini-2.5-flash-lite"
+
+    if usage:
+        um = MagicMock()
+        um.prompt_token_count = 10
+        um.candidates_token_count = 5
+        um.total_token_count = 15
+        event.usage_metadata = um
+    else:
+        event.usage_metadata = None
+
+    return event
+
+
+async def _mock_run_async_factory(events):
+    """Create an async generator that yields mock events."""
+    for e in events:
+        yield e
+
+
+# ---------------------------------------------------------------------------
+# run_context_agent — ADK path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_agent_returns_parsed_json():
+    """run_context_agent parses JSON from ADK LlmAgent response."""
+    expected = {
+        "search_queries": ["project alpha"],
+        "fetch_ids": [],
+        "filter_params": {"active_only": True, "type_hint": None},
+        "needs_web_search": False,
+        "web_search_query": None,
+        "gmail_query": None,
+        "include_calendar": False,
+    }
+    response_text = json.dumps(expected)
+
+    events = [
+        _make_mock_event(response_text, usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_agent
+
+            result = await run_context_agent(
+                "Tell me about project alpha",
+                [],
+                api_key="test-key",
+                model="google/gemini-2.5-flash-lite",
+            )
+
+    assert result["search_queries"] == ["project alpha"]
+    assert result["needs_web_search"] is False
+
+
+@pytest.mark.asyncio
+async def test_context_agent_invalid_json_fallback():
+    """run_context_agent falls back to message-as-query on invalid JSON."""
+    events = [
+        _make_mock_event("not valid json {{{", usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_agent
+
+            result = await run_context_agent(
+                "hello world",
+                [],
+                api_key="test-key",
+            )
+
+    assert result["search_queries"] == ["hello world"]
+    assert result["filter_params"]["active_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_context_agent_tracks_usage():
+    """run_context_agent accumulates usage stats from ADK events."""
+    from backend.agents import UsageStats
+
+    events = [
+        _make_mock_event('{"search_queries": ["test"], "filter_params": {}}', usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_agent
+
+            usage = UsageStats()
+            await run_context_agent("test", [], usage_stats=usage, api_key="k")
+
+    assert usage.prompt_tokens == 10
+    assert usage.completion_tokens == 5
+    assert usage.api_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_context_agent_ollama_fallback():
+    """run_context_agent tries Ollama first, falls back to ADK on failure."""
+    expected = {
+        "search_queries": ["adk result"],
+        "filter_params": {"active_only": True},
+    }
+    events = [
+        _make_mock_event(json.dumps(expected), usage=True),
+    ]
+
+    with (
+        patch("backend.context_agent.OLLAMA_MODEL", "test-ollama-model"),
+        patch(
+            "backend.context_agent._chat_ollama",
+            new_callable=AsyncMock,
+            side_effect=Exception("Ollama down"),
+        ),
+        patch("backend.context_agent.Runner") as MockRunner,
+        patch("backend.context_agent._session_service") as mock_svc,
+    ):
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        mock_session = MagicMock()
+        mock_session.id = "test-session"
+        mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+        from backend.context_agent import run_context_agent
+
+        result = await run_context_agent("test", [], api_key="k")
+
+    assert result["search_queries"] == ["adk result"]
+
+
+# ---------------------------------------------------------------------------
+# run_context_refinement — ADK path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_refinement_done():
+    """run_context_refinement returns done=True when agent says so."""
+    events = [
+        _make_mock_event('{"done": true}', usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_refinement
+
+            result = await run_context_refinement(
+                "test message",
+                [],
+                [{"id": "1", "title": "Test Thing"}],
+                ["previous query"],
+                api_key="test-key",
+            )
+
+    assert result["done"] is True
+
+
+@pytest.mark.asyncio
+async def test_context_refinement_needs_more():
+    """run_context_refinement returns additional queries when not done."""
+    refinement_result = {
+        "done": False,
+        "search_queries": ["more stuff"],
+        "thing_ids": ["uuid-123"],
+        "filter_params": {"active_only": True},
+    }
+    events = [
+        _make_mock_event(json.dumps(refinement_result), usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_refinement
+
+            result = await run_context_refinement(
+                "test",
+                [],
+                [{"id": "1", "title": "Existing"}],
+                ["old query"],
+                api_key="k",
+            )
+
+    assert result["done"] is False
+    assert result["search_queries"] == ["more stuff"]
+    assert result["thing_ids"] == ["uuid-123"]
+
+
+@pytest.mark.asyncio
+async def test_context_refinement_invalid_json_returns_done():
+    """run_context_refinement returns done=True on invalid JSON."""
+    events = [
+        _make_mock_event("invalid json!!!", usage=True),
+    ]
+
+    with patch("backend.context_agent.Runner") as MockRunner:
+        mock_runner = MagicMock()
+        mock_runner.run_async = MagicMock(
+            return_value=_mock_run_async_factory(events)
+        )
+        MockRunner.return_value = mock_runner
+
+        with patch("backend.context_agent._session_service") as mock_svc:
+            mock_session = MagicMock()
+            mock_session.id = "test-session"
+            mock_svc.create_session = AsyncMock(return_value=mock_session)
+
+            from backend.context_agent import run_context_refinement
+
+            result = await run_context_refinement(
+                "test", [], [{"id": "1"}], ["q"], api_key="k",
+            )
+
+    assert result == {"done": True}
+
+
+# ---------------------------------------------------------------------------
+# Model factory
+# ---------------------------------------------------------------------------
+
+
+def test_make_litellm_model_adds_prefix():
+    """_make_litellm_model adds openai/ prefix to model names."""
+    from backend.context_agent import _make_litellm_model
+
+    m = _make_litellm_model(model="google/gemini-2.5-flash-lite", api_key="k")
+    assert m.model == "openai/google/gemini-2.5-flash-lite"
+
+
+def test_make_litellm_model_no_double_prefix():
+    """_make_litellm_model does not double-prefix openai/ models."""
+    from backend.context_agent import _make_litellm_model
+
+    m = _make_litellm_model(model="openai/gpt-4o", api_key="k")
+    assert m.model == "openai/gpt-4o"


### PR DESCRIPTION
## Summary
- Convert Context Agent from manual implementation to ADK LlmAgent
- Stage 2 of ADK + LiteLLM migration

Part of #91

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (294 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)