### PR TITLE
feat: wire OTEL trace spans through SequentialAgent pipeline (re-ozyf)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -84,11 +84,6 @@ class Settings(BaseSettings):
     SENTRY_ENVIRONMENT: str = "production"
     SENTRY_TRACES_SAMPLE_RATE: float = 0.2
 
-    # --- Sweep scheduler ---
-    SWEEP_ENABLED: str = "true"
-    SWEEP_HOUR: int = 3
-    SWEEP_MINUTE: int = 0
-
     # --- Phoenix / OpenTelemetry ---
     PHOENIX_ENABLED: str = "false"
     PHOENIX_ENDPOINT: str = "http://localhost:6006/v1/traces"
@@ -97,6 +92,11 @@ class Settings(BaseSettings):
     @property
     def phoenix_enabled_bool(self) -> bool:
         return self.PHOENIX_ENABLED.lower() not in ("false", "0", "no")
+
+    # --- Sweep scheduler ---
+    SWEEP_ENABLED: str = "true"
+    SWEEP_HOUR: int = 3
+    SWEEP_MINUTE: int = 0
 
     @property
     def rate_limit_enabled_bool(self) -> bool:

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,10 @@ from .sentry import init_sentry  # noqa: E402
 
 init_sentry()
 
+from .tracing import init_tracing  # noqa: E402
+
+init_tracing()
+
 from fastapi import Depends, FastAPI, Request  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import FileResponse  # noqa: E402

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -34,10 +34,12 @@ from .google_calendar import fetch_upcoming_events
 from .google_calendar import is_connected as gcal_connected
 from .reasoning_agent import REASONING_AGENT_TOOL_SYSTEM, run_reasoning_agent
 from .response_agent import run_response_agent, run_response_agent_stream
+from .tracing import get_tracer, set_span_error
 from .vector_store import VECTOR_SEARCH_THRESHOLD, vector_count, vector_search
 from .web_search import google_search, is_search_configured
 
 logger = logging.getLogger(__name__)
+_tracer = get_tracer()
 
 # Maximum iterations for the context refinement loop
 MAX_CONTEXT_ITERATIONS = 4
@@ -586,6 +588,28 @@ class ChatPipeline:
     # Full pipeline execution
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _record_stage_usage(
+        span: Any,
+        stage: str,
+        usage: UsageStats,
+        calls_before: int,
+    ) -> None:
+        """Set span attributes for token counts from API calls made during a stage."""
+        new_calls = usage.calls[calls_before:]
+        stage_prompt = sum(c.prompt_tokens for c in new_calls)
+        stage_completion = sum(c.completion_tokens for c in new_calls)
+        stage_cost = sum(c.cost_usd for c in new_calls)
+        models_used = list({c.model for c in new_calls}) if new_calls else []
+
+        span.set_attribute(f"reli.{stage}.prompt_tokens", stage_prompt)
+        span.set_attribute(f"reli.{stage}.completion_tokens", stage_completion)
+        span.set_attribute(f"reli.{stage}.total_tokens", stage_prompt + stage_completion)
+        span.set_attribute(f"reli.{stage}.cost_usd", round(stage_cost, 6))
+        span.set_attribute(f"reli.{stage}.api_calls", len(new_calls))
+        if models_used:
+            span.set_attribute(f"reli.{stage}.model", models_used[0])
+
     async def run(
         self,
         message: str,
@@ -599,42 +623,108 @@ class ChatPipeline:
         """
         usage = UsageStats()
 
-        # Stage 1: Context Agent (iterative loop)
-        context_result, relevant_things, context_relationships = (
-            await self._run_context_stage(message, history, usage)
-        )
+        with _tracer.start_as_current_span("reli.pipeline") as pipeline_span:
+            pipeline_span.set_attribute("reli.user_id", self.user_id)
+            pipeline_span.set_attribute("reli.message_length", len(message))
+            pipeline_span.set_attribute("reli.history_length", len(history))
 
-        # External data
-        web_results, gmail_context, calendar_events = (
-            await self._fetch_external_data(message, context_result)
-        )
+            try:
+                # Stage 1: Context Agent (iterative loop)
+                calls_before = len(usage.calls)
+                with _tracer.start_as_current_span("reli.stage.context") as ctx_span:
+                    ctx_span.set_attribute("reli.context.model", self.user_models.get("context") or "default")
+                    ctx_span.set_attribute("reli.context.max_iterations", MAX_CONTEXT_ITERATIONS)
+                    try:
+                        context_result, relevant_things, context_relationships = (
+                            await self._run_context_stage(message, history, usage)
+                        )
+                        ctx_span.set_attribute("reli.context.things_found", len(relevant_things))
+                        ctx_span.set_attribute("reli.context.relationships_found", len(context_relationships))
+                        ctx_span.set_attribute(
+                            "reli.context.search_queries",
+                            json.dumps(context_result.get("search_queries", [])),
+                        )
+                        self._record_stage_usage(ctx_span, "context", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(ctx_span, exc)
+                        raise
 
-        # Stage 2: Reasoning Agent
-        reasoning_result = await run_reasoning_agent(
-            message, history, relevant_things, web_results, gmail_context,
-            calendar_events, relationships=context_relationships,
-            usage_stats=usage, context_window=self.context_window,
-            api_key=self.user_api_key, model=self.user_models.get("reasoning"),
-            user_id=self.user_id,
-        )
-        questions_for_user = reasoning_result.get("questions_for_user", [])
-        priority_question = reasoning_result.get("priority_question", "")
-        reasoning_summary = reasoning_result.get("reasoning_summary", "")
-        briefing_mode = reasoning_result.get("briefing_mode", False)
-        applied_changes = reasoning_result.get("applied_changes", {
-            "created": [], "updated": [], "deleted": [], "merged": [], "relationships_created": [],
-        })
+                # External data
+                web_results, gmail_context, calendar_events = (
+                    await self._fetch_external_data(message, context_result)
+                )
 
-        open_questions_by_thing = self._collect_open_questions(relevant_things, applied_changes)
+                # Stage 2: Reasoning Agent
+                calls_before = len(usage.calls)
+                with _tracer.start_as_current_span("reli.stage.reasoning") as reason_span:
+                    reason_span.set_attribute(
+                        "reli.reasoning.model",
+                        self.user_models.get("reasoning") or REQUESTY_REASONING_MODEL,
+                    )
+                    reason_span.set_attribute("reli.reasoning.things_input", len(relevant_things))
+                    try:
+                        reasoning_result = await run_reasoning_agent(
+                            message, history, relevant_things, web_results, gmail_context,
+                            calendar_events, relationships=context_relationships,
+                            usage_stats=usage, context_window=self.context_window,
+                            api_key=self.user_api_key, model=self.user_models.get("reasoning"),
+                            user_id=self.user_id,
+                        )
+                        questions_for_user = reasoning_result.get("questions_for_user", [])
+                        priority_question = reasoning_result.get("priority_question", "")
+                        reasoning_summary = reasoning_result.get("reasoning_summary", "")
+                        briefing_mode = reasoning_result.get("briefing_mode", False)
+                        applied_changes = reasoning_result.get("applied_changes", {
+                            "created": [], "updated": [], "deleted": [], "merged": [],
+                            "relationships_created": [],
+                        })
 
-        # Stage 3: Response Agent
-        reply = await run_response_agent(
-            message, reasoning_summary, questions_for_user, applied_changes,
-            web_results, usage_stats=usage,
-            open_questions_by_thing=open_questions_by_thing or None,
-            api_key=self.user_api_key, model=self.user_models.get("response"),
-            priority_question=priority_question, briefing_mode=briefing_mode,
-        )
+                        n_created = len(applied_changes.get("created", []))
+                        n_updated = len(applied_changes.get("updated", []))
+                        n_deleted = len(applied_changes.get("deleted", []))
+                        reason_span.set_attribute("reli.reasoning.changes_created", n_created)
+                        reason_span.set_attribute("reli.reasoning.changes_updated", n_updated)
+                        reason_span.set_attribute("reli.reasoning.changes_deleted", n_deleted)
+                        reason_span.set_attribute("reli.reasoning.questions_count", len(questions_for_user))
+                        reason_span.set_attribute("reli.reasoning.briefing_mode", briefing_mode)
+                        self._record_stage_usage(reason_span, "reasoning", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(reason_span, exc)
+                        raise
+
+                open_questions_by_thing = self._collect_open_questions(relevant_things, applied_changes)
+
+                # Stage 3: Response Agent
+                calls_before = len(usage.calls)
+                with _tracer.start_as_current_span("reli.stage.response") as resp_span:
+                    resp_span.set_attribute(
+                        "reli.response.model",
+                        self.user_models.get("response") or REQUESTY_RESPONSE_MODEL,
+                    )
+                    try:
+                        reply = await run_response_agent(
+                            message, reasoning_summary, questions_for_user, applied_changes,
+                            web_results, usage_stats=usage,
+                            open_questions_by_thing=open_questions_by_thing or None,
+                            api_key=self.user_api_key, model=self.user_models.get("response"),
+                            priority_question=priority_question, briefing_mode=briefing_mode,
+                        )
+                        resp_span.set_attribute("reli.response.reply_length", len(reply))
+                        self._record_stage_usage(resp_span, "response", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(resp_span, exc)
+                        raise
+
+                # Record totals on the pipeline span
+                pipeline_span.set_attribute("reli.total_prompt_tokens", usage.prompt_tokens)
+                pipeline_span.set_attribute("reli.total_completion_tokens", usage.completion_tokens)
+                pipeline_span.set_attribute("reli.total_tokens", usage.total_tokens)
+                pipeline_span.set_attribute("reli.total_cost_usd", round(usage.cost_usd, 6))
+                pipeline_span.set_attribute("reli.total_api_calls", usage.api_calls)
+
+            except Exception as exc:
+                set_span_error(pipeline_span, exc)
+                raise
 
         return PipelineResult(
             reply=reply,
@@ -665,59 +755,126 @@ class ChatPipeline:
         """
         usage = UsageStats()
 
-        # Stage 1: Context Agent
-        yield PipelineEvent(type="stage_start", stage="context")
+        with _tracer.start_as_current_span("reli.pipeline.stream") as pipeline_span:
+            pipeline_span.set_attribute("reli.user_id", self.user_id)
+            pipeline_span.set_attribute("reli.message_length", len(message))
+            pipeline_span.set_attribute("reli.history_length", len(history))
+            pipeline_span.set_attribute("reli.streaming", True)
 
-        context_result, relevant_things, context_relationships = (
-            await self._run_context_stage(message, history, usage)
-        )
+            try:
+                # Stage 1: Context Agent
+                yield PipelineEvent(type="stage_start", stage="context")
 
-        # External data
-        web_results, gmail_context, calendar_events = (
-            await self._fetch_external_data(message, context_result)
-        )
+                calls_before = len(usage.calls)
+                with _tracer.start_as_current_span("reli.stage.context") as ctx_span:
+                    ctx_span.set_attribute("reli.context.model", self.user_models.get("context") or "default")
+                    ctx_span.set_attribute("reli.context.max_iterations", MAX_CONTEXT_ITERATIONS)
+                    try:
+                        context_result, relevant_things, context_relationships = (
+                            await self._run_context_stage(message, history, usage)
+                        )
+                        ctx_span.set_attribute("reli.context.things_found", len(relevant_things))
+                        ctx_span.set_attribute("reli.context.relationships_found", len(context_relationships))
+                        ctx_span.set_attribute(
+                            "reli.context.search_queries",
+                            json.dumps(context_result.get("search_queries", [])),
+                        )
+                        self._record_stage_usage(ctx_span, "context", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(ctx_span, exc)
+                        raise
 
-        yield PipelineEvent(type="stage_complete", stage="context")
+                # External data
+                web_results, gmail_context, calendar_events = (
+                    await self._fetch_external_data(message, context_result)
+                )
 
-        # Stage 2: Reasoning Agent
-        yield PipelineEvent(type="stage_start", stage="reasoning")
+                yield PipelineEvent(type="stage_complete", stage="context")
 
-        reasoning_result = await run_reasoning_agent(
-            message, history, relevant_things, web_results, gmail_context,
-            calendar_events, relationships=context_relationships,
-            usage_stats=usage, context_window=self.context_window,
-            api_key=self.user_api_key, model=self.user_models.get("reasoning"),
-            user_id=self.user_id,
-        )
-        questions_for_user = reasoning_result.get("questions_for_user", [])
-        priority_question = reasoning_result.get("priority_question", "")
-        reasoning_summary = reasoning_result.get("reasoning_summary", "")
-        briefing_mode = reasoning_result.get("briefing_mode", False)
-        applied_changes = reasoning_result.get("applied_changes", {
-            "created": [], "updated": [], "deleted": [], "merged": [], "relationships_created": [],
-        })
+                # Stage 2: Reasoning Agent
+                yield PipelineEvent(type="stage_start", stage="reasoning")
 
-        open_questions_by_thing = self._collect_open_questions(relevant_things, applied_changes)
+                calls_before = len(usage.calls)
+                with _tracer.start_as_current_span("reli.stage.reasoning") as reason_span:
+                    reason_span.set_attribute(
+                        "reli.reasoning.model",
+                        self.user_models.get("reasoning") or REQUESTY_REASONING_MODEL,
+                    )
+                    reason_span.set_attribute("reli.reasoning.things_input", len(relevant_things))
+                    try:
+                        reasoning_result = await run_reasoning_agent(
+                            message, history, relevant_things, web_results, gmail_context,
+                            calendar_events, relationships=context_relationships,
+                            usage_stats=usage, context_window=self.context_window,
+                            api_key=self.user_api_key, model=self.user_models.get("reasoning"),
+                            user_id=self.user_id,
+                        )
+                        questions_for_user = reasoning_result.get("questions_for_user", [])
+                        priority_question = reasoning_result.get("priority_question", "")
+                        reasoning_summary = reasoning_result.get("reasoning_summary", "")
+                        briefing_mode = reasoning_result.get("briefing_mode", False)
+                        applied_changes = reasoning_result.get("applied_changes", {
+                            "created": [], "updated": [], "deleted": [], "merged": [],
+                            "relationships_created": [],
+                        })
 
-        yield PipelineEvent(type="stage_complete", stage="reasoning")
+                        n_created = len(applied_changes.get("created", []))
+                        n_updated = len(applied_changes.get("updated", []))
+                        n_deleted = len(applied_changes.get("deleted", []))
+                        reason_span.set_attribute("reli.reasoning.changes_created", n_created)
+                        reason_span.set_attribute("reli.reasoning.changes_updated", n_updated)
+                        reason_span.set_attribute("reli.reasoning.changes_deleted", n_deleted)
+                        reason_span.set_attribute("reli.reasoning.questions_count", len(questions_for_user))
+                        reason_span.set_attribute("reli.reasoning.briefing_mode", briefing_mode)
+                        self._record_stage_usage(reason_span, "reasoning", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(reason_span, exc)
+                        raise
 
-        # Stage 3: Response Agent (streaming)
-        yield PipelineEvent(type="stage_start", stage="response")
+                open_questions_by_thing = self._collect_open_questions(relevant_things, applied_changes)
 
-        reply_parts: list[str] = []
-        async for token in run_response_agent_stream(
-            message, reasoning_summary, questions_for_user, applied_changes,
-            web_results, usage_stats=usage,
-            open_questions_by_thing=open_questions_by_thing or None,
-            api_key=self.user_api_key, model=self.user_models.get("response"),
-            priority_question=priority_question, briefing_mode=briefing_mode,
-        ):
-            reply_parts.append(token)
-            yield PipelineEvent(type="token", data=token)
+                yield PipelineEvent(type="stage_complete", stage="reasoning")
 
-        reply = "".join(reply_parts)
+                # Stage 3: Response Agent (streaming)
+                yield PipelineEvent(type="stage_start", stage="response")
 
-        yield PipelineEvent(type="stage_complete", stage="response")
+                calls_before = len(usage.calls)
+                reply_parts: list[str] = []
+                with _tracer.start_as_current_span("reli.stage.response") as resp_span:
+                    resp_span.set_attribute(
+                        "reli.response.model",
+                        self.user_models.get("response") or REQUESTY_RESPONSE_MODEL,
+                    )
+                    try:
+                        async for token in run_response_agent_stream(
+                            message, reasoning_summary, questions_for_user, applied_changes,
+                            web_results, usage_stats=usage,
+                            open_questions_by_thing=open_questions_by_thing or None,
+                            api_key=self.user_api_key, model=self.user_models.get("response"),
+                            priority_question=priority_question, briefing_mode=briefing_mode,
+                        ):
+                            reply_parts.append(token)
+                            yield PipelineEvent(type="token", data=token)
+
+                        reply = "".join(reply_parts)
+                        resp_span.set_attribute("reli.response.reply_length", len(reply))
+                        self._record_stage_usage(resp_span, "response", usage, calls_before)
+                    except Exception as exc:
+                        set_span_error(resp_span, exc)
+                        raise
+
+                yield PipelineEvent(type="stage_complete", stage="response")
+
+                # Record totals on the pipeline span
+                pipeline_span.set_attribute("reli.total_prompt_tokens", usage.prompt_tokens)
+                pipeline_span.set_attribute("reli.total_completion_tokens", usage.completion_tokens)
+                pipeline_span.set_attribute("reli.total_tokens", usage.total_tokens)
+                pipeline_span.set_attribute("reli.total_cost_usd", round(usage.cost_usd, 6))
+                pipeline_span.set_attribute("reli.total_api_calls", usage.api_calls)
+
+            except Exception as exc:
+                set_span_error(pipeline_span, exc)
+                raise
 
         # Yield final result
         yield PipelineEvent(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,3 +29,4 @@ arize-phoenix>=8.0.0
 opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
+opentelemetry-exporter-otlp-proto-http>=1.20.0

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -6,16 +6,18 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clear_tracing_env(monkeypatch):
-    """Ensure PHOENIX_ENABLED is off by default."""
+def _clear_tracing_state(monkeypatch):
+    """Ensure PHOENIX_ENABLED is off and tracing state is reset."""
     monkeypatch.setenv("PHOENIX_ENABLED", "false")
+    import backend.tracing
+
+    backend.tracing._initialized = False
 
 
 def test_init_tracing_noop_when_disabled():
     """init_tracing should be a no-op when PHOENIX_ENABLED is false."""
     with patch("backend.tracing.settings") as mock_settings:
         mock_settings.phoenix_enabled_bool = False
-        mock_settings.PHOENIX_ENABLED = "false"
         from backend.tracing import init_tracing
 
         # Should not raise
@@ -47,12 +49,13 @@ def test_init_tracing_configures_provider_when_enabled():
         ):
             import backend.tracing
 
-            backend.tracing._tracer_provider = None
+            backend.tracing._initialized = False
             backend.tracing.init_tracing()
 
             mock_exp_cls.assert_called_once_with(endpoint="http://localhost:6006/v1/traces")
             mock_tracer_provider.add_span_processor.assert_called_once_with(mock_processor)
             mock_set_tp.assert_called_once_with(mock_tracer_provider)
+            assert backend.tracing._initialized is True
 
 
 def test_shutdown_tracing_flushes_provider():
@@ -60,18 +63,42 @@ def test_shutdown_tracing_flushes_provider():
     import backend.tracing
 
     mock_provider = MagicMock()
-    backend.tracing._tracer_provider = mock_provider
+    mock_provider.shutdown = MagicMock()
+    backend.tracing._initialized = True
 
-    backend.tracing.shutdown_tracing()
+    with patch("opentelemetry.trace.get_tracer_provider", return_value=mock_provider):
+        backend.tracing.shutdown_tracing()
 
     mock_provider.shutdown.assert_called_once()
-    assert backend.tracing._tracer_provider is None
+    assert backend.tracing._initialized is False
 
 
 def test_shutdown_tracing_noop_when_not_initialized():
-    """shutdown_tracing should be a no-op when no provider exists."""
+    """shutdown_tracing should be a no-op when not initialized."""
     import backend.tracing
 
-    backend.tracing._tracer_provider = None
+    backend.tracing._initialized = False
     # Should not raise
     backend.tracing.shutdown_tracing()
+
+
+def test_get_tracer_returns_tracer():
+    """get_tracer should return a tracer instance."""
+    from backend.tracing import get_tracer
+
+    tracer = get_tracer()
+    # Should return a tracer (no-op when not initialized)
+    assert tracer is not None
+
+
+def test_set_span_error_records_exception():
+    """set_span_error should set ERROR status and record the exception."""
+    from backend.tracing import set_span_error
+
+    mock_span = MagicMock()
+    exc = ValueError("test error")
+
+    set_span_error(mock_span, exc)
+
+    mock_span.set_status.assert_called_once()
+    mock_span.record_exception.assert_called_once_with(exc)

--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -1,68 +1,84 @@
-"""OpenTelemetry tracing setup with Phoenix exporter.
+"""OpenTelemetry tracing for the Reli agent pipeline.
 
-Configures the OTEL tracer provider to export spans to an Arize Phoenix
-instance via OTLP/HTTP. Controlled by PHOENIX_ENABLED env var.
+Configures a tracer provider that exports spans to Phoenix (or any
+OTLP-compatible collector).  Disabled by default — set PHOENIX_ENABLED=true
+to activate.
 
 Usage:
-    from backend.tracing import init_tracing, shutdown_tracing
+    from .tracing import get_tracer
 
-    # In lifespan:
-    init_tracing()
-    yield
-    shutdown_tracing()
+    tracer = get_tracer()
+    with tracer.start_as_current_span("my_operation") as span:
+        span.set_attribute("key", "value")
 """
 
 import logging
+
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode, Tracer
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
 
-_tracer_provider = None
+_TRACER_NAME = "reli.pipeline"
+_initialized = False
 
 
 def init_tracing() -> None:
-    """Initialize OTEL tracing with Phoenix OTLP exporter.
+    """Initialize the OTEL tracer provider and OTLP exporter.
 
-    No-op if PHOENIX_ENABLED is not set to true.
+    Safe to call multiple times — only the first call configures the provider.
+    Does nothing when PHOENIX_ENABLED is false.
     """
-    global _tracer_provider
-
-    if not settings.phoenix_enabled_bool:
-        logger.info("Phoenix tracing disabled (PHOENIX_ENABLED=%s)", settings.PHOENIX_ENABLED)
+    global _initialized
+    if _initialized or not settings.phoenix_enabled_bool:
         return
 
     try:
-        from opentelemetry import trace
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
         resource = Resource.create({"service.name": settings.OTEL_SERVICE_NAME})
-        _tracer_provider = TracerProvider(resource=resource)
-
+        provider = TracerProvider(resource=resource)
         exporter = OTLPSpanExporter(endpoint=settings.PHOENIX_ENDPOINT)
-        _tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
-
-        trace.set_tracer_provider(_tracer_provider)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+        _initialized = True
         logger.info(
-            "Phoenix tracing enabled — exporting to %s (service: %s)",
+            "OTEL tracing initialized — exporting to %s (service: %s)",
             settings.PHOENIX_ENDPOINT,
             settings.OTEL_SERVICE_NAME,
         )
     except Exception:
-        logger.exception("Failed to initialize Phoenix tracing")
+        logger.exception("Failed to initialize OTEL tracing")
 
 
 def shutdown_tracing() -> None:
     """Flush and shut down the tracer provider."""
-    global _tracer_provider
-
-    if _tracer_provider is not None:
+    global _initialized
+    provider = trace.get_tracer_provider()
+    if _initialized and hasattr(provider, 'shutdown'):
         try:
-            _tracer_provider.shutdown()
-            logger.info("Phoenix tracer provider shut down")
+            provider.shutdown()
+            logger.info("Tracer provider shut down")
         except Exception:
             logger.exception("Error shutting down tracer provider")
-        _tracer_provider = None
+        _initialized = False
+
+
+def get_tracer() -> Tracer:
+    """Return the pipeline tracer.
+
+    Returns the no-op tracer when tracing is disabled, so callers never
+    need to check whether tracing is active.
+    """
+    return trace.get_tracer(_TRACER_NAME)
+
+
+def set_span_error(span: trace.Span, exc: BaseException) -> None:
+    """Record an exception on a span and set ERROR status."""
+    span.set_status(StatusCode.ERROR, str(exc))
+    span.record_exception(exc)


### PR DESCRIPTION
## Summary
- Wire OpenTelemetry trace spans through the SequentialAgent pipeline
- Consolidate duplicate OTEL config sections, update tracing tests
- Stage 2 of Phoenix observability setup

Part of #96

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (320 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)