### PR TITLE
feat: enable Phoenix tracing + ADK auto-instrumentation (re-iimd)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ GOOGLE_SEARCH_CX=
 # Token encryption key (auto-generated if not set)
 # TOKEN_ENCRYPTION_KEY=
 
+# Phoenix observability (traces pipeline stages, tool calls, LLM invocations)
+PHOENIX_ENABLED=true
+# PHOENIX_ENDPOINT=http://phoenix:6006/v1/traces
+
 # Logging level
 # LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ embedding:
 
 Models can also be overridden via environment variables (`REQUESTY_MODEL`, `REQUESTY_REASONING_MODEL`, `REQUESTY_RESPONSE_MODEL`).
 
+## Observability (Phoenix)
+
+Reli ships with [Arize Phoenix](https://phoenix.arize.com/) for tracing the agent pipeline. When running with Docker Compose, Phoenix starts automatically alongside the app.
+
+**Dashboard:** [http://localhost:6006](http://localhost:6006)
+
+Phoenix captures:
+- Pipeline stages (context → reasoning → validation → response)
+- Google ADK agent executions and tool calls (auto-instrumented)
+- LLM invocations with inputs/outputs
+
+To disable tracing, set `PHOENIX_ENABLED=false` in your `.env`.
+
 ## Testing
 
 ```bash

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,3 +30,4 @@ opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
 opentelemetry-exporter-otlp-proto-http>=1.20.0
+openinference-instrumentation-google-adk>=0.1.0

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -35,6 +35,8 @@ def test_init_tracing_configures_provider_when_enabled():
         mock_exporter = MagicMock()
         mock_processor = MagicMock()
 
+        mock_adk_instrumentor = MagicMock()
+
         with (
             patch("opentelemetry.sdk.trace.TracerProvider", return_value=mock_tracer_provider),
             patch(
@@ -46,6 +48,10 @@ def test_init_tracing_configures_provider_when_enabled():
                 return_value=mock_processor,
             ),
             patch("opentelemetry.trace.set_tracer_provider") as mock_set_tp,
+            patch(
+                "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
+                return_value=mock_adk_instrumentor,
+            ),
         ):
             import backend.tracing
 
@@ -55,6 +61,7 @@ def test_init_tracing_configures_provider_when_enabled():
             mock_exp_cls.assert_called_once_with(endpoint="http://localhost:6006/v1/traces")
             mock_tracer_provider.add_span_processor.assert_called_once_with(mock_processor)
             mock_set_tp.assert_called_once_with(mock_tracer_provider)
+            mock_adk_instrumentor.instrument.assert_called_once_with(tracer_provider=mock_tracer_provider)
             assert backend.tracing._initialized is True
 
 

--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -46,6 +46,16 @@ def init_tracing() -> None:
         exporter = OTLPSpanExporter(endpoint=settings.PHOENIX_ENDPOINT)
         provider.add_span_processor(BatchSpanProcessor(exporter))
         trace.set_tracer_provider(provider)
+
+        # Auto-instrument Google ADK (agents, tool calls, LLM invocations)
+        try:
+            from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+            GoogleADKInstrumentor().instrument(tracer_provider=provider)
+            logger.info("Google ADK auto-instrumentation enabled")
+        except Exception:
+            logger.warning("Failed to enable Google ADK auto-instrumentation", exc_info=True)
+
         _initialized = True
         logger.info(
             "OTEL tracing initialized — exporting to %s (service: %s)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,22 @@ services:
       - SECRET_KEY=${SECRET_KEY:-}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}
+      - PHOENIX_ENABLED=${PHOENIX_ENABLED:-true}
+      - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
+    depends_on:
+      phoenix:
+        condition: service_started
     restart: unless-stopped
+
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    ports:
+      - "127.0.0.1:6006:6006"
+    volumes:
+      - phoenix_data:/data
+    environment:
+      - PHOENIX_WORKING_DIR=/data
+    restart: unless-stopped
+
+volumes:
+  phoenix_data:


### PR DESCRIPTION
## Summary

- Enable Phoenix tracing and ADK auto-instrumentation for observability

Part of #155

**Issue**: re-iimd
**Polecat**: furiosa
**Tests**: All passed (184 frontend + 402 backend, 81% coverage)

---
*Merged by Gas Town Refinery*