### PR TITLE
Add preference type_hint + update reasoning agent to detect/create user preferences (GH #191 Tasks 1-2)

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -300,6 +300,37 @@ entity and link them:
    data_json='{"notes": "User\\'s sister\\'s husband"}')  → returns ID_B
 3. create_relationship(from_thing_id=user_id, to_thing_id=ID_A, relationship_type="sister")
 4. create_relationship(from_thing_id=ID_A, to_thing_id=ID_B, relationship_type="husband")
+
+Preference Detection:
+After processing the user's request, also consider what you learned about the
+user as a person. Look for both explicit and inferred preferences:
+
+- **Explicit**: "I hate morning meetings" → create a preference Thing immediately
+- **Inferred**: user cancels or avoids the same kind of thing repeatedly → a
+  pattern is emerging
+
+When you detect a preference:
+1. Call fetch_context with type_hint="preference" to check for existing
+   preference Things that might cover this topic.
+2. If an existing preference Thing matches the topic, call update_thing to add
+   or reinforce the pattern in its data.patterns array. Increment observations
+   and update last_observed. Upgrade confidence if warranted:
+   - "emerging" for 1 observation (first signal)
+   - "moderate" for 2-3 observations
+   - "strong" for 4+ observations
+3. If no matching preference Thing exists, call create_thing with
+   type_hint="preference" and a data_json structure like:
+   {"patterns": [{"pattern": "<description>", "confidence": "emerging",
+   "observations": 1, "first_observed": "<today ISO date>"}]}
+4. Title preference Things descriptively, e.g. "Scheduling preferences" or
+   "Travel booking preferences".
+5. Preference Things can contain multiple related patterns in their
+   data.patterns array. Group by topic rather than creating one Thing per
+   pattern.
+6. Negative preferences (what the user avoids) are as valuable as positive
+   ones.
+7. If an interaction contradicts an existing preference, note the conflict in
+   the pattern but do NOT delete it — preferences can be context-dependent.
 """
 
 REASONING_AGENT_TOOL_SYSTEM = _TOOL_PREAMBLE + _TOOL_RULES

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -316,6 +316,72 @@ class TestCreateThingTool:
             # surface is at index 6 in the INSERT params
             assert args[6] == 0
 
+    def test_create_preference_defaults_surface_false(self):
+        """Preference type_hint should default to surface=false like other entity types."""
+        mock_conn = MagicMock()
+        mock_db_ctx = MagicMock()
+        mock_db_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_db_ctx.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("backend.reasoning_agent.db", return_value=mock_db_ctx),
+            patch("backend.reasoning_agent.upsert_thing"),
+            patch("backend.reasoning_agent.vs_delete"),
+        ):
+            from backend.reasoning_agent import _make_reasoning_tools
+
+            tools, applied, _fetched = _make_reasoning_tools("test-user")
+            create_fn = tools[2]
+
+            new_row = {
+                "id": "pref-uuid",
+                "title": "Scheduling preferences",
+                "type_hint": "preference",
+                "data": '{"patterns": []}',
+                "active": 1,
+                "surface": 0,
+                "open_questions": None,
+            }
+            mock_new = MagicMock()
+            mock_new.__getitem__ = lambda self, key: new_row[key]
+            mock_new.keys = lambda: new_row.keys()
+
+            mock_conn.execute.return_value.fetchone = MagicMock(side_effect=[None, mock_new])
+
+            create_fn(title="Scheduling preferences", type_hint="preference", surface=True)
+
+            insert_call = None
+            for call in mock_conn.execute.call_args_list:
+                if "INSERT INTO things" in str(call):
+                    insert_call = call
+                    break
+            assert insert_call is not None
+            args = insert_call[0][1]
+            # surface is at index 6 in the INSERT params
+            assert args[6] == 0
+
+
+class TestPreferencePromptInstructions:
+    """Verify the reasoning agent prompt includes preference detection instructions."""
+
+    def test_preference_in_entity_types(self):
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+        assert 'type_hint "preference"' in REASONING_AGENT_TOOL_SYSTEM
+
+    def test_preference_detection_section(self):
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+        assert "Preference Detection:" in REASONING_AGENT_TOOL_SYSTEM
+
+    def test_preference_in_entity_types_set(self):
+        from backend.reasoning_agent import _ENTITY_TYPES
+        assert "preference" in _ENTITY_TYPES
+
+    def test_preference_confidence_levels_documented(self):
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+        assert "emerging" in REASONING_AGENT_TOOL_SYSTEM
+        assert "moderate" in REASONING_AGENT_TOOL_SYSTEM
+        assert "strong" in REASONING_AGENT_TOOL_SYSTEM
+
 
 # ---------------------------------------------------------------------------
 # delete_thing tool tests


### PR DESCRIPTION
1. Add 'preference' to recognized type_hints in the Things system. 2. Update reasoning agent prompt to detect explicit and inferred user preferences and create/update preference Things with confidence levels (emerging/moderate/strong). See GH #191 for schema and examples.