### PR TITLE
feat: model picker with cost display (GH #185)

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -94,6 +94,8 @@ class UserSettingsUpdate(BaseModel):
 class RequestyModel(BaseModel):
     id: str
     name: str | None = None
+    input_cost_per_million: float | None = None
+    output_cost_per_million: float | None = None
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -245,7 +247,31 @@ async def list_models(
         resp = await client.get(f"{base_url}/models", headers=headers, timeout=10.0)
         resp.raise_for_status()
         data = resp.json().get("data", [])
-        return [RequestyModel(id=m["id"], name=m.get("name")) for m in data if m.get("id")]
+
+        # Build pricing lookup from Requesty response
+        api_pricing: dict[str, tuple[float, float]] = {}
+        for m in data:
+            mid = m.get("id", "")
+            inp = m.get("input_price")
+            outp = m.get("output_price")
+            if mid and inp is not None and outp is not None:
+                api_pricing[mid] = (float(inp) * 1_000_000, float(outp) * 1_000_000)
+
+        from ..agents import MODEL_PRICING
+
+        models = []
+        for m in data:
+            mid = m.get("id")
+            if not mid:
+                continue
+            pricing = api_pricing.get(mid) or MODEL_PRICING.get(mid)
+            models.append(RequestyModel(
+                id=mid,
+                name=m.get("name"),
+                input_cost_per_million=pricing[0] if pricing else None,
+                output_cost_per_million=pricing[1] if pricing else None,
+            ))
+        return models
     except Exception as exc:
         logger.warning("Failed to fetch models from Requesty: %s", exc)
         raise HTTPException(status_code=502, detail="Could not fetch models from Requesty API") from exc

--- a/frontend/src/__tests__/SettingsPanel.test.tsx
+++ b/frontend/src/__tests__/SettingsPanel.test.tsx
@@ -170,6 +170,18 @@ describe('SettingsPanel', () => {
     const firstSelect = selects[0]!
     expect(firstSelect).toHaveValue('custom-model')
   })
+
+  it('displays cost info when model has pricing data', () => {
+    storeState.modelSettings = { context: 'gpt-4', reasoning: 'gpt-4', response: 'gpt-4', chat_context_window: 3 }
+    storeState.availableModels = [
+      { id: 'gpt-4', name: null, input_cost_per_million: 30.0, output_cost_per_million: 60.0 },
+      { id: 'gpt-3.5', name: null, input_cost_per_million: 0.5, output_cost_per_million: 1.5 },
+    ]
+    render(<SettingsPanel />)
+
+    // Cost info should be shown below the selected model
+    expect(screen.getAllByText(/\$30\.0 input/)[0]).toBeInTheDocument()
+  })
 })
 
 // Helper: default model settings so SettingsForm renders (required for profile section)

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
-import type { ModelSettings, UserSettings, UserProfileRelationship } from '../store'
+import type { ModelSettings, UserSettings, UserProfileRelationship, RequestyModel } from '../store'
 import { useTheme, setTheme } from '../hooks/useTheme'
 import { ttsSupported, useAvailableVoices, getStoredVoiceURI, setStoredVoiceURI } from '../hooks/useTTS'
 import { RelationshipMiniGraph } from './RelationshipMiniGraph'
@@ -40,7 +40,7 @@ export function SettingsPanel() {
     fetchUserProfile()
   }, [fetchModelSettings, fetchAvailableModels, fetchUserSettings, fetchUserProfile])
 
-  const modelOptions = availableModels.map(m => m.id).sort()
+  const sortedModels = [...availableModels].sort((a, b) => a.id.localeCompare(b.id))
   const isLoading = settingsLoading || modelsLoading
 
   return (
@@ -74,7 +74,7 @@ export function SettingsPanel() {
                 key={`${modelSettings.context}|${modelSettings.reasoning}|${modelSettings.response}|${modelSettings.chat_context_window}|${userSettings?.requesty_api_key}`}
                 initial={modelSettings}
                 initialUserSettings={userSettings}
-                modelOptions={modelOptions}
+                models={sortedModels}
                 onClose={closeSettings}
               />
             ) : (
@@ -102,12 +102,12 @@ export function SettingsPanel() {
 function SettingsForm({
   initial,
   initialUserSettings,
-  modelOptions,
+  models,
   onClose,
 }: {
   initial: ModelSettings
   initialUserSettings: UserSettings | null
-  modelOptions: string[]
+  models: RequestyModel[]
   onClose: () => void
 }) {
   const updateModelSettings = useStore(s => s.updateModelSettings)
@@ -208,21 +208,21 @@ function SettingsForm({
             label="Context Model"
             description="Gathers context from your data"
             value={context}
-            options={modelOptions}
+            models={models}
             onChange={setContext}
           />
           <ModelSelect
             label="Reasoning Model"
             description="Plans actions and makes decisions"
             value={reasoning}
-            options={modelOptions}
+            models={models}
             onChange={setReasoning}
           />
           <ModelSelect
             label="Response Model"
             description="Generates the final reply"
             value={response}
-            options={modelOptions}
+            models={models}
             onChange={setResponse}
           />
         </div>
@@ -702,19 +702,28 @@ function ProactivitySection() {
   )
 }
 
+function formatCost(costPerMillion: number): string {
+  if (costPerMillion < 0.01) return '<$0.01'
+  if (costPerMillion < 1) return `$${costPerMillion.toFixed(2)}`
+  return `$${costPerMillion.toFixed(1)}`
+}
+
 function ModelSelect({
   label,
   description,
   value,
-  options,
+  models,
   onChange,
 }: {
   label: string
   description: string
   value: string
-  options: string[]
+  models: RequestyModel[]
   onChange: (v: string) => void
 }) {
+  const selectedModel = models.find(m => m.id === value)
+  const modelIds = models.map(m => m.id)
+
   return (
     <div>
       <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -726,15 +735,23 @@ function ModelSelect({
         onChange={e => onChange(e.target.value)}
         className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:focus:ring-indigo-500 focus:border-indigo-400 dark:focus:border-indigo-500"
       >
-        {value && !options.includes(value) && (
+        {value && !modelIds.includes(value) && (
           <option value={value}>{value}</option>
         )}
-        {options.map(id => (
-          <option key={id} value={id}>
-            {id}
+        {models.map(m => (
+          <option key={m.id} value={m.id}>
+            {m.id}
+            {m.input_cost_per_million != null && m.output_cost_per_million != null
+              ? ` (${formatCost(m.input_cost_per_million)} in / ${formatCost(m.output_cost_per_million)} out per 1M tokens)`
+              : ''}
           </option>
         ))}
       </select>
+      {selectedModel?.input_cost_per_million != null && selectedModel?.output_cost_per_million != null && (
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          Cost: {formatCost(selectedModel.input_cost_per_million)} input / {formatCost(selectedModel.output_cost_per_million)} output per 1M tokens
+        </p>
+      )}
     </div>
   )
 }

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -276,6 +276,8 @@ export const UserSettingsSchema = z.object({
 export const RequestyModelSchema = z.object({
   id: z.string(),
   name: z.string().nullable(),
+  input_cost_per_million: z.number().nullable().optional(),
+  output_cost_per_million: z.number().nullable().optional(),
 })
 
 // --- User Profile ---

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -195,6 +195,8 @@ export interface ModelSettings {
 export interface RequestyModel {
   id: string
   name: string | null
+  input_cost_per_million?: number | null
+  output_cost_per_million?: number | null
 }
 
 export type InteractionStyle = 'auto' | 'coach' | 'consultant'


### PR DESCRIPTION
## Summary
- Redesigns model picker with backend pricing from Requesty API + MODEL_PRICING fallback
- Frontend shows cost per 1M tokens in dropdown and below selected model

Part of #185

## Test plan
- [ ] CI Quality Gates pass
- [ ] Model picker shows costs per model option

🤖 Generated with [Claude Code](https://claude.com/claude-code)