### PR TITLE
feat: show only tokens and price in chat message footer (re-eont)

### DIFF
--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -266,18 +266,13 @@ function UsagePill({ msg }: { msg: ChatMessage }) {
 
   if (totalTokens === 0) return null
 
-  const uniqueModels = calls.length > 0
-    ? [...new Set(calls.map(c => c.model.split('/').pop() ?? c.model))]
-    : msg.model ? [msg.model.split('/').pop() ?? msg.model] : []
-  const modelLabel = uniqueModels.length > 0 ? uniqueModels.join(', ') : null
-
   return (
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(o => !o)}
         className="text-[10px] text-gray-400 dark:text-gray-400 font-mono hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer"
       >
-        {modelLabel && <>{modelLabel} · </>}{formatTokens(totalTokens)} tokens{msg.cost_usd != null && msg.cost_usd > 0 ? ` · ${formatCost(msg.cost_usd)}` : ''}
+        {formatTokens(totalTokens)} tokens{msg.cost_usd != null && msg.cost_usd > 0 ? ` · ${formatCost(msg.cost_usd)}` : ''}
       </button>
       {open && (
         <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2.5 min-w-[200px] font-mono text-[11px] text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- Replace model names with token counts and price in chat message footer

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (314 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)