### PR TITLE
feat: move history enrichment to separate metadata field

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -1018,16 +1018,6 @@ def _make_reasoning_tools(
 # Gemini thought_signature helpers (GH #158 / Sentry RELI-ZO-5)
 # ---------------------------------------------------------------------------
 
-# Markers appended by _enrich_history_content for turns that involved tool calls.
-_TOOL_CALL_MARKERS = ("[Created:", "[Updated:", "[Deleted:", "[Merged:")
-
-
-def _has_tool_call_markers(content: str) -> bool:
-    """Return True if the content contains enrichment markers from tool call turns."""
-    if not content:
-        return False
-    return any(marker in content for marker in _TOOL_CALL_MARKERS)
-
 
 def _is_thought_signature_error(exc: Exception) -> bool:
     """Return True if the exception is a Gemini thought_signature validation error."""
@@ -1232,16 +1222,17 @@ async def run_reasoning_agent(
     )
 
     # Build history into the user message for ADK (single-turn with context).
-    # Exclude assistant turns that had tool calls (identifiable by enrichment
-    # markers like [Created:, [Updated:, [Deleted:]) — replaying these through
-    # Gemini thinking models triggers thought_signature validation errors when
-    # the structured function-call metadata is lost.  User turns are always
-    # safe to include.  See GH #158 / Sentry RELI-ZO-5.
+    # Content is pristine (enrichment markers are in a separate metadata field),
+    # so all turns can be included without triggering Gemini thought_signature
+    # validation errors.  See GH #158 / re-jux4.
     history_block = ""
     for h in history[-context_window:]:
-        if h["role"] == "assistant" and _has_tool_call_markers(h["content"]):
-            continue
         history_block += f"<{h['role']}>{h['content']}</{h['role']}>\n"
+        # Append enrichment metadata (context/created/updated Things) as a
+        # separate note so the model knows what happened without polluting content.
+        enrichment = h.get("enrichment_metadata", "")
+        if enrichment:
+            history_block += f"<enrichment>{enrichment}</enrichment>\n"
 
     full_prompt = (
         (f"Conversation history:\n{history_block}\n" if history_block else "")

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -159,23 +159,18 @@ def migrate_session(body: MigrateSessionRequest, user_id: str = Depends(require_
 # ---------------------------------------------------------------------------
 
 
-def _enrich_history_content(row: sqlite3.Row) -> str:
-    """Append Thing metadata summary to assistant messages that have applied_changes.
+def _build_enrichment_summary(raw_applied_changes: Any) -> str:
+    """Build a human-readable enrichment summary from applied_changes JSON.
 
-    This gives the context/reasoning agents visibility into which Things were
-    involved in prior turns, improving pronoun/reference resolution.
+    Returns a short summary string describing which Things were involved
+    (context, created, updated) or an empty string if there's nothing to report.
     """
-    content: str = row["content"] or ""
-    if row["role"] != "assistant":
-        return content
+    if not raw_applied_changes:
+        return ""
 
-    raw = row["applied_changes"]
-    if not raw:
-        return content
-
-    changes = json.loads(raw) if isinstance(raw, str) else raw
+    changes = json.loads(raw_applied_changes) if isinstance(raw_applied_changes, str) else raw_applied_changes
     if not isinstance(changes, dict):
-        return content
+        return ""
 
     parts: list[str] = []
 
@@ -198,9 +193,7 @@ def _enrich_history_content(row: sqlite3.Row) -> str:
             ]
             parts.append(f"[{verb}: {', '.join(labels)}]")
 
-    if parts:
-        return content + "\n" + "\n".join(parts)
-    return content
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +228,15 @@ def _fetch_history(session_id: str, context_window: int) -> list[dict[str, Any]]
             " WHERE session_id = ? ORDER BY timestamp ASC LIMIT ?",
             (session_id, history_limit),
         ).fetchall()
-    return [{"role": r["role"], "content": _enrich_history_content(r)} for r in rows]
+    result = []
+    for r in rows:
+        entry: dict[str, Any] = {"role": r["role"], "content": r["content"] or ""}
+        if r["role"] == "assistant":
+            summary = _build_enrichment_summary(r["applied_changes"])
+            if summary:
+                entry["enrichment_metadata"] = summary
+        result.append(entry)
+    return result
 
 
 def _persist_exchange(

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -760,45 +760,6 @@ class TestToolCatchallErrorHandling:
 # ---------------------------------------------------------------------------
 
 
-class TestHasToolCallMarkers:
-    """Test _has_tool_call_markers detects enrichment markers from tool call turns."""
-
-    def test_detects_created_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        content = "I updated your project.\n[Created: New Project (project)]"
-        assert _has_tool_call_markers(content) is True
-
-    def test_detects_updated_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        content = "Done.\n[Updated: Existing Task (task)]"
-        assert _has_tool_call_markers(content) is True
-
-    def test_detects_deleted_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        content = "Removed it.\n[Deleted: Old Item]"
-        assert _has_tool_call_markers(content) is True
-
-    def test_detects_merged_marker(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        content = "Merged duplicates.\n[Merged: A into B]"
-        assert _has_tool_call_markers(content) is True
-
-    def test_no_markers_returns_false(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        assert _has_tool_call_markers("Just a normal response.") is False
-
-    def test_empty_content_returns_false(self):
-        from backend.reasoning_agent import _has_tool_call_markers
-
-        assert _has_tool_call_markers("") is False
-        assert _has_tool_call_markers(None) is False  # type: ignore[arg-type]
-
-
 class TestIsThoughtSignatureError:
     """Test _is_thought_signature_error detects Gemini thought_signature errors."""
 
@@ -889,16 +850,16 @@ class TestRunAdkWithThoughtSignatureFallback:
             )
 
 
-class TestHistoryFilteringInReasoningAgent:
-    """Test that run_reasoning_agent excludes tool-call history turns."""
+class TestHistoryEnrichmentInReasoningAgent:
+    """Test that run_reasoning_agent includes enrichment metadata separately."""
 
     @pytest.mark.asyncio
-    async def test_excludes_assistant_turns_with_tool_markers(self):
-        """Assistant turns with tool call markers should be excluded from history."""
+    async def test_includes_enrichment_metadata_separately(self):
+        """Assistant turns should have pristine content with enrichment in a separate tag."""
         metadata = {"reasoning_summary": "test"}
         history = [
             {"role": "user", "content": "Create a project called X"},
-            {"role": "assistant", "content": "Done!\n[Created: X (project)]"},
+            {"role": "assistant", "content": "Done!", "enrichment_metadata": "[Created: X (project)]"},
             {"role": "user", "content": "Now update it"},
         ]
 
@@ -925,8 +886,10 @@ class TestHistoryFilteringInReasoningAgent:
         full_prompt = call_args.args[1]  # second positional arg
         # User turns should be included
         assert "<user>" in full_prompt
-        # Assistant turn with tool marker should be excluded
-        assert "[Created:" not in full_prompt
+        # Assistant turn content should be pristine (no markers appended)
+        assert "<assistant>Done!</assistant>" in full_prompt
+        # Enrichment metadata should appear in a separate tag
+        assert "<enrichment>[Created: X (project)]</enrichment>" in full_prompt
 
     @pytest.mark.asyncio
     async def test_keeps_assistant_turns_without_markers(self):


### PR DESCRIPTION
## Summary
- Moves history enrichment from inline string mutation to a separate metadata field
- Cleaner separation of concerns for message processing

Fixes re-jux4

🤖 Generated with [Claude Code](https://claude.com/claude-code)