### PR TITLE
feat: install Phoenix + OTEL SDK, configure exporter (re-k2n2)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -89,6 +89,15 @@ class Settings(BaseSettings):
     SWEEP_HOUR: int = 3
     SWEEP_MINUTE: int = 0
 
+    # --- Phoenix / OpenTelemetry ---
+    PHOENIX_ENABLED: str = "false"
+    PHOENIX_ENDPOINT: str = "http://localhost:6006/v1/traces"
+    OTEL_SERVICE_NAME: str = "reli"
+
+    @property
+    def phoenix_enabled_bool(self) -> bool:
+        return self.PHOENIX_ENABLED.lower() not in ("false", "0", "no")
+
     @property
     def rate_limit_enabled_bool(self) -> bool:
         return self.RATE_LIMIT_ENABLED.lower() not in ("false", "0", "no")

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,20 +29,35 @@ from .database import clean_orphan_relationships, init_db  # noqa: E402
 from .metrics import MetricsMiddleware, metrics_response  # noqa: E402
 from .rate_limit import RateLimitMiddleware, get_rate_limit_config  # noqa: E402
 from .response_metrics import ResponseMetricsMiddleware, metrics_store  # noqa: E402
-from .routers import auth, briefing, calendar, chat, feedback, gmail, proactive, settings, sweep, thing_types, things  # noqa: E402
+from .routers import (  # noqa: E402
+    auth,
+    briefing,
+    calendar,
+    chat,
+    feedback,
+    gmail,
+    proactive,
+    settings,
+    sweep,
+    thing_types,
+    things,
+)
 from .sentry import set_sentry_user  # noqa: E402
 from .sweep_scheduler import start_scheduler, stop_scheduler  # noqa: E402
+from .tracing import init_tracing, shutdown_tracing  # noqa: E402
 
 _FRONTEND_DIST = pathlib.Path(__file__).parent.parent / "frontend" / "dist"
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    init_tracing()
     init_db()
     clean_orphan_relationships()
     start_scheduler()
     yield
     stop_scheduler()
+    shutdown_tracing()
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,7 @@ prometheus-client>=0.16.0
 sentry-sdk[fastapi]>=2.0.0
 litellm>=1.80.0
 google-adk>=1.25.0
+arize-phoenix>=8.0.0
+opentelemetry-api>=1.20.0
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp>=1.20.0

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -1,0 +1,77 @@
+"""Tests for Phoenix/OTEL tracing setup."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_tracing_env(monkeypatch):
+    """Ensure PHOENIX_ENABLED is off by default."""
+    monkeypatch.setenv("PHOENIX_ENABLED", "false")
+
+
+def test_init_tracing_noop_when_disabled():
+    """init_tracing should be a no-op when PHOENIX_ENABLED is false."""
+    with patch("backend.tracing.settings") as mock_settings:
+        mock_settings.phoenix_enabled_bool = False
+        mock_settings.PHOENIX_ENABLED = "false"
+        from backend.tracing import init_tracing
+
+        # Should not raise
+        init_tracing()
+
+
+def test_init_tracing_configures_provider_when_enabled():
+    """init_tracing should set up TracerProvider and OTLP exporter when enabled."""
+    with patch("backend.tracing.settings") as mock_settings:
+        mock_settings.phoenix_enabled_bool = True
+        mock_settings.PHOENIX_ENDPOINT = "http://localhost:6006/v1/traces"
+        mock_settings.OTEL_SERVICE_NAME = "reli-test"
+
+        mock_tracer_provider = MagicMock()
+        mock_exporter = MagicMock()
+        mock_processor = MagicMock()
+
+        with (
+            patch("opentelemetry.sdk.trace.TracerProvider", return_value=mock_tracer_provider),
+            patch(
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                return_value=mock_exporter,
+            ) as mock_exp_cls,
+            patch(
+                "opentelemetry.sdk.trace.export.BatchSpanProcessor",
+                return_value=mock_processor,
+            ),
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_tp,
+        ):
+            import backend.tracing
+
+            backend.tracing._tracer_provider = None
+            backend.tracing.init_tracing()
+
+            mock_exp_cls.assert_called_once_with(endpoint="http://localhost:6006/v1/traces")
+            mock_tracer_provider.add_span_processor.assert_called_once_with(mock_processor)
+            mock_set_tp.assert_called_once_with(mock_tracer_provider)
+
+
+def test_shutdown_tracing_flushes_provider():
+    """shutdown_tracing should call shutdown on the tracer provider."""
+    import backend.tracing
+
+    mock_provider = MagicMock()
+    backend.tracing._tracer_provider = mock_provider
+
+    backend.tracing.shutdown_tracing()
+
+    mock_provider.shutdown.assert_called_once()
+    assert backend.tracing._tracer_provider is None
+
+
+def test_shutdown_tracing_noop_when_not_initialized():
+    """shutdown_tracing should be a no-op when no provider exists."""
+    import backend.tracing
+
+    backend.tracing._tracer_provider = None
+    # Should not raise
+    backend.tracing.shutdown_tracing()

--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -1,0 +1,68 @@
+"""OpenTelemetry tracing setup with Phoenix exporter.
+
+Configures the OTEL tracer provider to export spans to an Arize Phoenix
+instance via OTLP/HTTP. Controlled by PHOENIX_ENABLED env var.
+
+Usage:
+    from backend.tracing import init_tracing, shutdown_tracing
+
+    # In lifespan:
+    init_tracing()
+    yield
+    shutdown_tracing()
+"""
+
+import logging
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+_tracer_provider = None
+
+
+def init_tracing() -> None:
+    """Initialize OTEL tracing with Phoenix OTLP exporter.
+
+    No-op if PHOENIX_ENABLED is not set to true.
+    """
+    global _tracer_provider
+
+    if not settings.phoenix_enabled_bool:
+        logger.info("Phoenix tracing disabled (PHOENIX_ENABLED=%s)", settings.PHOENIX_ENABLED)
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        resource = Resource.create({"service.name": settings.OTEL_SERVICE_NAME})
+        _tracer_provider = TracerProvider(resource=resource)
+
+        exporter = OTLPSpanExporter(endpoint=settings.PHOENIX_ENDPOINT)
+        _tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+
+        trace.set_tracer_provider(_tracer_provider)
+        logger.info(
+            "Phoenix tracing enabled — exporting to %s (service: %s)",
+            settings.PHOENIX_ENDPOINT,
+            settings.OTEL_SERVICE_NAME,
+        )
+    except Exception:
+        logger.exception("Failed to initialize Phoenix tracing")
+
+
+def shutdown_tracing() -> None:
+    """Flush and shut down the tracer provider."""
+    global _tracer_provider
+
+    if _tracer_provider is not None:
+        try:
+            _tracer_provider.shutdown()
+            logger.info("Phoenix tracer provider shut down")
+        except Exception:
+            logger.exception("Error shutting down tracer provider")
+        _tracer_provider = None


### PR DESCRIPTION
## Summary
- Install Phoenix and OpenTelemetry SDK
- Configure OTEL exporter for observability
- Stage 1 of Phoenix observability setup

Part of #96

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (318 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)