### PR TITLE
fix: inject current date into agent system prompts (GH #186)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sqlite3
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -244,6 +245,12 @@ async def _chat(
             model=getattr(response, "model", None) or used_model,
         )
     return response.choices[0].message.content or ""
+
+
+def _with_current_date(prompt: str) -> str:
+    """Prepend the current date to a system prompt so the LLM knows 'today'."""
+    today = date.today().strftime("%A, %B %-d, %Y")  # e.g. "Saturday, March 22, 2026"
+    return f"Current date: {today}\n\n{prompt}"
 
 
 # ---------------------------------------------------------------------------
@@ -1206,7 +1213,7 @@ def get_response_system_prompt(
     if personality_patterns:
         prompt += _build_personality_overlay(personality_patterns)
 
-    return prompt
+    return _with_current_date(prompt)
 
 
 def _build_response_messages(

--- a/backend/context_agent.py
+++ b/backend/context_agent.py
@@ -27,6 +27,7 @@ from .agents import (
     REQUESTY_MODEL,
     UsageStats,
     _chat_ollama,
+    _with_current_date,
 )
 
 logger = logging.getLogger(__name__)
@@ -180,7 +181,7 @@ async def run_context_agent(
     # Try Ollama first if configured (unchanged — Ollama doesn't use ADK)
     if OLLAMA_MODEL:
         try:
-            messages = [{"role": "system", "content": CONTEXT_AGENT_SYSTEM}]
+            messages = [{"role": "system", "content": _with_current_date(CONTEXT_AGENT_SYSTEM)}]
             for h in history[-context_window:]:
                 messages.append({"role": h["role"], "content": h["content"]})
             messages.append({"role": "user", "content": message})
@@ -208,7 +209,7 @@ async def run_context_agent(
             name="context_agent",
             description="Generates search parameters to find relevant Things in the database.",
             model=litellm_model,
-            instruction=CONTEXT_AGENT_SYSTEM,
+            instruction=_with_current_date(CONTEXT_AGENT_SYSTEM),
             generate_content_config=genai_types.GenerateContentConfig(
                 response_mime_type="application/json",
             ),
@@ -295,7 +296,7 @@ async def run_context_refinement(
     # Try Ollama first if configured
     if OLLAMA_MODEL:
         try:
-            messages = [{"role": "system", "content": CONTEXT_REFINEMENT_SYSTEM}]
+            messages = [{"role": "system", "content": _with_current_date(CONTEXT_REFINEMENT_SYSTEM)}]
             for h in history[-context_window:]:
                 messages.append({"role": h["role"], "content": h["content"]})
             messages.append({"role": "user", "content": refinement_prompt})
@@ -315,7 +316,7 @@ async def run_context_refinement(
             name="context_refinement_agent",
             description="Decides if more context searches are needed.",
             model=litellm_model,
-            instruction=CONTEXT_REFINEMENT_SYSTEM,
+            instruction=_with_current_date(CONTEXT_REFINEMENT_SYSTEM),
             generate_content_config=genai_types.GenerateContentConfig(
                 response_mime_type="application/json",
             ),

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -24,6 +24,7 @@ from .agents import (
     REQUESTY_REASONING_MODEL,
     UsageStats,
     _chat_ollama,
+    _with_current_date,
     apply_storage_changes,
 )
 from .context_agent import _make_litellm_model, _run_agent_for_text
@@ -431,11 +432,13 @@ def get_system_prompt_for_mode(mode: str, interaction_style: str = "auto") -> st
         base = REASONING_AGENT_TOOL_SYSTEM
 
     if interaction_style == "coach":
-        return base + _COACH_STYLE_OVERLAY
+        prompt = base + _COACH_STYLE_OVERLAY
     elif interaction_style == "consultant":
-        return base + _CONSULTANT_STYLE_OVERLAY
+        prompt = base + _CONSULTANT_STYLE_OVERLAY
     else:
-        return base + _AUTO_STYLE_OVERLAY
+        prompt = base + _AUTO_STYLE_OVERLAY
+
+    return _with_current_date(prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -1237,7 +1240,7 @@ async def run_reasoning_agent(
     # -- Ollama fallback (unchanged — uses JSON blob + apply_storage_changes) --
     if OLLAMA_MODEL:
         try:
-            messages = [{"role": "system", "content": REASONING_AGENT_SYSTEM}]
+            messages = [{"role": "system", "content": _with_current_date(REASONING_AGENT_SYSTEM)}]
             for h in history[-context_window:]:
                 messages.append({"role": h["role"], "content": h["content"]})
             messages.append({"role": "user", "content": user_content})


### PR DESCRIPTION
## Summary
- Adds `_with_current_date()` helper to inject current date into agent system prompts (context, reasoning, response)
- Fixes issue where agent responds with "I don't have access to real-time date information" when asked about schedule/agenda
- 512 tests pass

Fixes #186

## Test plan
- [ ] CI Quality Gates pass
- [ ] Agent correctly responds with current date when asked

🤖 Generated with [Claude Code](https://claude.com/claude-code)