### PR TITLE
fix: disable ChromaDB anonymous telemetry to fix PostHog capture() error (re-j7i1)

### DIFF
--- a/backend/vector_store.py
+++ b/backend/vector_store.py
@@ -76,7 +76,10 @@ _embedder = _ThingEmbedder()
 
 
 def _get_collection() -> chromadb.Collection:
-    client = chromadb.PersistentClient(path=str(CHROMA_PATH))
+    client = chromadb.PersistentClient(
+        path=str(CHROMA_PATH),
+        settings=chromadb.Settings(anonymized_telemetry=False),
+    )
     return client.get_or_create_collection(
         name=COLLECTION_NAME,
         embedding_function=_embedder,


### PR DESCRIPTION
## Summary
- Disables ChromaDB anonymous telemetry via `anonymized_telemetry=False` setting
- Fixes PostHog `capture()` signature error: `capture() takes 1 positional argument but 3 were given`

Fixes #163. Fixes #164.

## Test plan
- [x] Single-line config change, no logic changes
- [x] All gates pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)