### PR TITLE
feat: per-user processing and reasoning model for sweep (re-jom0)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -207,6 +207,28 @@ def _migrate_backfill_null_user_ids(conn: sqlite3.Connection) -> None:
         conn.execute(f"UPDATE {table} SET user_id = ? WHERE user_id IS NULL", (uid,))
 
 
+def _migrate_sweep_runs(conn: sqlite3.Connection) -> None:
+    """Create sweep_runs table for logging sweep execution history."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sweep_runs (
+            id TEXT PRIMARY KEY,
+            user_id TEXT REFERENCES users(id),
+            status TEXT NOT NULL DEFAULT 'running',
+            candidates_found INTEGER DEFAULT 0,
+            findings_created INTEGER DEFAULT 0,
+            model TEXT,
+            prompt_tokens INTEGER DEFAULT 0,
+            completion_tokens INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0,
+            error TEXT,
+            started_at TIMESTAMP NOT NULL,
+            completed_at TIMESTAMP
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_sweep_runs_user ON sweep_runs(user_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_sweep_runs_started ON sweep_runs(started_at)")
+
+
 def _migrate_merge_history(conn: sqlite3.Connection) -> None:
     """Create merge_history table to track Thing merges."""
     conn.execute("""
@@ -382,4 +404,5 @@ def init_db() -> None:
         _migrate_backfill_null_user_ids(conn)
         _migrate_user_settings(conn)
         _migrate_merge_history(conn)
+        _migrate_sweep_runs(conn)
         _seed_thing_types(conn)

--- a/backend/routers/sweep.py
+++ b/backend/routers/sweep.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ..auth import require_user, user_filter
+from ..database import db
 from ..sweep import ReflectionResult, collect_candidates, reflect_on_candidates
 
 logger = logging.getLogger(__name__)
@@ -15,13 +17,13 @@ router = APIRouter(prefix="/sweep", tags=["sweep"])
 
 
 @router.post("/run", summary="Run nightly sweep")
-async def run_sweep() -> dict[str, Any]:
+async def run_sweep(user_id: str = Depends(require_user)) -> dict[str, Any]:
     """Run the full nightly sweep: SQL candidate collection + LLM reflection.
 
     Returns the candidates found and the findings created by LLM reflection.
     """
-    candidates = collect_candidates()
-    result: ReflectionResult = await reflect_on_candidates(candidates)
+    candidates = collect_candidates(user_id=user_id)
+    result: ReflectionResult = await reflect_on_candidates(candidates, user_id=user_id)
 
     return {
         "candidates_found": len(candidates),
@@ -29,3 +31,22 @@ async def run_sweep() -> dict[str, Any]:
         "findings": result.findings,
         "usage": result.usage,
     }
+
+
+@router.get("/runs", summary="List sweep run history")
+def list_sweep_runs(
+    limit: int = 20,
+    user_id: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Return recent sweep run history for the current user."""
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        rows = conn.execute(
+            f"""SELECT * FROM sweep_runs
+               WHERE 1=1{uf_sql}
+               ORDER BY started_at DESC
+               LIMIT ?""",
+            (*uf_params, limit),
+        ).fetchall()
+
+    return [dict(row) for row in rows]

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -23,6 +23,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 
+from .auth import user_filter
 from .database import db
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,7 @@ def find_approaching_dates(
     conn: sqlite3.Connection,
     today: date | None = None,
     window_days: int = 7,
+    user_id: str = "",
 ) -> list[SweepCandidate]:
     """Find Things with dates (checkin_date or data JSON dates) within *window_days*.
 
@@ -124,14 +126,15 @@ def find_approaching_dates(
     today = today or date.today()
     cutoff = today + timedelta(days=window_days)
     candidates: list[SweepCandidate] = []
+    uf_sql, uf_params = user_filter(user_id)
 
     # 1. checkin_date column (already in ISO format)
     rows = conn.execute(
-        """SELECT id, title, checkin_date FROM things
+        f"""SELECT id, title, checkin_date FROM things
            WHERE active = 1
              AND checkin_date IS NOT NULL
-             AND DATE(checkin_date) BETWEEN ? AND ?""",
-        (today.isoformat(), cutoff.isoformat()),
+             AND DATE(checkin_date) BETWEEN ? AND ?{uf_sql}""",
+        (today.isoformat(), cutoff.isoformat(), *uf_params),
     ).fetchall()
     for row in rows:
         parsed = _parse_date_value(row["checkin_date"])
@@ -156,9 +159,10 @@ def find_approaching_dates(
 
     # 2. Date fields in the data JSON
     data_rows = conn.execute(
-        """SELECT id, title, data FROM things
+        f"""SELECT id, title, data FROM things
            WHERE active = 1
-             AND data IS NOT NULL AND data != '{}' AND data != 'null'"""
+             AND data IS NOT NULL AND data != '{{}}' AND data != 'null'{uf_sql}""",
+        uf_params,
     ).fetchall()
     for row in data_rows:
         try:
@@ -206,16 +210,18 @@ def find_stale_things(
     conn: sqlite3.Connection,
     today: date | None = None,
     stale_days: int = 14,
+    user_id: str = "",
 ) -> list[SweepCandidate]:
     """Find active Things not updated in *stale_days* or more."""
     today = today or date.today()
     cutoff = (today - timedelta(days=stale_days)).isoformat()
+    uf_sql, uf_params = user_filter(user_id)
     rows = conn.execute(
-        """SELECT id, title, type_hint, updated_at FROM things
+        f"""SELECT id, title, type_hint, updated_at FROM things
            WHERE active = 1
-             AND updated_at < ?
+             AND updated_at < ?{uf_sql}
            ORDER BY updated_at ASC""",
-        (cutoff,),
+        (cutoff, *uf_params),
     ).fetchall()
 
     candidates: list[SweepCandidate] = []
@@ -236,16 +242,18 @@ def find_stale_things(
     return candidates
 
 
-def find_orphan_things(conn: sqlite3.Connection) -> list[SweepCandidate]:
+def find_orphan_things(conn: sqlite3.Connection, user_id: str = "") -> list[SweepCandidate]:
     """Find active Things with no relationships (no parent, no children, no graph edges)."""
+    uf_sql, uf_params = user_filter(user_id, "t")
     rows = conn.execute(
-        """SELECT t.id, t.title, t.type_hint FROM things t
+        f"""SELECT t.id, t.title, t.type_hint FROM things t
            LEFT JOIN thing_relationships r
              ON t.id = r.from_thing_id OR t.id = r.to_thing_id
            WHERE t.active = 1
              AND t.parent_id IS NULL
-             AND r.id IS NULL
-           ORDER BY t.created_at DESC"""
+             AND r.id IS NULL{uf_sql}
+           ORDER BY t.created_at DESC""",
+        uf_params,
     ).fetchall()
 
     candidates: list[SweepCandidate] = []
@@ -263,7 +271,7 @@ def find_orphan_things(conn: sqlite3.Connection) -> list[SweepCandidate]:
     return candidates
 
 
-def find_completed_projects(conn: sqlite3.Connection) -> list[SweepCandidate]:
+def find_completed_projects(conn: sqlite3.Connection, user_id: str = "") -> list[SweepCandidate]:
     """Find active projects where all children are inactive (completed).
 
     A project qualifies if:
@@ -271,16 +279,18 @@ def find_completed_projects(conn: sqlite3.Connection) -> list[SweepCandidate]:
     - It has at least one child (via parent_id)
     - ALL of its children are inactive
     """
+    uf_sql, uf_params = user_filter(user_id, "p")
     rows = conn.execute(
-        """SELECT p.id, p.title,
+        f"""SELECT p.id, p.title,
                   COUNT(c.id) AS total_children,
                   SUM(CASE WHEN c.active = 0 THEN 1 ELSE 0 END) AS inactive_children
            FROM things p
            JOIN things c ON c.parent_id = p.id
            WHERE p.active = 1
-             AND p.type_hint = 'project'
+             AND p.type_hint = 'project'{uf_sql}
            GROUP BY p.id
-           HAVING total_children > 0 AND total_children = inactive_children"""
+           HAVING total_children > 0 AND total_children = inactive_children""",
+        uf_params,
     ).fetchall()
 
     candidates: list[SweepCandidate] = []
@@ -299,14 +309,16 @@ def find_completed_projects(conn: sqlite3.Connection) -> list[SweepCandidate]:
     return candidates
 
 
-def find_open_questions(conn: sqlite3.Connection) -> list[SweepCandidate]:
+def find_open_questions(conn: sqlite3.Connection, user_id: str = "") -> list[SweepCandidate]:
     """Find active Things that have unanswered open_questions."""
+    uf_sql, uf_params = user_filter(user_id)
     rows = conn.execute(
-        """SELECT id, title, open_questions FROM things
+        f"""SELECT id, title, open_questions FROM things
            WHERE active = 1
              AND open_questions IS NOT NULL
              AND open_questions != '[]'
-             AND open_questions != 'null'"""
+             AND open_questions != 'null'{uf_sql}""",
+        uf_params,
     ).fetchall()
 
     candidates: list[SweepCandidate] = []
@@ -343,6 +355,7 @@ def collect_candidates(
     today: date | None = None,
     window_days: int = 7,
     stale_days: int = 14,
+    user_id: str = "",
 ) -> list[SweepCandidate]:
     """Run all SQL candidate queries and return a combined, deduplicated list.
 
@@ -353,11 +366,11 @@ def collect_candidates(
 
     with db() as conn:
         candidates = (
-            find_approaching_dates(conn, today, window_days)
-            + find_stale_things(conn, today, stale_days)
-            + find_orphan_things(conn)
-            + find_completed_projects(conn)
-            + find_open_questions(conn)
+            find_approaching_dates(conn, today, window_days, user_id=user_id)
+            + find_stale_things(conn, today, stale_days, user_id=user_id)
+            + find_orphan_things(conn, user_id=user_id)
+            + find_completed_projects(conn, user_id=user_id)
+            + find_open_questions(conn, user_id=user_id)
         )
 
     # Deduplicate: keep the highest-priority (lowest number) candidate per (thing_id, finding_type)
@@ -414,6 +427,11 @@ Rules:
 - Keep findings to 3-8 items. Quality over quantity.
 - Don't just repeat what the SQL queries found — add insight and connections.
 - If candidates are empty or trivial, return {"findings": []} — don't fabricate.
+
+GUARD RAILS — you MUST follow these:
+- NEVER suggest deleting any Thing. You may only propose creating, updating, or reviewing.
+- Your output is advisory — you create findings (observations), never modify data directly.
+- When in doubt, surface information rather than recommend destructive action.
 """
 
 
@@ -443,16 +461,17 @@ def _format_candidates_for_llm(candidates: list[SweepCandidate]) -> str:
 
 async def reflect_on_candidates(
     candidates: list[SweepCandidate] | None = None,
+    user_id: str = "",
 ) -> ReflectionResult:
     """Phase 2: Send SQL candidates to LLM for nuanced reflection.
 
     If *candidates* is None, runs collect_candidates() first.
     Returns a ReflectionResult with the findings created in sweep_findings.
     """
-    from .agents import UsageStats, _chat
+    from .agents import REQUESTY_REASONING_MODEL, UsageStats, _chat
 
     if candidates is None:
-        candidates = collect_candidates()
+        candidates = collect_candidates(user_id=user_id)
 
     usage_stats = UsageStats()
     prompt = _format_candidates_for_llm(candidates)
@@ -462,7 +481,7 @@ async def reflect_on_candidates(
             {"role": "system", "content": SWEEP_REFLECTION_SYSTEM},
             {"role": "user", "content": prompt},
         ],
-        model=None,  # uses default context model (cheapest)
+        model=REQUESTY_REASONING_MODEL,
         response_format={"type": "json_object"},
         usage_stats=usage_stats,
     )
@@ -507,9 +526,9 @@ async def reflect_on_candidates(
             finding_id = f"sf-{uuid.uuid4().hex[:8]}"
             conn.execute(
                 """INSERT INTO sweep_findings
-                   (id, thing_id, finding_type, message, priority, dismissed, created_at, expires_at)
-                   VALUES (?, ?, ?, ?, ?, 0, ?, ?)""",
-                (finding_id, thing_id, "llm_insight", message, priority, now.isoformat(), expires_at),
+                   (id, thing_id, finding_type, message, priority, dismissed, created_at, expires_at, user_id)
+                   VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)""",
+                (finding_id, thing_id, "llm_insight", message, priority, now.isoformat(), expires_at, user_id or None),
             )
             created.append(
                 {

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -4,16 +4,17 @@ Default schedule: daily at 03:00 local time.  Configurable via the
 ``SWEEP_HOUR`` (0-23) and ``SWEEP_MINUTE`` (0-59) environment variables.
 Set ``SWEEP_ENABLED=false`` to disable entirely.
 
-The scheduler runs the SQL candidate phase first.  If candidates are found,
-it proceeds to the LLM reflection phase.  Errors are logged but never
-propagate to the main application.
+The scheduler iterates over all users, running the SQL candidate phase and
+LLM reflection phase per-user.  Each run is logged in the sweep_runs table.
+Errors are logged but never propagate to the main application.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+import uuid
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -43,28 +44,127 @@ def _seconds_until(hour: int, minute: int) -> float:
     return (target - now).total_seconds()
 
 
-async def _run_sweep() -> None:
-    """Execute one sweep cycle: SQL candidates → optional LLM reflection."""
+def _get_all_user_ids() -> list[str]:
+    """Return all user IDs from the database. Returns [''] if no users exist."""
+    from .database import db
+
+    with db() as conn:
+        rows = conn.execute("SELECT id FROM users ORDER BY created_at").fetchall()
+    if not rows:
+        return [""]  # No users — run in legacy single-user mode
+    return [row["id"] for row in rows]
+
+
+def _log_run(
+    run_id: str,
+    user_id: str,
+    status: str,
+    candidates_found: int = 0,
+    findings_created: int = 0,
+    model: str | None = None,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    cost_usd: float = 0.0,
+    error: str | None = None,
+    started_at: str = "",
+    completed_at: str | None = None,
+) -> None:
+    """Insert or update a sweep run record."""
+    from .database import db
+
+    with db() as conn:
+        conn.execute(
+            """INSERT INTO sweep_runs
+               (id, user_id, status, candidates_found, findings_created,
+                model, prompt_tokens, completion_tokens, cost_usd,
+                error, started_at, completed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                 status=excluded.status,
+                 candidates_found=excluded.candidates_found,
+                 findings_created=excluded.findings_created,
+                 model=excluded.model,
+                 prompt_tokens=excluded.prompt_tokens,
+                 completion_tokens=excluded.completion_tokens,
+                 cost_usd=excluded.cost_usd,
+                 error=excluded.error,
+                 completed_at=excluded.completed_at""",
+            (
+                run_id,
+                user_id or None,
+                status,
+                candidates_found,
+                findings_created,
+                model,
+                prompt_tokens,
+                completion_tokens,
+                cost_usd,
+                error,
+                started_at,
+                completed_at,
+            ),
+        )
+
+
+async def _run_sweep_for_user(user_id: str) -> None:
+    """Execute one sweep cycle for a single user."""
     from .sweep import collect_candidates, reflect_on_candidates
 
-    logger.info("Sweep started")
+    run_id = f"sr-{uuid.uuid4().hex[:8]}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    _log_run(run_id, user_id, status="running", started_at=now)
 
     try:
-        candidates = collect_candidates()
-        logger.info("Sweep SQL phase: %d candidates found", len(candidates))
+        candidates = collect_candidates(user_id=user_id)
+        user_label = user_id[:8] if user_id else "legacy"
+        logger.info("Sweep [%s] SQL phase: %d candidates found", user_label, len(candidates))
 
         if not candidates:
-            logger.info("Sweep complete — no candidates, skipping LLM phase")
+            _log_run(
+                run_id, user_id, status="completed",
+                candidates_found=0, findings_created=0,
+                started_at=now, completed_at=datetime.now(timezone.utc).isoformat(),
+            )
             return
 
-        result = await reflect_on_candidates(candidates)
-        logger.info(
-            "Sweep complete — %d findings created (usage: %s)",
-            result.findings_created,
-            result.usage,
+        result = await reflect_on_candidates(candidates, user_id=user_id)
+        _log_run(
+            run_id, user_id, status="completed",
+            candidates_found=len(candidates),
+            findings_created=result.findings_created,
+            model=result.usage.get("model"),
+            prompt_tokens=result.usage.get("prompt_tokens", 0),
+            completion_tokens=result.usage.get("completion_tokens", 0),
+            cost_usd=result.usage.get("cost_usd", 0.0),
+            started_at=now, completed_at=datetime.now(timezone.utc).isoformat(),
         )
-    except Exception:
-        logger.exception("Sweep failed")
+        logger.info(
+            "Sweep [%s] complete — %d findings created (usage: %s)",
+            user_label, result.findings_created, result.usage,
+        )
+    except Exception as exc:
+        logger.exception("Sweep failed for user %s", user_id)
+        _log_run(
+            run_id, user_id, status="failed",
+            error=str(exc),
+            started_at=now, completed_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+
+async def _run_sweep() -> None:
+    """Execute one sweep cycle: iterate over all users."""
+    logger.info("Sweep started")
+    user_ids = _get_all_user_ids()
+    logger.info("Sweep processing %d user(s)", len(user_ids))
+
+    for user_id in user_ids:
+        try:
+            await _run_sweep_for_user(user_id)
+        except Exception:
+            logger.exception("Sweep failed for user %s", user_id)
+
+    logger.info("Sweep cycle complete")
 
 
 async def sweep_loop() -> None:

--- a/backend/tests/test_sweep_reflection.py
+++ b/backend/tests/test_sweep_reflection.py
@@ -310,3 +310,9 @@ class TestSweepRouter:
         assert "findings_created" in data
         assert data["findings_created"] == 1
         assert "usage" in data
+
+    @pytest.mark.asyncio
+    async def test_run_sweep_endpoint_returns_run_history(self, async_client, patched_db):
+        resp = await async_client.get("/api/sweep/runs")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)

--- a/backend/tests/test_sweep_scheduler.py
+++ b/backend/tests/test_sweep_scheduler.py
@@ -9,8 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.sweep_scheduler import (
+    _get_all_user_ids,
     _get_config,
+    _log_run,
     _run_sweep,
+    _run_sweep_for_user,
     _seconds_until,
     start_scheduler,
     stop_scheduler,
@@ -77,65 +80,145 @@ class TestSecondsUntil:
             assert _seconds_until(h, 0) > 0
 
 
+class TestGetAllUserIds:
+    def test_no_users_returns_legacy(self, patched_db):
+        result = _get_all_user_ids()
+        assert result == [""]
+
+    def test_returns_user_ids(self, patched_db):
+        from backend.database import db
+
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u1", "a@b.com", "g1", "Alice"),
+            )
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u2", "c@d.com", "g2", "Bob"),
+            )
+        result = _get_all_user_ids()
+        assert result == ["u1", "u2"]
+
+
+class TestLogRun:
+    def test_creates_run_record(self, patched_db):
+        from backend.database import db
+
+        _log_run("sr-test1", "", status="completed", candidates_found=5,
+                 findings_created=2, started_at="2026-01-01T00:00:00Z",
+                 completed_at="2026-01-01T00:01:00Z")
+
+        with db() as conn:
+            row = conn.execute("SELECT * FROM sweep_runs WHERE id = ?", ("sr-test1",)).fetchone()
+        assert row is not None
+        assert row["status"] == "completed"
+        assert row["candidates_found"] == 5
+        assert row["findings_created"] == 2
+
+    def test_upsert_updates_existing(self, patched_db):
+        from backend.database import db
+
+        _log_run("sr-test2", "", status="running", started_at="2026-01-01T00:00:00Z")
+        _log_run("sr-test2", "", status="completed", candidates_found=3,
+                 findings_created=1, started_at="2026-01-01T00:00:00Z",
+                 completed_at="2026-01-01T00:01:00Z")
+
+        with db() as conn:
+            row = conn.execute("SELECT * FROM sweep_runs WHERE id = ?", ("sr-test2",)).fetchone()
+        assert row["status"] == "completed"
+        assert row["candidates_found"] == 3
+
+
+class TestRunSweepForUser:
+    @pytest.mark.asyncio
+    async def test_no_candidates_logs_completed(self, patched_db):
+        from backend.database import db
+
+        with patch("backend.sweep.collect_candidates", return_value=[]):
+            await _run_sweep_for_user("")
+
+        with db() as conn:
+            rows = conn.execute("SELECT * FROM sweep_runs").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "completed"
+        assert rows[0]["candidates_found"] == 0
+
+    @pytest.mark.asyncio
+    async def test_with_candidates_runs_reflection(self, patched_db):
+        from backend.database import db
+
+        fake_candidate = MagicMock()
+        mock_result = MagicMock(
+            findings_created=2,
+            usage={"model": "test-model", "prompt_tokens": 50, "completion_tokens": 30, "cost_usd": 0.01},
+        )
+
+        with (
+            patch("backend.sweep.collect_candidates", return_value=[fake_candidate]),
+            patch("backend.sweep.reflect_on_candidates", new_callable=AsyncMock, return_value=mock_result),
+        ):
+            await _run_sweep_for_user("")
+
+        with db() as conn:
+            rows = conn.execute("SELECT * FROM sweep_runs").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "completed"
+        assert rows[0]["candidates_found"] == 1
+        assert rows[0]["findings_created"] == 2
+
+
 class TestRunSweep:
     @pytest.mark.asyncio
-    async def test_no_candidates_skips_llm(self, patched_db):
-        """When SQL phase finds nothing, LLM phase is not called."""
-        with (
-            patch("backend.sweep.collect_candidates", return_value=[]) as mock_collect,
-            patch("backend.sweep.reflect_on_candidates") as mock_reflect,
-        ):
+    async def test_iterates_over_users(self, patched_db):
+        from backend.database import db
+
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u1", "a@b.com", "g1", "Alice"),
+            )
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u2", "c@d.com", "g2", "Bob"),
+            )
+
+        with patch("backend.sweep.collect_candidates", return_value=[]) as mock_collect:
             await _run_sweep()
-            mock_collect.assert_called_once()
-            mock_reflect.assert_not_called()
+
+        # Should have been called once per user
+        assert mock_collect.call_count == 2
+        call_user_ids = [c.kwargs.get("user_id") for c in mock_collect.call_args_list]
+        assert "u1" in call_user_ids
+        assert "u2" in call_user_ids
 
     @pytest.mark.asyncio
-    async def test_with_candidates_runs_llm(self, patched_db):
-        """When SQL phase finds candidates, LLM phase runs."""
-        fake_candidate = MagicMock()
-        mock_result = MagicMock(findings_created=2, usage={"total_tokens": 100})
+    async def test_error_in_one_user_doesnt_block_others(self, patched_db):
+        from backend.database import db
 
-        with (
-            patch(
-                "backend.sweep.collect_candidates",
-                return_value=[fake_candidate],
-            ),
-            patch(
-                "backend.sweep.reflect_on_candidates",
-                new_callable=AsyncMock,
-                return_value=mock_result,
-            ) as mock_reflect,
-        ):
-            await _run_sweep()
-            mock_reflect.assert_called_once_with([fake_candidate])
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u1", "a@b.com", "g1", "Alice"),
+            )
+            conn.execute(
+                "INSERT INTO users (id, email, google_id, name) VALUES (?, ?, ?, ?)",
+                ("u2", "c@d.com", "g2", "Bob"),
+            )
 
-    @pytest.mark.asyncio
-    async def test_sql_error_handled(self, patched_db):
-        """Errors in SQL phase are logged, not raised."""
-        with patch(
-            "backend.sweep.collect_candidates",
-            side_effect=RuntimeError("db boom"),
-        ):
-            # Should not raise
-            await _run_sweep()
+        call_count = 0
 
-    @pytest.mark.asyncio
-    async def test_llm_error_handled(self, patched_db):
-        """Errors in LLM phase are logged, not raised."""
-        fake_candidate = MagicMock()
-        with (
-            patch(
-                "backend.sweep.collect_candidates",
-                return_value=[fake_candidate],
-            ),
-            patch(
-                "backend.sweep.reflect_on_candidates",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("llm boom"),
-            ),
-        ):
-            # Should not raise
-            await _run_sweep()
+        def side_effect(user_id="", **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if user_id == "u1":
+                raise RuntimeError("boom")
+            return []
+
+        with patch("backend.sweep.collect_candidates", side_effect=side_effect):
+            await _run_sweep()  # Should not raise
+
+        assert call_count == 2  # Both users attempted
 
 
 class TestStartStop:
@@ -147,7 +230,7 @@ class TestStartStop:
         mod._task = None
         start_scheduler()
         assert mod._task is not None
-        # Let the task start and exit (disabled → returns immediately)
+        # Let the task start and exit (disabled -> returns immediately)
         await asyncio.sleep(0.1)
         stop_scheduler()
         assert mod._task is None


### PR DESCRIPTION
## Summary
- Add per-user processing to sweep scheduler so each user's things are analyzed independently
- Add run logging to track sweep execution history
- Integrate reasoning model into sweep for higher-quality analysis

## Test plan
- [ ] Verify sweep processes each user's things separately
- [ ] Check run logs are created for each sweep execution
- [ ] Confirm reasoning model is used during sweep analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)