### PR TITLE
fix: update tool-call history filter to use structured metadata

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -1018,15 +1018,24 @@ def _make_reasoning_tools(
 # Gemini thought_signature helpers (GH #158 / Sentry RELI-ZO-5)
 # ---------------------------------------------------------------------------
 
-# Markers appended by _enrich_history_content for turns that involved tool calls.
-_TOOL_CALL_MARKERS = ("[Created:", "[Updated:", "[Deleted:", "[Merged:")
+def _had_tool_calls(entry: dict) -> bool:
+    """Return True if a history entry represents a turn that involved tool calls.
 
-
-def _has_tool_call_markers(content: str) -> bool:
-    """Return True if the content contains enrichment markers from tool call turns."""
-    if not content:
-        return False
-    return any(marker in content for marker in _TOOL_CALL_MARKERS)
+    After the _enrich_history_content refactor (re-ay9o), tool-call metadata is
+    stored as structured ``referenced_things`` on the history dict rather than
+    as ``[Created: ...]`` string markers in the content.  We check both so that
+    any pre-migration rows still in the DB are also caught.
+    """
+    # New structured metadata path (post-refactor)
+    if entry.get("referenced_things"):
+        return True
+    # Legacy string-marker path (pre-refactor rows still in DB)
+    content = entry.get("content", "")
+    if content:
+        legacy_markers = ("[Created:", "[Updated:", "[Deleted:", "[Merged:")
+        if any(m in content for m in legacy_markers):
+            return True
+    return False
 
 
 def _is_thought_signature_error(exc: Exception) -> bool:
@@ -1232,14 +1241,13 @@ async def run_reasoning_agent(
     )
 
     # Build history into the user message for ADK (single-turn with context).
-    # Exclude assistant turns that had tool calls (identifiable by enrichment
-    # markers like [Created:, [Updated:, [Deleted:]) — replaying these through
+    # Exclude assistant turns that involved tool calls — replaying these through
     # Gemini thinking models triggers thought_signature validation errors when
     # the structured function-call metadata is lost.  User turns are always
-    # safe to include.  See GH #158 / Sentry RELI-ZO-5.
+    # safe to include.  See GH #158 / Sentry RELI-ZO-5 / RELI-ZO-G.
     history_block = ""
     for h in history[-context_window:]:
-        if h["role"] == "assistant" and _has_tool_call_markers(h["content"]):
+        if h["role"] == "assistant" and _had_tool_calls(h):
             continue
         history_block += f"<{h['role']}>{h['content']}</{h['role']}>\n"
 

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -760,43 +760,54 @@ class TestToolCatchallErrorHandling:
 # ---------------------------------------------------------------------------
 
 
-class TestHasToolCallMarkers:
-    """Test _has_tool_call_markers detects enrichment markers from tool call turns."""
+class TestHadToolCalls:
+    """Test _had_tool_calls detects tool-call turns via structured metadata or legacy markers."""
 
-    def test_detects_created_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_detects_referenced_things_metadata(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        content = "I updated your project.\n[Created: New Project (project)]"
-        assert _has_tool_call_markers(content) is True
+        entry = {"role": "assistant", "content": "Done.", "referenced_things": [{"id": "1", "title": "X", "action": "created"}]}
+        assert _had_tool_calls(entry) is True
 
-    def test_detects_updated_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_detects_legacy_created_marker(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        content = "Done.\n[Updated: Existing Task (task)]"
-        assert _has_tool_call_markers(content) is True
+        entry = {"role": "assistant", "content": "I updated your project.\n[Created: New Project (project)]"}
+        assert _had_tool_calls(entry) is True
 
-    def test_detects_deleted_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_detects_legacy_updated_marker(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        content = "Removed it.\n[Deleted: Old Item]"
-        assert _has_tool_call_markers(content) is True
+        entry = {"role": "assistant", "content": "Done.\n[Updated: Existing Task (task)]"}
+        assert _had_tool_calls(entry) is True
 
-    def test_detects_merged_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_detects_legacy_deleted_marker(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        content = "Merged duplicates.\n[Merged: A into B]"
-        assert _has_tool_call_markers(content) is True
+        entry = {"role": "assistant", "content": "Removed it.\n[Deleted: Old Item]"}
+        assert _had_tool_calls(entry) is True
 
-    def test_no_markers_returns_false(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_detects_legacy_merged_marker(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        assert _has_tool_call_markers("Just a normal response.") is False
+        entry = {"role": "assistant", "content": "Merged duplicates.\n[Merged: A into B]"}
+        assert _had_tool_calls(entry) is True
 
-    def test_empty_content_returns_false(self):
-        from backend.reasoning_agent import _has_tool_call_markers
+    def test_no_markers_no_metadata_returns_false(self):
+        from backend.reasoning_agent import _had_tool_calls
 
-        assert _has_tool_call_markers("") is False
-        assert _has_tool_call_markers(None) is False  # type: ignore[arg-type]
+        assert _had_tool_calls({"role": "assistant", "content": "Just a normal response."}) is False
+
+    def test_empty_referenced_things_returns_false(self):
+        from backend.reasoning_agent import _had_tool_calls
+
+        assert _had_tool_calls({"role": "assistant", "content": "", "referenced_things": []}) is False
+
+    def test_empty_content_no_metadata_returns_false(self):
+        from backend.reasoning_agent import _had_tool_calls
+
+        assert _had_tool_calls({"role": "assistant", "content": ""}) is False
+        assert _had_tool_calls({"role": "user", "content": "hello"}) is False
 
 
 class TestIsThoughtSignatureError:
@@ -893,12 +904,12 @@ class TestHistoryFilteringInReasoningAgent:
     """Test that run_reasoning_agent excludes tool-call history turns."""
 
     @pytest.mark.asyncio
-    async def test_excludes_assistant_turns_with_tool_markers(self):
-        """Assistant turns with tool call markers should be excluded from history."""
+    async def test_excludes_assistant_turns_with_referenced_things(self):
+        """Assistant turns with referenced_things metadata should be excluded from history."""
         metadata = {"reasoning_summary": "test"}
         history = [
             {"role": "user", "content": "Create a project called X"},
-            {"role": "assistant", "content": "Done!\n[Created: X (project)]"},
+            {"role": "assistant", "content": "Done!", "referenced_things": [{"id": "1", "title": "X", "action": "created"}]},
             {"role": "user", "content": "Now update it"},
         ]
 
@@ -925,7 +936,40 @@ class TestHistoryFilteringInReasoningAgent:
         full_prompt = call_args.args[1]  # second positional arg
         # User turns should be included
         assert "<user>" in full_prompt
-        # Assistant turn with tool marker should be excluded
+        # Assistant turn with tool calls should be excluded
+        assert "Done!" not in full_prompt
+
+    @pytest.mark.asyncio
+    async def test_excludes_assistant_turns_with_legacy_markers(self):
+        """Assistant turns with legacy string markers should still be excluded."""
+        metadata = {"reasoning_summary": "test"}
+        history = [
+            {"role": "user", "content": "Create a project called X"},
+            {"role": "assistant", "content": "Done!\n[Created: X (project)]"},
+            {"role": "user", "content": "Now update it"},
+        ]
+
+        with patch("backend.reasoning_agent._run_adk_with_thought_signature_fallback") as mock_run, \
+             patch("backend.reasoning_agent._make_reasoning_tools") as mock_make, \
+             patch("backend.reasoning_agent._make_litellm_model") as mock_factory, \
+             patch("backend.reasoning_agent.LlmAgent"):
+            mock_run.return_value = json.dumps(metadata)
+            mock_make.return_value = (
+                [MagicMock() for _ in range(6)],
+                {"created": [], "updated": [], "deleted": [], "merged": [], "relationships_created": []},
+                {},
+            )
+            mock_factory.return_value = MagicMock()
+
+            from backend.reasoning_agent import run_reasoning_agent
+
+            await run_reasoning_agent(
+                "Now update it", history, [], api_key="k", user_id="u",
+            )
+
+        call_args = mock_run.call_args
+        full_prompt = call_args.args[1]
+        assert "<user>" in full_prompt
         assert "[Created:" not in full_prompt
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes thought_signature errors leaking past retry fallback
- Updates tool-call history filter to use structured metadata instead of string matching

Fixes re-5r5h

🤖 Generated with [Claude Code](https://claude.com/claude-code)