### PR TITLE
GH#111 FR-101: User Thing — always in context (re-mlzy)

### DIFF
--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -192,6 +192,34 @@ def _fetch_user_thing(conn: sqlite3.Connection, user_id: str) -> dict[str, Any] 
     return dict(row) if row else None
 
 
+def _fetch_user_connections(
+    conn: sqlite3.Connection,
+    user_thing_id: str,
+    user_id: str = "",
+) -> list[dict[str, Any]]:
+    """Fetch ALL 1-hop connections from the User Thing (unfiltered by search).
+
+    Returns relationship rows with resolved Thing titles for context injection.
+    """
+    if not user_thing_id:
+        return []
+
+    rows = conn.execute(
+        "SELECT r.relationship_type,"
+        "  CASE WHEN r.from_thing_id = ? THEN 'outgoing' ELSE 'incoming' END AS direction,"
+        "  CASE WHEN r.from_thing_id = ? THEN t_to.title ELSE t_from.title END AS related_title,"
+        "  CASE WHEN r.from_thing_id = ? THEN t_to.type_hint ELSE t_from.type_hint END AS related_type"
+        " FROM thing_relationships r"
+        " LEFT JOIN things t_from ON r.from_thing_id = t_from.id"
+        " LEFT JOIN things t_to ON r.to_thing_id = t_to.id"
+        " WHERE r.from_thing_id = ? OR r.to_thing_id = ?"
+        " ORDER BY r.created_at DESC"
+        " LIMIT 50",
+        (user_thing_id, user_thing_id, user_thing_id, user_thing_id, user_thing_id),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def _fetch_relevant_things(
     conn: sqlite3.Connection,
     search_queries: list[str],
@@ -382,10 +410,10 @@ class ChatPipeline:
         message: str,
         history: list[dict[str, Any]],
         usage: UsageStats,
-    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
         """Run context agent with iterative refinement and data gathering.
 
-        Returns (context_result, relevant_things, context_relationships).
+        Returns (context_result, relevant_things, context_relationships, user_connections).
         """
         context_result = await run_context_agent(
             message, history, usage_stats=usage, context_window=self.context_window,
@@ -500,6 +528,7 @@ class ChatPipeline:
 
         # Fetch relationships for all relevant things and update last_referenced
         context_relationships: list[dict[str, Any]] = []
+        user_connections: list[dict[str, Any]] = []
         if relevant_things:
             with db() as conn:
                 now = datetime.now(timezone.utc).isoformat()
@@ -517,12 +546,20 @@ class ChatPipeline:
                 ).fetchall()
                 context_relationships = [dict(r) for r in rel_rows]
 
+                # Fetch all User Thing connections (unfiltered) for always-in-context
+                user_thing = _fetch_user_thing(conn, self.user_id)
+                if user_thing:
+                    user_connections = _fetch_user_connections(
+                        conn, user_thing["id"], self.user_id,
+                    )
+
         logger.info(
-            "Final context: %d Things, %d relationships after up to %d iterations",
-            len(relevant_things), len(context_relationships), MAX_CONTEXT_ITERATIONS,
+            "Final context: %d Things, %d relationships, %d user connections after up to %d iterations",
+            len(relevant_things), len(context_relationships), len(user_connections),
+            MAX_CONTEXT_ITERATIONS,
         )
 
-        return context_result, relevant_things, context_relationships
+        return context_result, relevant_things, context_relationships, user_connections
 
     # ------------------------------------------------------------------
     # External data fetching
@@ -635,7 +672,7 @@ class ChatPipeline:
                     ctx_span.set_attribute("reli.context.model", self.user_models.get("context") or "default")
                     ctx_span.set_attribute("reli.context.max_iterations", MAX_CONTEXT_ITERATIONS)
                     try:
-                        context_result, relevant_things, context_relationships = (
+                        context_result, relevant_things, context_relationships, user_connections = (
                             await self._run_context_stage(message, history, usage)
                         )
                         ctx_span.set_attribute("reli.context.things_found", len(relevant_things))
@@ -666,6 +703,7 @@ class ChatPipeline:
                         reasoning_result = await run_reasoning_agent(
                             message, history, relevant_things, web_results, gmail_context,
                             calendar_events, relationships=context_relationships,
+                            user_connections=user_connections,
                             usage_stats=usage, context_window=self.context_window,
                             api_key=self.user_api_key, model=self.user_models.get("reasoning"),
                             user_id=self.user_id,
@@ -770,7 +808,7 @@ class ChatPipeline:
                     ctx_span.set_attribute("reli.context.model", self.user_models.get("context") or "default")
                     ctx_span.set_attribute("reli.context.max_iterations", MAX_CONTEXT_ITERATIONS)
                     try:
-                        context_result, relevant_things, context_relationships = (
+                        context_result, relevant_things, context_relationships, user_connections = (
                             await self._run_context_stage(message, history, usage)
                         )
                         ctx_span.set_attribute("reli.context.things_found", len(relevant_things))
@@ -805,6 +843,7 @@ class ChatPipeline:
                         reasoning_result = await run_reasoning_agent(
                             message, history, relevant_things, web_results, gmail_context,
                             calendar_events, relationships=context_relationships,
+                            user_connections=user_connections,
                             usage_stats=usage, context_window=self.context_window,
                             api_key=self.user_api_key, model=self.user_models.get("reasoning"),
                             user_id=self.user_id,

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -219,11 +219,23 @@ When referencing existing Things for relationships, use their IDs from the
 relevant Things list. For newly created Things, use the ID returned by
 create_thing.
 
+User Thing (Always in Context):
+The user's own Thing is provided in <user_thing> tags at the top of every
+message. It contains the user's profile, preferences, notes, and connections.
+- Use its ID as from_thing_id for relationships involving the user.
+- When the user shares personal preferences ("I prefer bullet points",
+  "I like morning reminders"), update the User Thing's data via update_thing
+  with the preferences in the data_json field.
+- When the user shares personal information ("I work at Acme", "my birthday
+  is March 5"), update the User Thing's data accordingly.
+- The User Thing's preferences and notes should inform your responses (e.g.
+  if the user noted "prefers concise responses", keep summaries short).
+
 Possessive Patterns:
 When the user uses possessive language ("my sister", "my doctor"), treat this
 as an implicit relationship declaration between the user and the entity:
 
-1. The first Thing in the Relevant Things list is always the user's own Thing.
+1. The user's own Thing is in the <user_thing> block above the Relevant Things.
    Use its ID as the from_thing_id for possessive relationships.
 2. Check the Relevant Things list for an existing Thing matching the entity.
    If found, reuse it instead of creating a duplicate.
@@ -755,6 +767,70 @@ def _make_reasoning_tools(
 # ---------------------------------------------------------------------------
 
 
+def _format_user_thing_context(
+    relevant_things: list[dict[str, Any]],
+    user_connections: list[dict[str, Any]] | None = None,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Extract the User Thing from relevant_things and format it as a dedicated context section.
+
+    Returns (user_context_block, remaining_things).
+    """
+    if not relevant_things:
+        return "", relevant_things
+
+    # The first Thing with type_hint='person' and surface=0 is the User Thing
+    user_thing = None
+    remaining: list[dict[str, Any]] = []
+    for t in relevant_things:
+        if user_thing is None and t.get("type_hint") == "person" and not t.get("surface"):
+            user_thing = t
+        else:
+            remaining.append(t)
+
+    if not user_thing:
+        return "", relevant_things
+
+    # Parse the User Thing's data for rich context
+    data = user_thing.get("data")
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+    elif data is None:
+        data = {}
+
+    lines = [
+        "<user_thing>",
+        f"ID: {user_thing['id']}",
+        f"Name: {user_thing.get('title', 'Unknown')}",
+    ]
+    # Include user profile fields (preferences, notes, custom data)
+    for key, value in data.items():
+        if key in ("google_id",):
+            continue  # skip internal fields
+        lines.append(f"{key}: {value}")
+
+    if user_connections:
+        conn_lines = []
+        for c in user_connections:
+            direction = c.get("direction", "outgoing")
+            rel_type = c.get("relationship_type", "related-to")
+            title = c.get("related_title", "Unknown")
+            thing_type = c.get("related_type", "")
+            type_str = f" ({thing_type})" if thing_type else ""
+            if direction == "outgoing":
+                conn_lines.append(f"  - {rel_type}: {title}{type_str}")
+            else:
+                conn_lines.append(f"  - {title}{type_str} [{rel_type}]")
+        if conn_lines:
+            lines.append("Connections:")
+            lines.extend(conn_lines)
+
+    lines.append("</user_thing>")
+    return "\n".join(lines), remaining
+
+
 async def run_reasoning_agent(
     message: str,
     history: list[dict[str, Any]],
@@ -763,6 +839,7 @@ async def run_reasoning_agent(
     gmail_context: list[dict[str, Any]] | None = None,
     calendar_events: list[dict[str, Any]] | None = None,
     relationships: list[dict[str, Any]] | None = None,
+    user_connections: list[dict[str, Any]] | None = None,
     usage_stats: UsageStats | None = None,
     context_window: int = 10,
     api_key: str | None = None,
@@ -779,9 +856,17 @@ async def run_reasoning_agent(
       - questions_for_user, priority_question, reasoning_summary, briefing_mode
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d (%A)")
-    things_json = json.dumps(relevant_things, default=str)
-    user_content = (
-        f"Today's date: {today}\n\n"
+
+    # Extract User Thing and format it as a dedicated context section
+    user_thing_block, other_things = _format_user_thing_context(
+        relevant_things, user_connections,
+    )
+
+    things_json = json.dumps(other_things, default=str)
+    user_content = f"Today's date: {today}\n\n"
+    if user_thing_block:
+        user_content += f"{user_thing_block}\n\n"
+    user_content += (
         f"<user_message>\n{message}\n</user_message>\n\n"
         f"Relevant Things from database:\n{things_json}"
     )

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -88,14 +88,25 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
                 (user_id, email, google_id, name, picture, now, now),
             )
-            _create_user_thing(conn, user_id, name, email, google_id, now)
+            _create_user_thing(conn, user_id, name, email, google_id, now, picture=picture)
     return user_id
 
 
-def _create_user_thing(conn: sqlite3.Connection, user_id: str, name: str, email: str, google_id: str, now: str) -> None:
+def _create_user_thing(
+    conn: sqlite3.Connection,
+    user_id: str,
+    name: str,
+    email: str,
+    google_id: str,
+    now: str,
+    picture: str | None = None,
+) -> None:
     """Create a Thing representing the user as their anchor node."""
     thing_id = str(uuid.uuid4())
-    data_json = json.dumps({"email": email, "google_id": google_id})
+    data: dict[str, str] = {"email": email, "google_id": google_id}
+    if picture:
+        data["picture"] = picture
+    data_json = json.dumps(data)
     conn.execute(
         """INSERT INTO things
            (id, title, type_hint, parent_id, checkin_date, priority, active, surface,


### PR DESCRIPTION
## Summary

- Create a User Thing on first login, auto-inject into context for every pipeline run
- User Thing updatable via conversation, connections loadable on demand
- Replaces user_preferences collection
- **Issue**: re-mlzy
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/re-mlzy@mmuyxj6i
- **Tests**: All passed (511 tests — 184 frontend, 327 backend)
- **Quality gates**: setup, typecheck, lint, build all passed

Part of #111

---
*Created by Gas Town Refinery*