### PR TITLE
feat: add custom OTEL spans for tool calls in reasoning agent (re-jtff)

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -7,6 +7,7 @@ function signatures.  Preserves the same public interface so callers in
 chat.py need only update their import path.
 """
 
+import functools
 import json
 import logging
 import uuid
@@ -15,6 +16,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from google.adk.agents import LlmAgent
+from opentelemetry import trace
 
 from .agents import (
     OLLAMA_MODEL,
@@ -26,10 +28,66 @@ from .agents import (
 )
 from .context_agent import _make_litellm_model, _run_agent_for_text
 from .database import db
+from .tracing import get_tracer
 from .vector_store import delete_thing as vs_delete
 from .vector_store import upsert_thing
 
 logger = logging.getLogger(__name__)
+
+_tracer = get_tracer("reli.reasoning_agent")
+
+# Max length for span attribute values to avoid oversized payloads
+_ATTR_VALUE_LIMIT = 4096
+
+
+def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+    """Wrap a tool function with an OTEL span recording inputs and outputs."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        with _tracer.start_as_current_span(
+            f"tool.{func.__name__}",
+            kind=trace.SpanKind.INTERNAL,
+        ) as span:
+            # Record input arguments
+            import inspect
+
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            for param_name, value in bound.arguments.items():
+                attr_val = str(value) if not isinstance(value, str) else value
+                if len(attr_val) > _ATTR_VALUE_LIMIT:
+                    attr_val = attr_val[:_ATTR_VALUE_LIMIT] + "..."
+                span.set_attribute(f"tool.input.{param_name}", attr_val)
+
+            try:
+                result = func(*args, **kwargs)
+            except Exception as exc:
+                span.set_status(trace.StatusCode.ERROR, str(exc))
+                span.record_exception(exc)
+                raise
+
+            # Record output
+            if isinstance(result, dict):
+                if "error" in result:
+                    span.set_status(trace.StatusCode.ERROR, result["error"])
+                    span.set_attribute("tool.error", result["error"])
+                else:
+                    span.set_status(trace.StatusCode.OK)
+                result_str = json.dumps(result, default=str)
+                if len(result_str) > _ATTR_VALUE_LIMIT:
+                    result_str = result_str[:_ATTR_VALUE_LIMIT] + "..."
+                span.set_attribute("tool.output", result_str)
+
+                # Set key identifiers as top-level attributes for easy filtering
+                for key in ("id", "deleted", "keep_id"):
+                    if key in result:
+                        span.set_attribute(f"tool.result.{key}", str(result[key]))
+
+            return result
+
+    return wrapper
 
 
 # ---------------------------------------------------------------------------
@@ -681,7 +739,15 @@ def _make_reasoning_tools(
             applied["relationships_created"].append(rel_info)
             return rel_info
 
-    return [create_thing, update_thing, delete_thing, merge_things, create_relationship], applied
+    # Wrap each tool with OTEL span instrumentation
+    traced_tools = [
+        _traced_tool(create_thing),
+        _traced_tool(update_thing),
+        _traced_tool(delete_thing),
+        _traced_tool(merge_things),
+        _traced_tool(create_relationship),
+    ]
+    return traced_tools, applied
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -91,6 +91,16 @@ def test_get_tracer_returns_tracer():
     assert tracer is not None
 
 
+def test_get_tracer_with_custom_name():
+    """get_tracer with a custom name should return a tracer."""
+    from opentelemetry import trace
+
+    from backend.tracing import get_tracer
+
+    tracer = get_tracer("test-module")
+    assert isinstance(tracer, trace.Tracer)
+
+
 def test_set_span_error_records_exception():
     """set_span_error should set ERROR status and record the exception."""
     from backend.tracing import set_span_error
@@ -102,3 +112,130 @@ def test_set_span_error_records_exception():
 
     mock_span.set_status.assert_called_once()
     mock_span.record_exception.assert_called_once_with(exc)
+
+
+# ---------------------------------------------------------------------------
+# _traced_tool decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestTracedToolDecorator:
+    """Tests for the _traced_tool span instrumentation decorator."""
+
+    def test_traced_tool_preserves_function_name(self):
+        """Wrapped function should preserve __name__ for ADK schema generation."""
+        from backend.reasoning_agent import _traced_tool
+
+        def my_tool(title: str) -> dict:
+            """My tool docstring."""
+            return {"id": "123", "title": title}
+
+        wrapped = _traced_tool(my_tool)
+        assert wrapped.__name__ == "my_tool"
+        assert wrapped.__doc__ == "My tool docstring."
+
+    def test_traced_tool_passes_through_result(self):
+        """Wrapped tool should return the same result as the original."""
+        from backend.reasoning_agent import _traced_tool
+
+        def my_tool(title: str, priority: int = 3) -> dict:
+            return {"id": "abc", "title": title, "priority": priority}
+
+        wrapped = _traced_tool(my_tool)
+        result = wrapped(title="Test", priority=1)
+        assert result == {"id": "abc", "title": "Test", "priority": 1}
+
+    def test_traced_tool_propagates_exceptions(self):
+        """Wrapped tool should re-raise exceptions from the original."""
+        from backend.reasoning_agent import _traced_tool
+
+        def failing_tool(x: str) -> dict:
+            raise ValueError("boom")
+
+        wrapped = _traced_tool(failing_tool)
+        with pytest.raises(ValueError, match="boom"):
+            wrapped(x="test")
+
+    def test_traced_tool_records_span_attributes(self):
+        """Wrapped tool should set span attributes for inputs and outputs."""
+        from backend.reasoning_agent import _traced_tool
+
+        mock_span = MagicMock()
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        with patch("backend.reasoning_agent._tracer", mock_tracer):
+            def create_thing(title: str, priority: int = 3) -> dict:
+                return {"id": "new-uuid", "title": title}
+
+            wrapped = _traced_tool(create_thing)
+            result = wrapped(title="Buy groceries", priority=1)
+
+        assert result == {"id": "new-uuid", "title": "Buy groceries"}
+
+        # Verify span was started with correct name
+        mock_tracer.start_as_current_span.assert_called_once()
+        call_args = mock_tracer.start_as_current_span.call_args
+        assert call_args[0][0] == "tool.create_thing"
+
+        # Verify input attributes were set
+        set_attr_calls = {
+            call[0][0]: call[0][1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+        assert set_attr_calls["tool.input.title"] == "Buy groceries"
+        assert set_attr_calls["tool.input.priority"] == "1"
+        assert "new-uuid" in set_attr_calls["tool.output"]
+        assert set_attr_calls["tool.result.id"] == "new-uuid"
+
+    def test_traced_tool_records_error_status_on_error_result(self):
+        """Wrapped tool should set ERROR status when result contains 'error' key."""
+        from backend.reasoning_agent import _traced_tool
+
+        mock_span = MagicMock()
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        with patch("backend.reasoning_agent._tracer", mock_tracer):
+            def bad_tool(thing_id: str) -> dict:
+                return {"error": "Thing not found"}
+
+            wrapped = _traced_tool(bad_tool)
+            result = wrapped(thing_id="missing")
+
+        assert result == {"error": "Thing not found"}
+
+        set_attr_calls = {
+            call[0][0]: call[0][1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+        assert set_attr_calls["tool.error"] == "Thing not found"
+
+    def test_tools_from_factory_are_traced(self):
+        """Tools returned by _make_reasoning_tools should be wrapped with tracing."""
+        with patch("backend.reasoning_agent.db"), \
+             patch("backend.reasoning_agent.upsert_thing"), \
+             patch("backend.reasoning_agent.vs_delete"):
+            from backend.reasoning_agent import _make_reasoning_tools
+
+            tools, _ = _make_reasoning_tools("test-user")
+
+        # All tools should still have their original names (via functools.wraps)
+        names = [t.__name__ for t in tools]
+        assert names == [
+            "create_thing",
+            "update_thing",
+            "delete_thing",
+            "merge_things",
+            "create_relationship",
+        ]

--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -69,13 +69,16 @@ def shutdown_tracing() -> None:
         _initialized = False
 
 
-def get_tracer() -> Tracer:
-    """Return the pipeline tracer.
+def get_tracer(name: str = _TRACER_NAME) -> Tracer:
+    """Return an OTEL tracer.
 
-    Returns the no-op tracer when tracing is disabled, so callers never
-    need to check whether tracing is active.
+    When tracing is enabled, returns a real tracer from the configured provider.
+    When disabled, returns a no-op tracer (spans are created but discarded).
+
+    Args:
+        name: Tracer name for span attribution. Defaults to "reli.pipeline".
     """
-    return trace.get_tracer(_TRACER_NAME)
+    return trace.get_tracer(name)
 
 
 def set_span_error(span: trace.Span, exc: BaseException) -> None:


### PR DESCRIPTION
## Summary
- Add custom OpenTelemetry spans for tool calls and storage operations in reasoning agent
- Stage 3 of Phoenix observability setup

Part of #96

## Quality Gates
- Setup: PASSED
- Typecheck: PASSED
- Lint: PASSED
- Test: PASSED (327 passed)
- Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)