### PR TITLE
GH#112 FR-102: Learnings as Things (re-hxd8)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -279,7 +279,8 @@ Respond with ONLY valid JSON matching this schema (no markdown, no explanation):
   (e.g. following relationships, referencing previously mentioned Things by ID).
   Empty array when not needed.
 - filter_params.active_only: true unless user asks about archived/all items
-- filter_params.type_hint: null or one of task|note|idea|project|goal|journal|person|place|event|concept|reference
+- filter_params.type_hint: null or one of task|note|idea|project|goal|journal|
+  person|place|event|concept|reference|learning
 - needs_web_search: true if the user is asking about external/real-world info
   that would benefit from a web search (current events, facts, how-to questions,
   product info, documentation, etc.). false for personal task management requests
@@ -296,6 +297,12 @@ Respond with ONLY valid JSON matching this schema (no markdown, no explanation):
 - include_calendar: true if the user asks about their schedule, calendar, meetings,
   events, availability, free time, what's coming up today/this week, or anything
   time/schedule related. Default false.
+
+Learnings: The database contains "learning" type Things — observations about the
+user's patterns and preferences. When the user asks about what Reli knows about
+them, their habits, preferences, or patterns, set type_hint to "learning" to
+retrieve relevant learnings. Also include learnings as additional search_queries
+when contextually relevant (e.g. user asks about a topic where a learning exists).
 """
 
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -57,6 +57,7 @@ _DEFAULT_THING_TYPES = [
     ("event", "📅", None),
     ("concept", "🧠", None),
     ("reference", "🔗", None),
+    ("learning", "🔍", None),
 ]
 
 

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -189,6 +189,13 @@ merge_things. Rules:
 - Only merge Things you are confident refer to the same entity. If uncertain,
   add a question to questions_for_user instead.
 
+Learning Things:
+NEVER create Things with type_hint "learning" during real-time conversation.
+Learning Things are ONLY created by the nightly sweep process. If you notice
+a pattern or preference about the user, note it in reasoning_summary — the
+sweep will pick it up later. Do NOT use the "LearnedAbout" relationship type
+during real-time chat either.
+
 Entity Types:
 When the user mentions people, places, events, concepts, or references, create
 entity Things to build a knowledge graph:
@@ -252,7 +259,7 @@ REASONING_AGENT_TOOL_SYSTEM = _TOOL_PREAMBLE + _TOOL_RULES
 # ---------------------------------------------------------------------------
 
 # Entity type_hints that default to surface=false
-_ENTITY_TYPES = {"person", "place", "event", "concept", "reference"}
+_ENTITY_TYPES = {"person", "place", "event", "concept", "reference", "learning"}
 
 
 def _make_reasoning_tools(

--- a/backend/routers/sweep.py
+++ b/backend/routers/sweep.py
@@ -1,13 +1,20 @@
-"""Sweep endpoints — run nightly sweep (SQL candidates + LLM reflection)."""
+"""Sweep endpoints — run nightly sweep (SQL candidates + LLM reflection + learnings)."""
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from ..sweep import ReflectionResult, collect_candidates, reflect_on_candidates
+from ..auth import require_user
+from ..sweep import (
+    LearningResult,
+    ReflectionResult,
+    collect_candidates,
+    generate_learnings,
+    reflect_on_candidates,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,17 +22,39 @@ router = APIRouter(prefix="/sweep", tags=["sweep"])
 
 
 @router.post("/run", summary="Run nightly sweep")
-async def run_sweep() -> dict[str, Any]:
-    """Run the full nightly sweep: SQL candidate collection + LLM reflection.
+async def run_sweep(user_id: str = Depends(require_user)) -> dict[str, Any]:
+    """Run the full nightly sweep: SQL candidates + LLM reflection + learning generation.
 
-    Returns the candidates found and the findings created by LLM reflection.
+    Returns the candidates found, findings created, and learnings generated.
     """
     candidates = collect_candidates()
-    result: ReflectionResult = await reflect_on_candidates(candidates)
+    reflection: ReflectionResult = await reflect_on_candidates(candidates)
+    learnings: LearningResult = await generate_learnings(user_id=user_id)
 
     return {
         "candidates_found": len(candidates),
-        "findings_created": result.findings_created,
-        "findings": result.findings,
+        "findings_created": reflection.findings_created,
+        "findings": reflection.findings,
+        "learnings_created": learnings.learnings_created,
+        "learnings": learnings.learnings,
+        "usage": {
+            "reflection": reflection.usage,
+            "learnings": learnings.usage,
+        },
+    }
+
+
+@router.post("/learnings", summary="Generate learnings from conversations")
+async def run_learning_generation(user_id: str = Depends(require_user)) -> dict[str, Any]:
+    """Run learning generation: analyze recent conversations to extract user patterns.
+
+    Creates Learning Things tagged #learning, connected to User Thing via
+    LearnedAbout relationship. This is the nightly sweep's learning phase.
+    """
+    result: LearningResult = await generate_learnings(user_id=user_id)
+
+    return {
+        "learnings_created": result.learnings_created,
+        "learnings": result.learnings,
         "usage": result.usage,
     }

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -162,6 +162,27 @@ def get_user_thing(user_id: str = Depends(require_user)) -> UserProfileDetail:
     return UserProfileDetail(thing=thing, relationships=relationships)
 
 
+@router.get("/learnings", response_model=list[Thing], summary="List user's learnings")
+def list_learnings(
+    active_only: bool = Query(True, description="Filter to active learnings only"),
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
+    user_id: str = Depends(require_user),
+) -> list[Thing]:
+    """Return Learning Things for the current user, ordered by recency."""
+    uf_sql, uf_params = user_filter(user_id)
+    sql = "SELECT * FROM things WHERE type_hint = 'learning'"
+    params: list = []
+    sql += uf_sql
+    params.extend(uf_params)
+    if active_only:
+        sql += " AND active = 1"
+    sql += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+    with db() as conn:
+        rows = conn.execute(sql, params).fetchall()
+    return [_row_to_thing(r) for r in rows]
+
+
 @router.get("/search", response_model=list[Thing], summary="Search Things across the full graph")
 def search_things(
     q: str = Query("", description="Free-text search query matched against title, data, type_hint, and relationships"),

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -527,3 +527,270 @@ async def reflect_on_candidates(
         findings=created,
         usage=usage_stats.to_dict(),
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Learning generation (FR-102)
+# ---------------------------------------------------------------------------
+
+LEARNING_GENERATION_SYSTEM = """\
+You are the Learning Analyst for Reli, an AI personal information manager.
+You review recent conversation history and existing Things to identify patterns,
+preferences, habits, and observations about the user.
+
+Your job: distill the user's conversations into concise learnings — things Reli
+has observed about how the user thinks, works, or lives. These become permanent
+knowledge that helps Reli serve the user better over time.
+
+Examples of good learnings:
+- "Alex prefers to break down work projects into small tasks before starting"
+- "Alex's approach to party planning is detail-oriented and starts weeks early"
+- "Alex tends to defer health-related tasks repeatedly"
+- "Alex values morning routines and plans around early meetings"
+
+Respond with ONLY valid JSON matching this schema (no markdown, no explanation):
+{
+  "learnings": [
+    {
+      "title": "Short, descriptive title of the learning",
+      "notes": "Detailed observation with supporting evidence from conversations",
+      "tags": ["learning"],
+      "related_thing_titles": ["Existing Thing titles this learning relates to"]
+    }
+  ]
+}
+
+Rules:
+- Each learning MUST be about the USER — their behavior, preferences, or patterns
+- tags: always include "learning". Add "user-pattern" for behavioral patterns
+- title: concise, reads as an observation (e.g. "Alex prefers morning meetings")
+- notes: 1-3 sentences explaining what was observed and why it matters
+- related_thing_titles: titles of existing Things this learning connects to
+  (people, projects, concepts, etc.). Empty list if none.
+- Return 0-5 learnings per sweep. Quality over quantity.
+- Do NOT repeat learnings that already exist (check the existing learnings list).
+- Do NOT fabricate — only create learnings supported by conversation evidence.
+- If there's nothing new to learn, return {"learnings": []}
+"""
+
+
+@dataclass
+class LearningResult:
+    """Result of the learning generation phase."""
+
+    learnings_created: int = 0
+    learnings: list[dict] = field(default_factory=list)
+    usage: dict = field(default_factory=dict)
+
+
+def _fetch_recent_conversations(
+    conn: sqlite3.Connection,
+    days: int = 7,
+    user_id: str = "",
+) -> list[dict]:
+    """Fetch recent user messages from chat_history for learning extraction."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    params: list = [cutoff]
+    uf = ""
+    if user_id:
+        uf = " AND user_id = ?"
+        params.append(user_id)
+    rows = conn.execute(
+        f"""SELECT role, content, timestamp FROM chat_history
+           WHERE role = 'user' AND timestamp > ?{uf}
+           ORDER BY timestamp DESC LIMIT 50""",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _fetch_existing_learnings(
+    conn: sqlite3.Connection,
+    user_id: str = "",
+) -> list[dict]:
+    """Fetch existing learning Things to avoid duplicates."""
+    params: list = []
+    uf = ""
+    if user_id:
+        uf = " AND user_id = ?"
+        params.append(user_id)
+    rows = conn.execute(
+        f"""SELECT id, title, data FROM things
+           WHERE type_hint = 'learning' AND active = 1{uf}""",
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _format_learning_prompt(
+    conversations: list[dict],
+    existing_learnings: list[dict],
+    things: list[dict],
+) -> str:
+    """Format conversation history and context for the learning LLM."""
+    lines = [f"Today: {date.today().isoformat()}", ""]
+
+    if existing_learnings:
+        lines.append(f"Existing learnings ({len(existing_learnings)}):")
+        for lg in existing_learnings:
+            lines.append(f"  - {lg['title']}")
+        lines.append("")
+
+    if things:
+        lines.append(f"User's Things ({len(things)}):")
+        for t in things[:30]:
+            lines.append(f"  - [{t.get('type_hint', 'thing')}] {t['title']}")
+        lines.append("")
+
+    if conversations:
+        lines.append(f"Recent conversations ({len(conversations)} messages):")
+        for c in conversations:
+            content = c["content"][:300]
+            lines.append(f"  [{c.get('timestamp', '')}] {content}")
+    else:
+        lines.append("No recent conversations.")
+
+    return "\n".join(lines)
+
+
+async def generate_learnings(
+    user_id: str = "",
+    days: int = 7,
+) -> LearningResult:
+    """Phase 3: Analyze conversations to generate Learning Things.
+
+    Reads recent chat history, identifies user patterns and preferences,
+    creates Learning Things tagged with #learning, and connects them to
+    the User Thing via LearnedAbout relationships and to relevant domain Things.
+
+    This should ONLY be called from the nightly sweep, not during real-time chat.
+    """
+    from .agents import UsageStats, _chat
+
+    usage_stats = UsageStats()
+
+    with db() as conn:
+        conversations = _fetch_recent_conversations(conn, days, user_id)
+        existing_learnings = _fetch_existing_learnings(conn, user_id)
+        things = conn.execute(
+            "SELECT id, title, type_hint, data FROM things WHERE active = 1"
+            + (" AND user_id = ?" if user_id else ""),
+            ([user_id] if user_id else []),
+        ).fetchall()
+        things_list = [dict(r) for r in things]
+
+    if not conversations:
+        logger.info("No recent conversations for learning generation")
+        return LearningResult(usage=usage_stats.to_dict())
+
+    prompt = _format_learning_prompt(conversations, existing_learnings, things_list)
+
+    raw = await _chat(
+        messages=[
+            {"role": "system", "content": LEARNING_GENERATION_SYSTEM},
+            {"role": "user", "content": prompt},
+        ],
+        model=None,
+        response_format={"type": "json_object"},
+        usage_stats=usage_stats,
+    )
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Learning generation returned invalid JSON: %s", raw[:200])
+        return LearningResult(usage=usage_stats.to_dict())
+
+    raw_learnings = parsed.get("learnings", [])
+    if not isinstance(raw_learnings, list):
+        raw_learnings = []
+
+    now = datetime.now(timezone.utc).isoformat()
+    created: list[dict] = []
+
+    with db() as conn:
+        # Find user Thing for LearnedAbout relationships
+        user_thing_row = conn.execute(
+            "SELECT id FROM things WHERE type_hint = 'person' AND surface = 0"
+            + (" AND user_id = ?" if user_id else "")
+            + " LIMIT 1",
+            ([user_id] if user_id else []),
+        ).fetchone()
+        user_thing_id = user_thing_row["id"] if user_thing_row else None
+
+        # Build title→id lookup for linking related Things
+        title_lookup: dict[str, str] = {}
+        for t in things_list:
+            title_lookup[t["title"].lower()] = t["id"]
+
+        for learning in raw_learnings:
+            if not isinstance(learning, dict):
+                continue
+            title = str(learning.get("title", "")).strip()
+            if not title:
+                continue
+
+            # Skip duplicates by title
+            existing_titles = {lg["title"].lower() for lg in existing_learnings}
+            if title.lower() in existing_titles:
+                logger.info("Skipping duplicate learning: %s", title)
+                continue
+
+            notes = str(learning.get("notes", "")).strip()
+            tags = learning.get("tags", ["learning"])
+            if not isinstance(tags, list):
+                tags = ["learning"]
+            if "learning" not in tags:
+                tags.insert(0, "learning")
+
+            data = {"notes": notes, "tags": tags}
+
+            learning_id = str(uuid.uuid4())
+            conn.execute(
+                """INSERT INTO things
+                   (id, title, type_hint, priority, active, surface, data,
+                    created_at, updated_at, user_id)
+                   VALUES (?, ?, 'learning', 3, 1, 0, ?, ?, ?, ?)""",
+                (learning_id, title, json.dumps(data), now, now, user_id or None),
+            )
+
+            # Create LearnedAbout relationship: User Thing → Learning
+            if user_thing_id:
+                rel_id = str(uuid.uuid4())
+                conn.execute(
+                    """INSERT INTO thing_relationships
+                       (id, from_thing_id, to_thing_id, relationship_type, created_at)
+                       VALUES (?, ?, ?, 'LearnedAbout', ?)""",
+                    (rel_id, user_thing_id, learning_id, now),
+                )
+
+            # Connect to related domain Things
+            related_titles = learning.get("related_thing_titles", [])
+            if isinstance(related_titles, list):
+                for rt in related_titles[:5]:
+                    rt_lower = str(rt).lower().strip()
+                    related_id = title_lookup.get(rt_lower)
+                    if related_id and related_id != learning_id:
+                        conn.execute(
+                            """INSERT INTO thing_relationships
+                               (id, from_thing_id, to_thing_id, relationship_type,
+                                created_at)
+                               VALUES (?, ?, ?, 'related-to', ?)""",
+                            (str(uuid.uuid4()), learning_id, related_id, now),
+                        )
+
+            created.append({
+                "id": learning_id,
+                "title": title,
+                "tags": tags,
+                "notes": notes,
+            })
+            # Track to avoid creating more duplicates within same batch
+            existing_learnings.append({"title": title})
+
+    logger.info("Generated %d learnings from conversations", len(created))
+    return LearningResult(
+        learnings_created=len(created),
+        learnings=created,
+        usage=usage_stats.to_dict(),
+    )

--- a/backend/tests/test_learnings.py
+++ b/backend/tests/test_learnings.py
@@ -1,0 +1,325 @@
+"""Tests for FR-102: Learnings as Things — sweep generation and API endpoints."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.database import db
+from backend.sweep import (
+    _fetch_existing_learnings,
+    _fetch_recent_conversations,
+    _format_learning_prompt,
+    generate_learnings,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_thing(
+    conn,
+    thing_id: str,
+    title: str,
+    *,
+    type_hint: str | None = None,
+    surface: bool = True,
+    active: bool = True,
+    data: dict | None = None,
+    user_id: str | None = None,
+) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """INSERT INTO things
+           (id, title, type_hint, active, surface, data, created_at, updated_at, user_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            thing_id,
+            title,
+            type_hint,
+            int(active),
+            int(surface),
+            json.dumps(data) if data else None,
+            now,
+            now,
+            user_id,
+        ),
+    )
+
+
+def _insert_chat_message(conn, content: str, role: str = "user", user_id: str | None = None) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """INSERT INTO chat_history (session_id, role, content, timestamp, user_id)
+           VALUES (?, ?, ?, ?, ?)""",
+        (str(uuid.uuid4()), role, content, now, user_id),
+    )
+
+
+def _insert_relationship(conn, from_id: str, to_id: str, rel_type: str) -> None:
+    conn.execute(
+        """INSERT INTO thing_relationships (id, from_thing_id, to_thing_id, relationship_type)
+           VALUES (?, ?, ?, ?)""",
+        (str(uuid.uuid4()), from_id, to_id, rel_type),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRecentConversations:
+    def test_returns_user_messages(self, patched_db):
+        with db() as conn:
+            _insert_chat_message(conn, "Hello, what's on my plate?")
+            _insert_chat_message(conn, "I prefer morning meetings")
+            _insert_chat_message(conn, "Agent response", role="assistant")
+        with db() as conn:
+            results = _fetch_recent_conversations(conn, days=7)
+        assert len(results) == 2
+        assert all(r["role"] == "user" for r in results)
+
+    def test_empty_history(self, patched_db):
+        with db() as conn:
+            results = _fetch_recent_conversations(conn, days=7)
+        assert results == []
+
+
+class TestFetchExistingLearnings:
+    def test_returns_learning_things(self, patched_db):
+        with db() as conn:
+            _insert_thing(conn, "l1", "User prefers mornings", type_hint="learning")
+            _insert_thing(conn, "t1", "Some task", type_hint="task")
+        with db() as conn:
+            results = _fetch_existing_learnings(conn)
+        assert len(results) == 1
+        assert results[0]["title"] == "User prefers mornings"
+
+    def test_excludes_inactive(self, patched_db):
+        with db() as conn:
+            _insert_thing(conn, "l1", "Old learning", type_hint="learning", active=False)
+        with db() as conn:
+            results = _fetch_existing_learnings(conn)
+        assert results == []
+
+
+class TestFormatLearningPrompt:
+    def test_includes_conversations(self):
+        convos = [{"content": "I like mornings", "timestamp": "2026-03-17"}]
+        result = _format_learning_prompt(convos, [], [])
+        assert "I like mornings" in result
+
+    def test_includes_existing_learnings(self):
+        learnings = [{"title": "User prefers mornings"}]
+        result = _format_learning_prompt([], learnings, [])
+        assert "User prefers mornings" in result
+
+    def test_includes_things(self):
+        things = [{"title": "Budget project", "type_hint": "project"}]
+        result = _format_learning_prompt([], [], things)
+        assert "Budget project" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_learnings integration test
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateLearnings:
+    @pytest.mark.asyncio
+    async def test_creates_learning_things(self, patched_db):
+        """Learning generation creates Things with correct type, tags, and relationships."""
+        with db() as conn:
+            _insert_thing(conn, "user-1", "Alex", type_hint="person", surface=False)
+            _insert_thing(conn, "proj-1", "Budget project", type_hint="project")
+            _insert_chat_message(conn, "I always break down projects before starting")
+            _insert_chat_message(conn, "Morning meetings work best for me")
+
+        llm_response = json.dumps({
+            "learnings": [
+                {
+                    "title": "Alex breaks down projects before starting",
+                    "notes": "Observed from conversation about project approach",
+                    "tags": ["learning", "user-pattern"],
+                    "related_thing_titles": ["Budget project"],
+                },
+            ]
+        })
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            result = await generate_learnings()
+
+        assert result.learnings_created == 1
+        assert result.learnings[0]["title"] == "Alex breaks down projects before starting"
+        assert "learning" in result.learnings[0]["tags"]
+
+        # Verify the Thing was created in the database
+        with db() as conn:
+            row = conn.execute(
+                "SELECT * FROM things WHERE type_hint = 'learning'"
+            ).fetchone()
+            assert row is not None
+            assert row["title"] == "Alex breaks down projects before starting"
+            assert row["surface"] == 0  # learnings are not surfaced
+            data = json.loads(row["data"])
+            assert "learning" in data["tags"]
+
+            # Verify LearnedAbout relationship to user Thing
+            rels = conn.execute(
+                "SELECT * FROM thing_relationships WHERE relationship_type = 'LearnedAbout'"
+            ).fetchall()
+            assert len(rels) == 1
+            assert rels[0]["from_thing_id"] == "user-1"
+            assert rels[0]["to_thing_id"] == row["id"]
+
+            # Verify related-to relationship to domain Thing
+            domain_rels = conn.execute(
+                "SELECT * FROM thing_relationships WHERE from_thing_id = ? AND relationship_type = 'related-to'",
+                (row["id"],),
+            ).fetchall()
+            assert len(domain_rels) == 1
+            assert domain_rels[0]["to_thing_id"] == "proj-1"
+
+    @pytest.mark.asyncio
+    async def test_no_conversations_returns_empty(self, patched_db):
+        """No recent conversations means no learnings generated."""
+        result = await generate_learnings()
+        assert result.learnings_created == 0
+        assert result.learnings == []
+
+    @pytest.mark.asyncio
+    async def test_skips_duplicate_learnings(self, patched_db):
+        """Learnings with same title as existing ones are skipped."""
+        with db() as conn:
+            _insert_thing(conn, "l1", "Alex prefers mornings", type_hint="learning")
+            _insert_chat_message(conn, "I like mornings")
+
+        llm_response = json.dumps({
+            "learnings": [
+                {
+                    "title": "Alex prefers mornings",
+                    "notes": "Duplicate",
+                    "tags": ["learning"],
+                    "related_thing_titles": [],
+                },
+            ]
+        })
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            result = await generate_learnings()
+
+        assert result.learnings_created == 0
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_empty(self, patched_db):
+        """Invalid LLM response returns empty result."""
+        with db() as conn:
+            _insert_chat_message(conn, "Something")
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value="not json"):
+            result = await generate_learnings()
+
+        assert result.learnings_created == 0
+
+    @pytest.mark.asyncio
+    async def test_ensures_learning_tag(self, patched_db):
+        """The 'learning' tag is always present even if LLM doesn't include it."""
+        with db() as conn:
+            _insert_thing(conn, "user-1", "Alex", type_hint="person", surface=False)
+            _insert_chat_message(conn, "I delegate well")
+
+        llm_response = json.dumps({
+            "learnings": [
+                {
+                    "title": "Alex delegates effectively",
+                    "notes": "Good at delegation",
+                    "tags": ["user-pattern"],
+                    "related_thing_titles": [],
+                },
+            ]
+        })
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            result = await generate_learnings()
+
+        assert result.learnings_created == 1
+        assert "learning" in result.learnings[0]["tags"]
+
+        with db() as conn:
+            row = conn.execute("SELECT data FROM things WHERE type_hint = 'learning'").fetchone()
+            data = json.loads(row["data"])
+            assert "learning" in data["tags"]
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLearningsEndpoint:
+    def test_list_learnings_empty(self, client):
+        resp = client.get("/api/things/learnings")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_learnings_returns_only_learnings(self, client):
+        with db() as conn:
+            _insert_thing(conn, "l1", "User prefers mornings", type_hint="learning", surface=False)
+            _insert_thing(conn, "t1", "Some task", type_hint="task")
+        resp = client.get("/api/things/learnings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "User prefers mornings"
+        assert data[0]["type_hint"] == "learning"
+
+    def test_list_learnings_excludes_inactive(self, client):
+        with db() as conn:
+            _insert_thing(conn, "l1", "Active learning", type_hint="learning")
+            _insert_thing(conn, "l2", "Inactive learning", type_hint="learning", active=False)
+        resp = client.get("/api/things/learnings")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_list_learnings_includes_inactive_when_requested(self, client):
+        with db() as conn:
+            _insert_thing(conn, "l1", "Active", type_hint="learning")
+            _insert_thing(conn, "l2", "Inactive", type_hint="learning", active=False)
+        resp = client.get("/api/things/learnings?active_only=false")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+
+class TestSweepLearningsEndpoint:
+    @pytest.mark.asyncio
+    async def test_learning_generation_endpoint(self, async_client, patched_db):
+        with db() as conn:
+            _insert_chat_message(conn, "I prefer detailed plans")
+
+        llm_response = json.dumps({"learnings": []})
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            resp = await async_client.post("/api/sweep/learnings")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "learnings_created" in data
+        assert "learnings" in data
+
+
+# ---------------------------------------------------------------------------
+# Learning type in thing types
+# ---------------------------------------------------------------------------
+
+
+class TestLearningThingType:
+    def test_learning_type_seeded(self, patched_db):
+        with db() as conn:
+            row = conn.execute(
+                "SELECT * FROM thing_types WHERE name = 'learning'"
+            ).fetchone()
+        assert row is not None
+        assert row["icon"] == "🔍"


### PR DESCRIPTION
## Summary

- Implement Learnings as Things — sweep learnings stored as first-class Things
- **Issue**: re-hxd8
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/re-hxd8@mmuzzzyi
- **Tests**: All passed (529 tests — 184 frontend, 345 backend)
- **Quality gates**: setup, typecheck, lint, build all passed

Part of #112

---
*Created by Gas Town Refinery*