### PR TITLE
fix: switch reasoning model to non-thinking gemini-2.5-flash to fix thought_signature errors

### DIFF
--- a/backend/context_agent.py
+++ b/backend/context_agent.py
@@ -47,6 +47,25 @@ def _strip_markdown_fences(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Gemini model names that are known "thinking" models requiring
+# thought_signature handling.  The openai/ routing through Requesty
+# does NOT preserve thought_signatures, so these models will fail
+# on multi-step tool calls.  See GH #176.
+_GEMINI_THINKING_MODELS = frozenset({
+    "gemini-3-flash-preview",
+    "gemini-3-flash",
+    "gemini-2.5-pro-preview",
+    "gemini-2.5-flash-thinking",
+})
+
+
+def _is_thinking_model(model_name: str) -> bool:
+    """Return True if *model_name* is a Gemini thinking model."""
+    # Strip provider prefixes like "google/" or "openai/google/"
+    base = model_name.rsplit("/", 1)[-1]
+    return base in _GEMINI_THINKING_MODELS
+
+
 def _make_litellm_model(
     model: str | None = None,
     api_key: str | None = None,
@@ -56,8 +75,21 @@ def _make_litellm_model(
 
     Extra kwargs are forwarded to the LiteLlm constructor and ultimately to
     litellm's completion call (e.g. ``extra_body`` for provider-specific params).
+
+    Warning: Gemini thinking models (e.g. gemini-3-flash-preview) require
+    thought_signature preservation which is NOT supported when routing
+    through the openai/ prefix to Requesty.  Multi-step tool calls will
+    fail with 400 errors.  Use a non-thinking model for tool-calling agents.
     """
     effective_model = model or REQUESTY_MODEL
+    if _is_thinking_model(effective_model):
+        logger.warning(
+            "Model %s is a Gemini thinking model — multi-step tool calls "
+            "may fail with thought_signature errors when routed through "
+            "the openai/ prefix. Consider using a non-thinking model "
+            "like google/gemini-2.5-flash. See GH #176.",
+            effective_model,
+        )
     # LiteLlm expects the openai/ prefix for OpenAI-compatible providers
     if not effective_model.startswith("openai/"):
         effective_model = f"openai/{effective_model}"

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -1096,7 +1096,7 @@ def _make_reasoning_tools(
 
 
 # ---------------------------------------------------------------------------
-# Gemini thought_signature helpers (GH #158 / Sentry RELI-ZO-5)
+# Gemini thought_signature helpers (GH #158 / Sentry RELI-ZO-5 / GH #176)
 # ---------------------------------------------------------------------------
 
 
@@ -1113,54 +1113,24 @@ async def _run_adk_with_thought_signature_fallback(
     usage_stats: "UsageStats | None" = None,
     api_key: str | None = None,
 ) -> str:
-    """Run an ADK agent with a fallback for thought_signature errors.
+    """Run an ADK agent, retrying with a fresh session on thought_signature errors.
 
-    If the first attempt fails with a thought_signature error (Gemini rejects
-    function-call parts that lack signatures when thinking is enabled), retry
-    with only the current-turn content (no history) and a NEW session.
-
-    If it STILL fails, we retry one last time with the
-    'skip_thought_signature_validator' workaround injected into extra_body.
+    Gemini thinking models require thought_signature preservation in multi-turn
+    tool calls.  The openai/ routing through Requesty does not support this
+    (see GH #176).  The default config now uses a non-thinking model, so this
+    fallback should rarely trigger.  If it does, we retry once with a fresh
+    session (no accumulated history) which avoids the missing-signature issue.
     """
     try:
         return await _run_agent_for_text(agent, full_prompt, usage_stats)
     except Exception as exc:
         if _is_thought_signature_error(exc):
             logger.warning(
-                "thought_signature error from Gemini, retrying with fresh session: %s",
+                "thought_signature error — retrying with fresh session "
+                "(consider switching to a non-thinking model, see GH #176): %s",
                 exc,
             )
-            try:
-                # First retry: same config, fresh session, no history
-                return await _run_agent_for_text(agent, fallback_prompt, usage_stats)
-            except Exception as exc2:
-                if _is_thought_signature_error(exc2):
-                    logger.warning("Persistent thought_signature error, retrying with validator skip")
-                    # Second retry: Inject the skip validator workaround
-                    original_model = agent.model
-                    try:
-                        # Determine the original model string
-                        if isinstance(original_model, str):
-                            model_str = original_model
-                        elif hasattr(original_model, "model"):
-                            # LiteLlm objects have a .model attribute
-                            model_str = getattr(original_model, "model")
-                        else:
-                            model_str = REQUESTY_REASONING_MODEL
-
-                        # We re-create the model instance with the skip parameter
-                        agent.model = _make_litellm_model(
-                            model=model_str,
-                            api_key=api_key,
-                            extra_body={
-                                "thinking_config": {"include_thoughts": True, "thinking_budget": 1000},
-                                "thought_signature": "skip_thought_signature_validator",
-                            },
-                        )
-                        return await _run_agent_for_text(agent, fallback_prompt, usage_stats)
-                    finally:
-                        agent.model = original_model
-                raise
+            return await _run_agent_for_text(agent, fallback_prompt, usage_stats)
         raise
 
 
@@ -1277,20 +1247,9 @@ async def run_reasoning_agent(
                 seen_ids.add(t["id"])
                 fetched_context["things"].append(t)
 
-    # Enable thinking for reasoning models. We use 'thinking_budget' which
-    # is the standard parameter LiteLLM expects for Gemini models.
-    # Note: Some OpenAI-compatible proxies (like Requesty) might strip the
-    # required thought_signatures from tool-call turns, causing 400 errors.
-    # We bypass this by injecting a skip validator by default.
-    # TODO: Fix thought_signature stripping in ADK/LiteLLM/Requesty proxy stack
-    # properly and remove this skip (see https://github.com/alexsiri7/reli/issues/180).
     litellm_model = _make_litellm_model(
         model=model or REQUESTY_REASONING_MODEL,
         api_key=api_key,
-        extra_body={
-            "thinking_config": {"include_thoughts": True, "thinking_budget": 1000},
-            "thought_signature": "skip_thought_signature_validator",
-        },
     )
 
     system_prompt = get_system_prompt_for_mode(mode, interaction_style)

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -751,9 +751,9 @@ def test_tool_system_prompt_no_json_output_schema():
 
 
 @pytest.mark.asyncio
-async def test_reasoning_agent_disables_thinking():
-    """LiteLlm model for reasoning agent must disable thinking to avoid
-    thought_signature errors when routing through OpenAI-compatible providers."""
+async def test_reasoning_agent_no_thinking_config():
+    """Reasoning agent must NOT pass thinking config to avoid thought_signature
+    errors when routing through OpenAI-compatible providers (GH #176)."""
     metadata = {"reasoning_summary": "test"}
 
     with (
@@ -780,13 +780,13 @@ async def test_reasoning_agent_disables_thinking():
             user_id="u",
         )
 
-    # Verify _make_litellm_model was called with thinking enabled (re-zo fix)
+    # Verify _make_litellm_model was called without thinking config
     mock_factory.assert_called_once()
     call_kwargs = mock_factory.call_args
     extra_body = call_kwargs.kwargs.get("extra_body")
-    assert extra_body is not None, "extra_body must be passed to enable thinking"
-    assert extra_body.get("thinking_config", {}).get("thinking_budget") == 1000, (
-        "thinking_budget must be 1000 to enable reasoning capabilities"
+    assert extra_body is None, (
+        "extra_body with thinking_config must NOT be passed — "
+        "thinking models cause thought_signature errors via openai/ routing (GH #176)"
     )
 
 
@@ -955,40 +955,27 @@ class TestRunAdkWithThoughtSignatureFallback:
         assert result == "ok"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_skip_validator_on_persistent_error(self):
+    async def test_retries_with_fallback_prompt_on_thought_signature_error(self):
         from backend.reasoning_agent import _run_adk_with_thought_signature_fallback
 
         agent = MagicMock()
-        agent.model.model = "openai/google/gemini-3-flash-preview"
         call_count = 0
 
         async def mock_run(ag, prompt, stats=None):
             nonlocal call_count
             call_count += 1
-            # Fail both first try (history) and second try (no history)
-            if call_count <= 2:
+            if call_count == 1:
                 raise Exception("Function call is missing a thought_signature in functionCall parts.")
-            return f"fallback ok with {ag.model.model}"
+            return f"fallback ok: {prompt}"
 
-        with (
-            patch("backend.reasoning_agent._run_agent_for_text", side_effect=mock_run),
-            patch("backend.reasoning_agent._make_litellm_model") as mock_factory,
-        ):
-            # Mock the factory to return a mock model with the skip parameter
-            mock_skip = MagicMock()
-            mock_skip.model = "openai/google/gemini-3-flash-preview"
-            mock_factory.return_value = mock_skip
-
+        with patch("backend.reasoning_agent._run_agent_for_text", side_effect=mock_run):
             result = await _run_adk_with_thought_signature_fallback(
-                agent, "full with history", "just current turn", usage_stats=None, api_key="test-api-key"
+                agent, "full with history", "just current turn"
             )
 
         assert "fallback ok" in result
-        assert call_count == 3
-        # Verify factory was called with the skip parameter AND the original api_key
-        mock_factory.assert_called_once()
-        assert mock_factory.call_args.kwargs["extra_body"]["thought_signature"] == "skip_thought_signature_validator"
-        assert mock_factory.call_args.kwargs["api_key"] == "test-api-key"
+        assert "just current turn" in result
+        assert call_count == 2
 
     @pytest.mark.asyncio
     async def test_raises_non_thought_signature_errors(self):

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ llm:
   base_url: https://router.requesty.ai/v1
   models:
     context: google/gemini-2.5-flash-lite
-    reasoning: google/gemini-3-flash-preview
+    reasoning: google/gemini-2.5-flash
     response: google/gemini-2.5-flash-lite
 
 ollama:


### PR DESCRIPTION
## Summary
- Switches the reasoning agent to use non-thinking gemini-2.5-flash to eliminate `thought_signature` stripping errors
- Fixes Sentry issue 104463274 where consecutive tool calls through ADK + LiteLLM + Requesty to Gemini 3 Flash were rejected with 400 errors
- Removes insufficient workarounds and resolves the root cause

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)