### PR TITLE
fix: update deploy path from old gt to new gc location

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.61.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.61.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.61.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.61.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.61.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.61.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.61.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.61.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.61.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.61.0 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             docker pull "$IMAGE:$NEW_TAG"
 
             # Update and restart
-            cd /home/asiri/gt/reli/mayor/rig
+            cd /home/asiri/gc/rigs/reli
             git pull --rebase
             RELI_IMAGE_TAG="$NEW_TAG" docker compose up -d
 


### PR DESCRIPTION
## Summary
- Updates the CD deploy path from `/home/asiri/gt/reli/mayor/rig` (old Gas Town) to `/home/asiri/gc/rigs/reli` (new Gas City)
- Without this fix, deployments on merge to master would either fail or deploy from stale code

## Test plan
- [ ] CI passes (this is a workflow-only change, no app code touched)
- [ ] Next merge to master triggers deploy to the correct path