### PR TITLE
feat: staleness & neglect detection (re-i5s3)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ from .routers import (  # noqa: E402
     gmail,
     proactive,
     settings,
+    staleness,
     sweep,
     thing_types,
     things,
@@ -158,6 +159,10 @@ _TAG_METADATA = [
         "description": "Auto-connect: suggested relationships between semantically similar Things.",
     },
     {
+        "name": "staleness",
+        "description": "Staleness & neglect detection: batch summary of stale and neglected items.",
+    },
+    {
         "name": "feedback",
         "description": "User feedback submission via GitHub Issues.",
     },
@@ -213,6 +218,7 @@ app.include_router(proactive.router, prefix="/api", dependencies=_api_deps)
 app.include_router(settings.router, prefix="/api", dependencies=_api_deps)
 app.include_router(sweep.router, prefix="/api", dependencies=_api_deps)
 app.include_router(focus.router, prefix="/api", dependencies=_api_deps)
+app.include_router(staleness.router, prefix="/api", dependencies=_api_deps)
 app.include_router(feedback.router, prefix="/api", dependencies=_api_deps)
 app.include_router(connections.router, prefix="/api", dependencies=_api_deps)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -287,6 +287,44 @@ class BriefingResponse(BaseModel):
     total: int
 
 
+# ── Staleness & Neglect ─────────────────────────────────────────────────────
+
+
+class StaleItem(BaseModel):
+    """A Thing that hasn't been updated within the configured staleness window."""
+
+    thing: Thing
+    days_stale: int
+    is_neglected: bool
+    active_children: int = 0
+
+
+class OverdueCheckin(BaseModel):
+    """A Thing whose checkin_date is in the past."""
+
+    thing: Thing
+    days_overdue: int
+
+
+class StalenessCategory(BaseModel):
+    """Staleness counts grouped by category."""
+
+    stale: int = 0
+    neglected: int = 0
+    overdue_checkins: int = 0
+
+
+class StalenessReport(BaseModel):
+    """Batch summary of stale and neglected items."""
+
+    as_of: str
+    stale_threshold_days: int
+    stale_items: list[StaleItem]
+    overdue_checkins: list[OverdueCheckin]
+    counts: StalenessCategory
+    total: int
+
+
 # ── Proactive Surfaces ───────────────────────────────────────────────────────
 
 

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -29,6 +29,7 @@ _VALID_KEYS = {
     "chat_context_window",
     "theme",
     "chat_mode",
+    "stale_threshold_days",
 }
 
 
@@ -61,6 +62,7 @@ class UserSettings(BaseModel):
     chat_context_window: int | None = None
     theme: str = ""
     chat_mode: str = "normal"
+    stale_threshold_days: int = 14
 
 
 class UserSettingsUpdate(BaseModel):
@@ -75,6 +77,7 @@ class UserSettingsUpdate(BaseModel):
     chat_context_window: int | None = None
     theme: str | None = None
     chat_mode: str | None = None
+    stale_threshold_days: int | None = None
 
 
 class RequestyModel(BaseModel):
@@ -160,6 +163,17 @@ def get_user_chat_context_window(user_id: str) -> int:
         except (ValueError, TypeError):
             pass
     return get_chat_context_window()
+
+
+def get_user_stale_threshold(user_id: str) -> int:
+    """Return per-user stale threshold in days, defaulting to 14."""
+    val = get_user_setting(user_id, "stale_threshold_days")
+    if val is not None:
+        try:
+            return max(1, min(int(val), 365))
+        except (ValueError, TypeError):
+            pass
+    return 14
 
 
 def get_user_api_key(user_id: str) -> str:
@@ -295,6 +309,9 @@ def get_user_settings_endpoint(user_id: str = Depends(require_user)) -> UserSett
             return "****"
         return "*" * (len(val) - 4) + val[-4:]
 
+    stale_val = user_settings.get("stale_threshold_days")
+    stale_threshold = int(stale_val) if stale_val else 14
+
     return UserSettings(
         requesty_api_key=_mask(user_settings.get("requesty_api_key", "")),
         openai_api_key=_mask(user_settings.get("openai_api_key", "")),
@@ -305,6 +322,7 @@ def get_user_settings_endpoint(user_id: str = Depends(require_user)) -> UserSett
         chat_context_window=int(user_settings["chat_context_window"]) if "chat_context_window" in user_settings else None,
         theme=user_settings.get("theme", ""),
         chat_mode=user_settings.get("chat_mode", "normal"),
+        stale_threshold_days=stale_threshold,
     )
 
 
@@ -326,6 +344,8 @@ def update_user_settings(
                 elif field_name == "chat_mode":
                     if val not in ("normal", "planning"):
                         continue
+                elif field_name == "stale_threshold_days":
+                    val = str(max(1, min(int(val), 365)))
                 _set_user_setting(conn, user_id, field_name, str(val))
 
     return get_user_settings_endpoint(user_id)

--- a/backend/routers/staleness.py
+++ b/backend/routers/staleness.py
@@ -1,0 +1,116 @@
+"""Staleness & neglect detection endpoint — batch summary for notifications."""
+
+from datetime import date, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from ..auth import require_user, user_filter
+from ..database import db
+from ..models import (
+    OverdueCheckin,
+    StaleItem,
+    StalenessCategory,
+    StalenessReport,
+)
+from ..sweep import _parse_date_value
+from .settings import get_user_stale_threshold
+from .things import _row_to_thing
+
+router = APIRouter(prefix="/staleness", tags=["staleness"])
+
+
+@router.get("", response_model=StalenessReport, summary="Staleness & neglect report")
+def get_staleness_report(
+    stale_days: int | None = Query(
+        default=None,
+        ge=1,
+        le=365,
+        description="Override staleness threshold (days). Uses per-user setting if omitted.",
+    ),
+    user_id: str = Depends(require_user),
+) -> StalenessReport:
+    """Return a batch summary of stale and neglected Things.
+
+    Stale: active Things not updated within *stale_days*.
+    Neglected: stale Things that also have high priority or pending children.
+    Overdue check-ins: active Things whose checkin_date is in the past.
+    """
+    today = date.today()
+    threshold = stale_days if stale_days is not None else get_user_stale_threshold(user_id)
+    cutoff = today.isoformat()
+    stale_cutoff = (today - timedelta(days=threshold)).isoformat()
+
+    uf_sql, uf_params = user_filter(user_id)
+
+    with db() as conn:
+        # Stale / neglected items
+        stale_rows = conn.execute(
+            f"""SELECT t.*,
+                       (SELECT COUNT(*) FROM things c
+                        WHERE c.parent_id = t.id AND c.active = 1) AS active_children
+                FROM things t
+                WHERE t.active = 1
+                  AND t.updated_at < ?{uf_sql}
+                ORDER BY t.updated_at ASC""",
+            [stale_cutoff, *uf_params],
+        ).fetchall()
+
+        # Overdue check-ins
+        overdue_rows = conn.execute(
+            f"""SELECT * FROM things
+                WHERE active = 1
+                  AND checkin_date IS NOT NULL
+                  AND DATE(checkin_date) < ?{uf_sql}
+                ORDER BY checkin_date ASC""",
+            [cutoff, *uf_params],
+        ).fetchall()
+
+    stale_items: list[StaleItem] = []
+    neglected_count = 0
+    plain_stale_count = 0
+
+    for row in stale_rows:
+        thing = _row_to_thing(row)
+        updated = row["updated_at"] or ""
+        parsed = _parse_date_value(updated)
+        days_stale = (today - parsed).days if parsed else threshold
+
+        active_children = row["active_children"] or 0
+        priority = row["priority"] or 3
+        is_neglected = priority <= 2 or active_children > 0
+
+        if is_neglected:
+            neglected_count += 1
+        else:
+            plain_stale_count += 1
+
+        stale_items.append(
+            StaleItem(
+                thing=thing,
+                days_stale=days_stale,
+                is_neglected=is_neglected,
+                active_children=active_children,
+            )
+        )
+
+    overdue_list: list[OverdueCheckin] = []
+    for row in overdue_rows:
+        thing = _row_to_thing(row)
+        parsed = _parse_date_value(row["checkin_date"])
+        days_overdue = (today - parsed).days if parsed else 1
+        overdue_list.append(OverdueCheckin(thing=thing, days_overdue=days_overdue))
+
+    total = len(stale_items) + len(overdue_list)
+
+    return StalenessReport(
+        as_of=today.isoformat(),
+        stale_threshold_days=threshold,
+        stale_items=stale_items,
+        overdue_checkins=overdue_list,
+        counts=StalenessCategory(
+            stale=plain_stale_count,
+            neglected=neglected_count,
+            overdue_checkins=len(overdue_list),
+        ),
+        total=total,
+    )

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -6,7 +6,9 @@ reflection, producing sweep_findings with priority and expiry.
 
 Finding types:
   - approaching_date: Thing with a date (checkin, birthday, deadline, etc.) within 7 days
-  - stale: Active Thing not updated in 14+ days
+  - stale: Active Thing not updated in the configured threshold (low priority, no pending work)
+  - neglected: Active Thing not updated AND high-priority or has pending children
+  - overdue_checkin: Active Thing whose checkin_date is in the past (beyond grace period)
   - orphan: Active Thing with no relationships (no parent, no children, no graph edges)
   - completed_project: Project where all children are inactive but project is still active
   - open_question: Active Thing with unanswered open_questions
@@ -212,15 +214,22 @@ def find_stale_things(
     stale_days: int = 14,
     user_id: str = "",
 ) -> list[SweepCandidate]:
-    """Find active Things not updated in *stale_days* or more."""
+    """Find active Things not updated in *stale_days* or more.
+
+    Includes neglect context: Things with higher priority or pending children
+    are flagged as ``neglected`` instead of plain ``stale``.
+    """
     today = today or date.today()
     cutoff = (today - timedelta(days=stale_days)).isoformat()
     uf_sql, uf_params = user_filter(user_id)
     rows = conn.execute(
-        f"""SELECT id, title, type_hint, updated_at FROM things
-           WHERE active = 1
-             AND updated_at < ?{uf_sql}
-           ORDER BY updated_at ASC""",
+        f"""SELECT t.id, t.title, t.type_hint, t.updated_at, t.priority,
+                  t.checkin_date,
+                  (SELECT COUNT(*) FROM things c WHERE c.parent_id = t.id AND c.active = 1) AS active_children
+           FROM things t
+           WHERE t.active = 1
+             AND t.updated_at < ?{uf_sql}
+           ORDER BY t.updated_at ASC""",
         (cutoff, *uf_params),
     ).fetchall()
 
@@ -229,14 +238,84 @@ def find_stale_things(
         parsed_dt = _parse_date_value(row["updated_at"])
         days_stale = (today - parsed_dt).days if parsed_dt else stale_days
         type_label = row["type_hint"] or "Thing"
+        priority_val = row["priority"] or 3
+        active_children = row["active_children"] or 0
+
+        # Distinguish neglected (high-priority or has pending work) from plain stale
+        is_neglected = priority_val <= 2 or active_children > 0
+        finding_type = "neglected" if is_neglected else "stale"
+
+        if is_neglected:
+            parts = []
+            if priority_val <= 2:
+                parts.append("high-priority")
+            if active_children > 0:
+                parts.append(f"{active_children} pending subtask{'s' if active_children != 1 else ''}")
+            context = ", ".join(parts)
+            message = f"Neglected for {days_stale}d ({context}): {row['title']}"
+            pri = 2  # higher urgency for neglected items
+        else:
+            message = f"Untouched for {days_stale}d: {row['title']}"
+            pri = 3
+
         candidates.append(
             SweepCandidate(
                 thing_id=row["id"],
                 thing_title=row["title"],
-                finding_type="stale",
-                message=f"Untouched for {days_stale}d: {row['title']}",
-                priority=3,
-                extra={"days_stale": days_stale, "type_hint": type_label},
+                finding_type=finding_type,
+                message=message,
+                priority=pri,
+                extra={
+                    "days_stale": days_stale,
+                    "type_hint": type_label,
+                    "is_neglected": is_neglected,
+                    "active_children": active_children,
+                },
+            )
+        )
+    return candidates
+
+
+def find_overdue_checkins(
+    conn: sqlite3.Connection,
+    today: date | None = None,
+    grace_days: int = 1,
+) -> list[SweepCandidate]:
+    """Find active Things with overdue checkin_date (past the grace period).
+
+    Things whose checkin_date is today or within *grace_days* are handled by
+    ``find_approaching_dates``; this catches items that have been overdue longer.
+    """
+    today = today or date.today()
+    cutoff = (today - timedelta(days=grace_days)).isoformat()
+    rows = conn.execute(
+        """SELECT id, title, type_hint, checkin_date, priority FROM things
+           WHERE active = 1
+             AND checkin_date IS NOT NULL
+             AND DATE(checkin_date) < ?
+           ORDER BY checkin_date ASC""",
+        (cutoff,),
+    ).fetchall()
+
+    candidates: list[SweepCandidate] = []
+    for row in rows:
+        parsed = _parse_date_value(row["checkin_date"])
+        if not parsed:
+            continue
+        days_overdue = (today - parsed).days
+        priority_val = row["priority"] or 3
+        pri = 1 if days_overdue >= 7 or priority_val <= 2 else 2
+        candidates.append(
+            SweepCandidate(
+                thing_id=row["id"],
+                thing_title=row["title"],
+                finding_type="overdue_checkin",
+                message=f"Check-in overdue by {days_overdue}d: {row['title']}",
+                priority=pri,
+                extra={
+                    "days_overdue": days_overdue,
+                    "type_hint": row["type_hint"] or "Thing",
+                },
             )
         )
     return candidates
@@ -368,6 +447,7 @@ def collect_candidates(
         candidates = (
             find_approaching_dates(conn, today, window_days, user_id=user_id)
             + find_stale_things(conn, today, stale_days, user_id=user_id)
+            + find_overdue_checkins(conn, today)
             + find_orphan_things(conn, user_id=user_id)
             + find_completed_projects(conn, user_id=user_id)
             + find_open_questions(conn, user_id=user_id)

--- a/backend/tests/test_staleness.py
+++ b/backend/tests/test_staleness.py
@@ -1,0 +1,114 @@
+"""Tests for the staleness & neglect detection endpoint."""
+
+from datetime import date, timedelta
+
+
+def _create_thing(client, title: str, **kwargs) -> dict:
+    payload = {"title": title, **kwargs}
+    resp = client.post("/api/things", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+class TestStalenessEndpoint:
+    def test_empty_staleness_report(self, client):
+        resp = client.get("/api/staleness")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["stale_items"] == []
+        assert data["overdue_checkins"] == []
+        assert data["total"] == 0
+        assert data["stale_threshold_days"] == 14
+        assert "as_of" in data
+
+    def test_stale_item_detected(self, client, patched_db):
+        from backend.database import db
+
+        # Create a thing and manually backdate its updated_at
+        thing = _create_thing(client, "Old Task")
+        old_date = (date.today() - timedelta(days=20)).isoformat()
+        with db() as conn:
+            conn.execute("UPDATE things SET updated_at = ? WHERE id = ?", (old_date, thing["id"]))
+
+        resp = client.get("/api/staleness")
+        data = resp.json()
+        assert data["total"] >= 1
+        stale_ids = [s["thing"]["id"] for s in data["stale_items"]]
+        assert thing["id"] in stale_ids
+
+    def test_overdue_checkin_detected(self, client):
+        past = (date.today() - timedelta(days=5)).isoformat()
+        thing = _create_thing(client, "Overdue Check-in", checkin_date=f"{past}T09:00:00")
+
+        resp = client.get("/api/staleness")
+        data = resp.json()
+        overdue_ids = [o["thing"]["id"] for o in data["overdue_checkins"]]
+        assert thing["id"] in overdue_ids
+        overdue = next(o for o in data["overdue_checkins"] if o["thing"]["id"] == thing["id"])
+        assert overdue["days_overdue"] >= 5
+
+    def test_custom_stale_days_override(self, client, patched_db):
+        from backend.database import db
+
+        thing = _create_thing(client, "Slightly Old")
+        # Updated 5 days ago — stale only if threshold is < 5
+        old_date = (date.today() - timedelta(days=5)).isoformat()
+        with db() as conn:
+            conn.execute("UPDATE things SET updated_at = ? WHERE id = ?", (old_date, thing["id"]))
+
+        # Default threshold (14) — not stale
+        resp = client.get("/api/staleness")
+        stale_ids = [s["thing"]["id"] for s in resp.json()["stale_items"]]
+        assert thing["id"] not in stale_ids
+
+        # Override to 3 days — now stale
+        resp = client.get("/api/staleness?stale_days=3")
+        data = resp.json()
+        assert data["stale_threshold_days"] == 3
+        stale_ids = [s["thing"]["id"] for s in data["stale_items"]]
+        assert thing["id"] in stale_ids
+
+    def test_neglected_vs_stale_distinction(self, client, patched_db):
+        from backend.database import db
+
+        # High-priority thing — should be neglected
+        high_pri = _create_thing(client, "Urgent Thing", priority=1)
+        # Low-priority thing — should be plain stale
+        low_pri = _create_thing(client, "Low Priority Note", priority=5)
+
+        old_date = (date.today() - timedelta(days=20)).isoformat()
+        with db() as conn:
+            conn.execute("UPDATE things SET updated_at = ? WHERE id = ?", (old_date, high_pri["id"]))
+            conn.execute("UPDATE things SET updated_at = ? WHERE id = ?", (old_date, low_pri["id"]))
+
+        resp = client.get("/api/staleness")
+        data = resp.json()
+
+        stale_map = {s["thing"]["id"]: s for s in data["stale_items"]}
+        assert stale_map[high_pri["id"]]["is_neglected"] is True
+        assert stale_map[low_pri["id"]]["is_neglected"] is False
+
+        assert data["counts"]["neglected"] >= 1
+        assert data["counts"]["stale"] >= 1
+
+    def test_inactive_things_excluded(self, client):
+        past = (date.today() - timedelta(days=5)).isoformat()
+        thing = _create_thing(client, "Done Thing", checkin_date=f"{past}T09:00:00")
+        # Mark as inactive
+        client.patch(f"/api/things/{thing['id']}", json={"active": False})
+
+        resp = client.get("/api/staleness")
+        data = resp.json()
+        all_ids = [s["thing"]["id"] for s in data["stale_items"]] + [
+            o["thing"]["id"] for o in data["overdue_checkins"]
+        ]
+        assert thing["id"] not in all_ids
+
+    def test_counts_structure(self, client):
+        resp = client.get("/api/staleness")
+        data = resp.json()
+        counts = data["counts"]
+        assert "stale" in counts
+        assert "neglected" in counts
+        assert "overdue_checkins" in counts
+        assert data["total"] == counts["stale"] + counts["neglected"] + counts["overdue_checkins"]

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -10,6 +10,7 @@ from backend.sweep import (
     find_completed_projects,
     find_open_questions,
     find_orphan_things,
+    find_overdue_checkins,
     find_stale_things,
 )
 
@@ -172,6 +173,105 @@ class TestStaleThings:
             results = find_stale_things(conn, today, stale_days=14)
         assert len(results) == 0
 
+    def test_high_priority_flagged_as_neglected(self, patched_db):
+        """High-priority stale Things should be flagged as 'neglected'."""
+        today = date.today()
+        old_date = (today - timedelta(days=20)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Urgent Task", updated_at=old_date)
+            conn.execute("UPDATE things SET priority = 1 WHERE id = 't1'")
+        with db() as conn:
+            results = find_stale_things(conn, today, stale_days=14)
+        assert len(results) == 1
+        assert results[0].finding_type == "neglected"
+        assert results[0].priority == 2  # higher urgency
+        assert "high-priority" in results[0].message
+        assert results[0].extra["is_neglected"] is True
+
+    def test_thing_with_active_children_flagged_as_neglected(self, patched_db):
+        """Stale Things with active children should be flagged as 'neglected'."""
+        today = date.today()
+        old_date = (today - timedelta(days=20)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "proj", "Old Project", type_hint="project", updated_at=old_date)
+            _insert_thing(conn, "c1", "Active Child", parent_id="proj")
+        with db() as conn:
+            results = find_stale_things(conn, today, stale_days=14)
+        neglected = [r for r in results if r.thing_id == "proj"]
+        assert len(neglected) == 1
+        assert neglected[0].finding_type == "neglected"
+        assert "1 pending subtask" in neglected[0].message
+
+    def test_low_priority_no_children_is_plain_stale(self, patched_db):
+        """Low-priority stale Things without children are plain 'stale'."""
+        today = date.today()
+        old_date = (today - timedelta(days=20)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Low Priority Note", updated_at=old_date)
+            conn.execute("UPDATE things SET priority = 4 WHERE id = 't1'")
+        with db() as conn:
+            results = find_stale_things(conn, today, stale_days=14)
+        assert len(results) == 1
+        assert results[0].finding_type == "stale"
+        assert results[0].extra["is_neglected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Overdue check-ins
+# ---------------------------------------------------------------------------
+
+
+class TestOverdueCheckins:
+    def test_overdue_checkin_detected(self, patched_db):
+        today = date.today()
+        past = (today - timedelta(days=5)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Overdue Task", checkin_date=f"{past}T09:00:00")
+        with db() as conn:
+            results = find_overdue_checkins(conn, today, grace_days=1)
+        assert len(results) == 1
+        assert results[0].finding_type == "overdue_checkin"
+        assert results[0].extra["days_overdue"] == 5
+        assert "overdue by 5d" in results[0].message.lower()
+
+    def test_recent_checkin_within_grace_excluded(self, patched_db):
+        """Check-ins within the grace period are not flagged (handled by approaching_dates)."""
+        today = date.today()
+        yesterday = (today - timedelta(days=0)).isoformat()  # today
+        with db() as conn:
+            _insert_thing(conn, "t1", "Today Check-in", checkin_date=f"{yesterday}T09:00:00")
+        with db() as conn:
+            results = find_overdue_checkins(conn, today, grace_days=1)
+        assert len(results) == 0
+
+    def test_inactive_excluded(self, patched_db):
+        today = date.today()
+        past = (today - timedelta(days=10)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Done Thing", checkin_date=f"{past}T09:00:00", active=False)
+        with db() as conn:
+            results = find_overdue_checkins(conn, today, grace_days=1)
+        assert len(results) == 0
+
+    def test_severely_overdue_gets_high_priority(self, patched_db):
+        today = date.today()
+        old = (today - timedelta(days=10)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Very Overdue", checkin_date=f"{old}T09:00:00")
+        with db() as conn:
+            results = find_overdue_checkins(conn, today, grace_days=1)
+        assert len(results) == 1
+        assert results[0].priority == 1  # high priority for 7+ days overdue
+
+    def test_future_checkin_excluded(self, patched_db):
+        today = date.today()
+        future = (today + timedelta(days=5)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "Future Check-in", checkin_date=f"{future}T09:00:00")
+        with db() as conn:
+            results = find_overdue_checkins(conn, today, grace_days=1)
+        assert len(results) == 0
+
 
 # ---------------------------------------------------------------------------
 # Orphan Things
@@ -326,12 +426,15 @@ class TestCollectCandidates:
         today = date.today()
         old = (today - timedelta(days=20)).isoformat()
         tomorrow = (today + timedelta(days=1)).isoformat()
+        past = (today - timedelta(days=5)).isoformat()
 
         with db() as conn:
             # approaching date
             _insert_thing(conn, "t1", "Upcoming", checkin_date=f"{tomorrow}T09:00:00")
             # stale
             _insert_thing(conn, "t2", "Stale", updated_at=old)
+            # overdue checkin
+            _insert_thing(conn, "t4", "Overdue", checkin_date=f"{past}T09:00:00")
             # orphan (t1 and t2 are also orphans — they'll appear there too)
             # completed project
             _insert_thing(conn, "proj", "Done Project", type_hint="project")
@@ -343,6 +446,7 @@ class TestCollectCandidates:
         types = {c.finding_type for c in results}
         assert "approaching_date" in types
         assert "stale" in types
+        assert "overdue_checkin" in types
         assert "orphan" in types
         assert "completed_project" in types
         assert "open_question" in types

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -118,6 +118,7 @@ function SettingsForm({
   const [chatContextWindow, setChatContextWindow] = useState(initial.chat_context_window)
   const [reqApiKey, setReqApiKey] = useState('')
   const [reqApiKeyDisplay, setReqApiKeyDisplay] = useState(initialUserSettings?.requesty_api_key || '')
+  const [staleThresholdDays, setStaleThresholdDays] = useState(initialUserSettings?.stale_threshold_days ?? 14)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
 
@@ -128,8 +129,9 @@ function SettingsForm({
     chatContextWindow !== initial.chat_context_window
 
   const hasApiKeyChange = reqApiKey.length > 0
+  const hasStaleThresholdChange = staleThresholdDays !== (initialUserSettings?.stale_threshold_days ?? 14)
 
-  const hasChanges = hasModelChanges || hasApiKeyChange
+  const hasChanges = hasModelChanges || hasApiKeyChange || hasStaleThresholdChange
 
   const handleSave = async () => {
     setSaving(true)
@@ -145,6 +147,11 @@ function SettingsForm({
       await updateUserSettings({ requesty_api_key: reqApiKey })
       setReqApiKeyDisplay(reqApiKey.length <= 4 ? '****' : '*'.repeat(reqApiKey.length - 4) + reqApiKey.slice(-4))
       setReqApiKey('')
+    }
+
+    // Save stale threshold if changed
+    if (hasStaleThresholdChange) {
+      await updateUserSettings({ stale_threshold_days: staleThresholdDays })
     }
 
     setSaving(false)
@@ -238,6 +245,29 @@ function SettingsForm({
             onChange={e => {
               const v = parseInt(e.target.value, 10)
               if (!isNaN(v)) setChatContextWindow(Math.max(1, Math.min(50, v)))
+            }}
+            className="w-24 px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:focus:ring-indigo-500 focus:border-indigo-400 dark:focus:border-indigo-500"
+          />
+        </div>
+      </div>
+      {/* Staleness Detection */}
+      <div className="mt-6 pt-5 border-t border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Staleness Detection</h3>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Stale Threshold (days)
+          </label>
+          <p className="text-xs text-gray-400 dark:text-gray-400 mb-1.5">
+            Things not updated for this many days are flagged as stale or neglected (1-365)
+          </p>
+          <input
+            type="number"
+            min={1}
+            max={365}
+            value={staleThresholdDays}
+            onChange={e => {
+              const v = parseInt(e.target.value, 10)
+              if (!isNaN(v)) setStaleThresholdDays(Math.max(1, Math.min(365, v)))
             }}
             className="w-24 px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:focus:ring-indigo-500 focus:border-indigo-400 dark:focus:border-indigo-500"
           />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,6 +12,8 @@ import { ConnectionSuggestions } from './ConnectionSuggestions'
 const FINDING_TYPE_ICONS: Record<string, string> = {
   approaching_date: '\u23F0',
   stale: '\u{1F4A4}',
+  neglected: '\u{1F6A8}',
+  overdue_checkin: '\u{1F4C5}',
   orphan: '\u{1F50D}',
   inconsistency: '\u26A0\uFE0F',
   open_question: '\u2753',

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -214,6 +214,7 @@ export const UserSettingsSchema = z.object({
   chat_context_window: z.number().nullable(),
   theme: z.string(),
   chat_mode: z.string().optional().default('normal'),
+  stale_threshold_days: z.number().default(14),
 })
 
 export const RequestyModelSchema = z.object({

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -154,6 +154,7 @@ export interface UserSettings {
   chat_context_window: number | null
   theme: string
   chat_mode: string
+  stale_threshold_days: number
 }
 
 export interface UserProfileRelationship {


### PR DESCRIPTION
## Summary
- Add staleness detection API that identifies neglected things based on activity patterns
- New settings for configuring staleness thresholds
- Backend tests for staleness detection logic
- Sweep integration for automated neglect monitoring

Part of #121

## Test plan
- [ ] Verify staleness endpoint returns neglected things with correct thresholds
- [ ] Test configurable staleness settings in settings panel
- [ ] Run backend tests for staleness detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)