### PR TITLE
fix: set SENTRY_DSN='' in test env to prevent prod pollution

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,9 @@ from httpx import ASGITransport, AsyncClient
 # Disable rate limiting for all tests (except test_rate_limit.py which uses its own app)
 os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
+# Prevent test errors from polluting production Sentry (re-icdi)
+os.environ.setdefault("SENTRY_DSN", "")
+
 # ---------------------------------------------------------------------------
 # Database fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Sets `SENTRY_DSN=""` in test conftest.py to prevent test errors from reaching production Sentry
- Fixes high-volume noise (RELI-ZO-A/B/8/9) obscuring real errors

Fixes re-icdi

🤖 Generated with [Claude Code](https://claude.com/claude-code)