### PR TITLE
fix: use shared lifespan-managed httpx client to prevent resource leaks

### DIFF
--- a/backend/http_client.py
+++ b/backend/http_client.py
@@ -1,0 +1,18 @@
+"""Shared httpx client — managed by the app lifespan to prevent resource leaks.
+
+Usage in endpoints:
+    from ..http_client import get_http_client
+
+    @router.get("/example")
+    async def example(client: httpx.AsyncClient = Depends(get_http_client)):
+        resp = await client.get("https://example.com")
+"""
+
+import httpx
+from fastapi import Request
+
+
+def get_http_client(request: Request) -> httpx.AsyncClient:
+    """FastAPI dependency that returns the shared httpx.AsyncClient."""
+    client: httpx.AsyncClient = request.app.state.httpx_client
+    return client

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,8 @@ import pathlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
+import httpx
+
 from .config import settings as _app_settings  # noqa: E402 — must load before other backend imports
 
 # Configure logging — LOG_LEVEL env var controls verbosity (default: INFO)
@@ -63,7 +65,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     init_db()
     clean_orphan_relationships()
     start_scheduler()
-    yield
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        app.state.httpx_client = client
+        yield
     stop_scheduler()
     shutdown_tracing()
 

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from ..auth import require_user
 from ..config import settings
+from ..http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ def _category_label(category: str) -> str:
 async def submit_feedback(
     body: FeedbackRequest,
     user_id: str = Depends(require_user),
+    client: httpx.AsyncClient = Depends(get_http_client),
 ) -> FeedbackResponse:
     """Create a GitHub issue with the user's feedback and app context."""
     token = settings.GITHUB_FEEDBACK_TOKEN
@@ -75,28 +77,27 @@ async def submit_feedback(
     label = _category_label(body.category)
 
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"https://api.github.com/repos/{repo}/issues",
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-                json={
-                    "title": title,
-                    "body": issue_body,
-                    "labels": [label],
-                },
-                timeout=15.0,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return FeedbackResponse(
-                success=True,
-                issue_url=data.get("html_url"),
-                message="Feedback submitted successfully.",
-            )
+        resp = await client.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={
+                "title": title,
+                "body": issue_body,
+                "labels": [label],
+            },
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return FeedbackResponse(
+            success=True,
+            issue_url=data.get("html_url"),
+            message="Feedback submitted successfully.",
+        )
     except httpx.HTTPStatusError as exc:
         logger.error("GitHub API error creating feedback issue: %s %s", exc.response.status_code, exc.response.text)
         raise HTTPException(status_code=502, detail="Failed to create feedback issue on GitHub.") from exc

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from ..auth import require_user
 from ..database import db
+from ..http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,10 @@ def get_user_models(user_id: str) -> dict[str, str]:
 
 
 @router.get("/models", response_model=list[RequestyModel], summary="List available LLM models")
-def list_models(user_id: str = Depends(require_user)) -> list[RequestyModel]:
+async def list_models(
+    user_id: str = Depends(require_user),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> list[RequestyModel]:
     """Proxy the Requesty /v1/models endpoint using the user's API key if available."""
     cfg = _read_config()
     base_url = cfg.get("llm", {}).get("base_url", "https://router.requesty.ai/v1")
@@ -238,11 +242,10 @@ def list_models(user_id: str = Depends(require_user)) -> list[RequestyModel]:
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
     try:
-        with httpx.Client(timeout=10.0) as client:
-            resp = client.get(f"{base_url}/models", headers=headers)
-            resp.raise_for_status()
-            data = resp.json().get("data", [])
-            return [RequestyModel(id=m["id"], name=m.get("name")) for m in data if m.get("id")]
+        resp = await client.get(f"{base_url}/models", headers=headers, timeout=10.0)
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        return [RequestyModel(id=m["id"], name=m.get("name")) for m in data if m.get("id")]
     except Exception as exc:
         logger.warning("Failed to fetch models from Requesty: %s", exc)
         raise HTTPException(status_code=502, detail="Could not fetch models from Requesty API") from exc

--- a/backend/web_search.py
+++ b/backend/web_search.py
@@ -31,7 +31,9 @@ def is_search_configured() -> bool:
     return bool(GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_CX)
 
 
-async def google_search(query: str, num_results: int = 5) -> list[SearchResult]:
+async def google_search(
+    query: str, num_results: int = 5, client: httpx.AsyncClient | None = None,
+) -> list[SearchResult]:
     """Search Google using the Custom Search JSON API.
 
     Returns up to `num_results` results. Returns empty list on failure or
@@ -49,8 +51,13 @@ async def google_search(query: str, num_results: int = 5) -> list[SearchResult]:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(GOOGLE_SEARCH_URL, params=params)
+        if client is None:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(GOOGLE_SEARCH_URL, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        else:
+            resp = await client.get(GOOGLE_SEARCH_URL, params=params, timeout=10.0)
             resp.raise_for_status()
             data = resp.json()
     except httpx.HTTPStatusError as e:


### PR DESCRIPTION
## Summary
- Fixes unclosed httpx client sessions in /api/conflicts endpoint (RELI-ZO-7)
- Uses shared lifespan-managed httpx client instead of creating per-request clients

Fixes re-c0of

🤖 Generated with [Claude Code](https://claude.com/claude-code)