### PR TITLE
gc costs: golden eval datasets for preference detection (GH#191 Task 5) (re-4rv)

### DIFF
--- a/eval/_generate_datasets.py
+++ b/eval/_generate_datasets.py
@@ -1239,7 +1239,149 @@ _REASONING_PREFERENCES = EvalSet(
                 ),
             ],
         ),
-        # Negative preference — explicit avoidance
+        # Contradiction — existing preference contradicted by user action
+        EvalCase(
+            eval_id="preference-contradiction",
+            conversation=[
+                Invocation(
+                    invocation_id="inv-1",
+                    user_content=_user(
+                        _reasoning_prompt(
+                            "Schedule an 8am call with the client "
+                            "tomorrow. I know it's early but it's "
+                            "the only time that works.",
+                            things_json=_SCHED_PREF,
+                        )
+                    ),
+                    final_response=_model(
+                        _final_json(
+                            reasoning_summary=(
+                                "Scheduled 8am call; noted "
+                                "contradiction with morning-meeting "
+                                "avoidance preference."
+                            ),
+                        )
+                    ),
+                    intermediate_data=IntermediateData(
+                        tool_uses=[
+                            _fc("fetch_context", {
+                                "search_queries_json": json.dumps([
+                                    "client call",
+                                    "8am",
+                                    "scheduling preferences",
+                                ]),
+                            }),
+                            _fc("create_thing", {
+                                "title": "Client call",
+                                "type_hint": "event",
+                                "data_json": json.dumps({
+                                    "time": "08:00",
+                                    "day": "2026-03-19",
+                                }),
+                                "surface": False,
+                            }),
+                            _fc("update_thing", {
+                                "thing_id": "pref-100",
+                                "data_json": json.dumps({
+                                    "patterns": [{
+                                        "pattern": (
+                                            "Avoids morning meetings"
+                                        ),
+                                        "confidence": "emerging",
+                                        "observations": 1,
+                                        "first_observed": "2026-03-10",
+                                        "last_observed": "2026-03-10",
+                                        "exceptions": [
+                                            "Booked 8am client call "
+                                            "when no other time available "
+                                            "(2026-03-19)"
+                                        ],
+                                    }],
+                                }),
+                            }),
+                        ],
+                        tool_responses=[
+                            _fr("fetch_context", _things_ctx(
+                                {
+                                    "id": "pref-100",
+                                    "title": "Scheduling preferences",
+                                    "type_hint": "preference",
+                                }
+                            )),
+                            _fr("create_thing", {
+                                "id": "eval-pref-0005",
+                                "title": "Client call",
+                                "type_hint": "event",
+                            }),
+                            _fr("update_thing", {
+                                "id": "pref-100",
+                                "title": "Scheduling preferences",
+                            }),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+        # Negative preference — explicit avoidance (what user avoids)
+        EvalCase(
+            eval_id="preference-avoidance-explicit",
+            conversation=[
+                Invocation(
+                    invocation_id="inv-1",
+                    user_content=_user(
+                        _reasoning_prompt(
+                            "I don't work on weekends — please "
+                            "don't schedule anything on Saturday "
+                            "or Sunday."
+                        )
+                    ),
+                    final_response=_model(
+                        _final_json(
+                            reasoning_summary=(
+                                "Noted work-life boundary: does not "
+                                "work on weekends."
+                            ),
+                        )
+                    ),
+                    intermediate_data=IntermediateData(
+                        tool_uses=[
+                            _fc("fetch_context", {
+                                "search_queries_json": json.dumps([
+                                    "weekend",
+                                    "scheduling preferences",
+                                    "work-life",
+                                ]),
+                            }),
+                            _fc("create_thing", {
+                                "title": "Work-life preferences",
+                                "type_hint": "preference",
+                                "data_json": json.dumps({
+                                    "patterns": [{
+                                        "pattern": (
+                                            "Does not work on weekends"
+                                        ),
+                                        "confidence": "strong",
+                                        "observations": 1,
+                                        "first_observed": "2026-03-18",
+                                        "last_observed": "2026-03-18",
+                                    }],
+                                }),
+                                "surface": False,
+                            }),
+                        ],
+                        tool_responses=[
+                            _fr("fetch_context", _empty_ctx()),
+                            _fr("create_thing", {
+                                "id": "eval-pref-0006",
+                                "title": "Work-life preferences",
+                                "type_hint": "preference",
+                            }),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+        # Negative preference — existing cost optimization (kept for coverage)
         EvalCase(
             eval_id="preference-negative-explicit",
             conversation=[

--- a/eval/reasoning_agent/preference_detection.test.json
+++ b/eval/reasoning_agent/preference_detection.test.json
@@ -495,6 +495,240 @@
       "final_session_state": {}
     },
     {
+      "eval_id": "preference-contradiction",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-18 (Wednesday)\n\n<user_message>\nSchedule an 8am call with the client tomorrow. I know it's early but it's the only time that works.\n</user_message>\n\nRelevant Things from database:\n[{\"id\": \"pref-100\", \"title\": \"Scheduling preferences\", \"type_hint\": \"preference\", \"data\": \"{\\\"patterns\\\": [{\\\"pattern\\\": \\\"Avoids morning meetings\\\", \\\"confidence\\\": \\\"emerging\\\", \\\"observations\\\": 1, \\\"first_observed\\\": \\\"2026-03-10\\\", \\\"last_observed\\\": \\\"2026-03-10\\\"}]}\", \"active\": 1}]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"Scheduled 8am call; noted contradiction with morning-meeting avoidance preference.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "search_queries_json": "[\"client call\", \"8am\", \"scheduling preferences\"]"
+                },
+                "name": "fetch_context",
+                "partial_args": null,
+                "will_continue": null
+              },
+              {
+                "id": null,
+                "args": {
+                  "title": "Client call",
+                  "type_hint": "event",
+                  "data_json": "{\"time\": \"08:00\", \"day\": \"2026-03-19\"}",
+                  "surface": false
+                },
+                "name": "create_thing",
+                "partial_args": null,
+                "will_continue": null
+              },
+              {
+                "id": null,
+                "args": {
+                  "thing_id": "pref-100",
+                  "data_json": "{\"patterns\": [{\"pattern\": \"Avoids morning meetings\", \"confidence\": \"emerging\", \"observations\": 1, \"first_observed\": \"2026-03-10\", \"last_observed\": \"2026-03-10\", \"exceptions\": [\"Booked 8am client call when no other time available (2026-03-19)\"]}]}"
+                },
+                "name": "update_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "fetch_context",
+                "response": {
+                  "things": [
+                    {
+                      "id": "pref-100",
+                      "title": "Scheduling preferences",
+                      "type_hint": "preference"
+                    }
+                  ],
+                  "count": 1
+                }
+              },
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "create_thing",
+                "response": {
+                  "id": "eval-pref-0005",
+                  "title": "Client call",
+                  "type_hint": "event"
+                }
+              },
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "update_thing",
+                "response": {
+                  "id": "pref-100",
+                  "title": "Scheduling preferences"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
+    },
+    {
+      "eval_id": "preference-avoidance-explicit",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-18 (Wednesday)\n\n<user_message>\nI don't work on weekends — please don't schedule anything on Saturday or Sunday.\n</user_message>\n\nRelevant Things from database:\n[]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"Noted work-life boundary: does not work on weekends.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "search_queries_json": "[\"weekend\", \"scheduling preferences\", \"work-life\"]"
+                },
+                "name": "fetch_context",
+                "partial_args": null,
+                "will_continue": null
+              },
+              {
+                "id": null,
+                "args": {
+                  "title": "Work-life preferences",
+                  "type_hint": "preference",
+                  "data_json": "{\"patterns\": [{\"pattern\": \"Does not work on weekends\", \"confidence\": \"strong\", \"observations\": 1, \"first_observed\": \"2026-03-18\", \"last_observed\": \"2026-03-18\"}]}",
+                  "surface": false
+                },
+                "name": "create_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "fetch_context",
+                "response": {
+                  "things": [],
+                  "relationships": [],
+                  "count": 0
+                }
+              },
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "create_thing",
+                "response": {
+                  "id": "eval-pref-0006",
+                  "title": "Work-life preferences",
+                  "type_hint": "preference"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
+    },
+    {
       "eval_id": "preference-negative-explicit",
       "conversation": [
         {


### PR DESCRIPTION
## Summary

Golden eval datasets for preference detection — 5 eval categories complete (explicit, inferred, reinforcement, contradiction, avoidance). 641 tests pass.

- Issue: re-4rv
- Branch: gc-polecat-1-re-4rv
- Target: master

Part of #191