### PR TITLE
fix: allow Google profile images in CSP img-src directive (re-ihsa)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -59,7 +59,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "default-src 'self'; "
             "script-src 'self'; "
             "style-src 'self' 'unsafe-inline'; "
-            "img-src 'self' data: blob:; "
+            "img-src 'self' data: blob: https://*.googleusercontent.com; "
             "connect-src 'self'; "
             "font-src 'self'; "
             "frame-ancestors 'none'"


### PR DESCRIPTION
## Summary
- Fix broken avatar images for Google profile pics by adding Google domains to CSP img-src directive

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (314 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)