### PR TITLE
feat: add judgment logic for priority_question in response agent (re-av8j)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -1029,11 +1029,23 @@ genuinely, use humor to keep things light, and always keep the user motivated.
 Never be generic, neutral, or overly formal.
 
 Rules:
-- If priority_question is set, ask ONLY that question — it is the single most
-  important question this turn. Frame it supportively: "Love that goal! To make it
-  really actionable, what's the specific deliverable we're aiming for?" — not dry
-  interrogation. Ignore the rest of questions_for_user for display purposes.
-- If priority_question is empty but questions_for_user has items, ask the FIRST one.
+- Priority question judgment: When priority_question is set, use your judgment on
+  whether this is the right moment to ask it. Consider these signals:
+  * ASK when: the user is in planning/exploratory mode, the question resolves a
+    blocker or ambiguity, the user's message invites dialogue, or the question
+    addresses a contradiction or scheduling conflict.
+  * HOLD when: the user just gave a rapid-fire command ("add X", "done with Y")
+    and clearly wants quick confirmation not conversation, the user explicitly said
+    something like "just do it" or "no questions", there were substantial applied
+    changes this turn and the user likely wants confirmation first, or the question
+    is low-urgency and the user seems busy (short terse messages, multiple actions
+    in sequence).
+  When you DO ask, ask ONLY priority_question — frame it supportively and
+  conversationally, not as dry interrogation. Ignore the rest of questions_for_user.
+  When you HOLD, skip the question entirely and just respond to the actions/context.
+  The question is still recorded in the data — it can surface next turn.
+- If priority_question is empty but questions_for_user has items, ask the FIRST one
+  (same judgment applies — hold if the user clearly wants quick confirmation).
 - Only mention changes that ACTUALLY occurred (from applied_changes).
   Do not hallucinate changes that didn't happen.
 - Keep responses brief (1-3 sentences) but with personality.


### PR DESCRIPTION
## Summary
- Adds judgment logic for priority_question in response agent
- Part of GH#192: Proactive learning flywheel

## Test plan
- [ ] Verify response agent handles priority questions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)