### PR TITLE
Fix Gemini thought_signature error breaking chat (re-xai6)

### DIFF
--- a/backend/context_agent.py
+++ b/backend/context_agent.py
@@ -51,8 +51,13 @@ def _strip_markdown_fences(text: str) -> str:
 def _make_litellm_model(
     model: str | None = None,
     api_key: str | None = None,
+    **kwargs: Any,
 ) -> LiteLlm:
-    """Create a LiteLlm model instance configured for Requesty."""
+    """Create a LiteLlm model instance configured for Requesty.
+
+    Extra kwargs are forwarded to the LiteLlm constructor and ultimately to
+    litellm's completion call (e.g. ``extra_body`` for provider-specific params).
+    """
     effective_model = model or REQUESTY_MODEL
     # LiteLlm expects the openai/ prefix for OpenAI-compatible providers
     if not effective_model.startswith("openai/"):
@@ -61,6 +66,7 @@ def _make_litellm_model(
         model=effective_model,
         api_key=api_key or REQUESTY_API_KEY,
         api_base=REQUESTY_BASE_URL,
+        **kwargs,
     )
 
 

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -840,8 +840,14 @@ async def run_reasoning_agent(
     # -- ADK path with tool calling --
     tools, applied_changes = _make_reasoning_tools(user_id)
 
+    # Disable thinking to avoid thought_signature errors.  Gemini 2.5 Flash
+    # attaches thought_signatures to function-call parts when thinking is on;
+    # these signatures are lost when routing through OpenAI-compatible
+    # providers (Requesty), causing "missing thought_signature" rejections.
     litellm_model = _make_litellm_model(
-        model=model or REQUESTY_REASONING_MODEL, api_key=api_key
+        model=model or REQUESTY_REASONING_MODEL,
+        api_key=api_key,
+        extra_body={"thinking_config": {"thinking_budget": 0}},
     )
 
     reasoning_agent = LlmAgent(

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -596,3 +596,40 @@ def test_tool_system_prompt_no_json_output_schema():
     from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
 
     assert '"storage_changes"' not in REASONING_AGENT_TOOL_SYSTEM
+
+
+# ---------------------------------------------------------------------------
+# Thinking disabled regression test (re-xai6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reasoning_agent_disables_thinking():
+    """LiteLlm model for reasoning agent must disable thinking to avoid
+    thought_signature errors when routing through OpenAI-compatible providers."""
+    metadata = {"reasoning_summary": "test"}
+
+    with patch("backend.reasoning_agent._run_agent_for_text") as mock_run, \
+         patch("backend.reasoning_agent._make_reasoning_tools") as mock_make, \
+         patch("backend.reasoning_agent._make_litellm_model") as mock_factory, \
+         patch("backend.reasoning_agent.LlmAgent"):
+        mock_run.return_value = json.dumps(metadata)
+        mock_make.return_value = (
+            [MagicMock() for _ in range(5)],
+            {"created": [], "updated": [], "deleted": [], "merged": [], "relationships_created": []},
+        )
+        mock_factory.return_value = MagicMock()
+
+        from backend.reasoning_agent import run_reasoning_agent
+
+        await run_reasoning_agent(
+            "test", [], [], api_key="k", user_id="u",
+        )
+
+    # Verify _make_litellm_model was called with thinking disabled
+    mock_factory.assert_called_once()
+    call_kwargs = mock_factory.call_args
+    extra_body = call_kwargs.kwargs.get("extra_body")
+    assert extra_body is not None, "extra_body must be passed to disable thinking"
+    assert extra_body.get("thinking_config", {}).get("thinking_budget") == 0, \
+        "thinking_budget must be 0 to prevent thought_signature errors"


### PR DESCRIPTION
## Summary

- **Issue**: re-xai6 (P0 bug)
- **Polecat**: furiosa
- **Branch**: polecat/furiosa/re-xai6@mmvbft2q
- **Tests**: All passed (328 backend + 184 frontend, verified by refinery)

Fixes Gemini thought_signature error that crashes the entire chat pipeline when using google/gemini-2.5-flash with tool calls.

---
*Created by Gas Town Refinery*