### PR TITLE
feat: switch reasoning model to gemini-3-flash-preview (re-zo)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ llm:
   base_url: https://router.requesty.ai/v1
   models:
     context: google/gemini-2.5-flash-lite
-    reasoning: google/gemini-2.5-flash
+    reasoning: google/gemini-3-flash-preview
     response: google/gemini-2.5-flash-lite
 
 ollama:


### PR DESCRIPTION
This PR switches the default reasoning model to **Gemini 3 Flash Preview**.

It relies on the  fallback mechanism and history filtering already present in master to mitigate the strict validation errors encountered when routing thinking models through Requesty.

Note: While stable for general chat, Gemini 3 remains sensitive to tool-call signature mismatches in certain multi-turn scenarios.