### PR TITLE
feat: add communication style signal detection to reasoning agent

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -302,7 +302,64 @@ entity and link them:
 4. create_relationship(from_thing_id=ID_A, to_thing_id=ID_B, relationship_type="husband")
 """
 
-REASONING_AGENT_TOOL_SYSTEM = _TOOL_PREAMBLE + _TOOL_RULES
+_COMM_STYLE_SIGNAL_RULES = """
+Reli Communication Style Signal Detection:
+Alongside regular storage changes, watch for signals about how the user wants
+RELI ITSELF to communicate. These are NOT preferences about the world — they are
+feedback about Reli's own behavior.
+
+**Explicit corrections** (strong signal — act immediately):
+- Direct style instructions: "don't use emoji", "stop using bullet points",
+  "be more concise", "too verbose", "just answer directly", "no preamble",
+  "shorter responses", "don't explain yourself"
+- The user is explicitly telling Reli to change how it responds.
+
+**Implicit corrections** (weaker signal — note as emerging):
+- User says "just" at the start of a request: "just tell me X", "just do Y"
+- User says "simpler", "shorter", "brief", "quick", "tldr" in a follow-up
+- User appears to be correcting Reli's verbosity or style in their next message
+
+When you detect either type:
+1. Search for an existing `reli_communication` preference Thing via fetch_context
+   with search_queries like ["Reli communication style", "how Reli communicates"].
+2. If an existing preference Thing is found (category='reli_communication'), call
+   update_thing to update its data_json, adding or reinforcing the pattern.
+3. If no preference Thing exists, call create_thing with:
+   - title: "How [user's first name or 'the user'] wants Reli to communicate"
+   - type_hint: "preference"
+   - surface: false
+   - data_json: JSON with category="reli_communication" and patterns array
+
+The patterns array follows this structure:
+  {
+    "category": "reli_communication",
+    "patterns": [
+      {
+        "pattern": "<short description of the style rule>",
+        "confidence": "emerging" | "established" | "strong",
+        "observations": <int count>
+      }
+    ]
+  }
+
+Confidence rules:
+- First detection of a pattern: "emerging", observations=1
+- Pattern repeated 2-3 times: "established", observations=N
+- Pattern consistently seen 4+ times: "strong", observations=N
+- Explicit correction → start at "established" (strong signal)
+- Implicit signal → start at "emerging"
+
+When updating an existing preference Thing, increment observations and upgrade
+confidence when the threshold is reached. Never downgrade confidence based on
+silence — only downgrade if the user explicitly contradicts a prior preference
+(e.g., says "actually use emoji now").
+
+Do NOT create a reli_communication preference if:
+- The user is asking about communication in general (not correcting Reli)
+- The message is ambiguous and could be about something else
+"""
+
+REASONING_AGENT_TOOL_SYSTEM = _TOOL_PREAMBLE + _TOOL_RULES + _COMM_STYLE_SIGNAL_RULES
 
 # ---------------------------------------------------------------------------
 # Planning mode system prompt overlay
@@ -365,7 +422,7 @@ After making all needed tool calls, output your final response as JSON:
 }
 """
 
-PLANNING_AGENT_TOOL_SYSTEM = _PLANNING_PREAMBLE + _TOOL_RULES
+PLANNING_AGENT_TOOL_SYSTEM = _PLANNING_PREAMBLE + _TOOL_RULES + _COMM_STYLE_SIGNAL_RULES
 
 # Valid chat modes
 VALID_MODES = {"normal", "planning"}

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -1102,3 +1102,200 @@ class TestHistoryEnrichmentInReasoningAgent:
         full_prompt = call_args.args[1]
         # Both user and assistant turns should be present
         assert "Hi there, how can I help?" in full_prompt
+
+
+# ---------------------------------------------------------------------------
+# Communication style signal detection — system prompt coverage
+# ---------------------------------------------------------------------------
+
+
+class TestCommStyleSignalSystemPrompt:
+    """Verify that communication style signal detection is present in system prompts."""
+
+    def test_comm_style_rules_in_tool_system(self):
+        """REASONING_AGENT_TOOL_SYSTEM includes communication style signal rules."""
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+
+        assert "reli_communication" in REASONING_AGENT_TOOL_SYSTEM
+        assert "Explicit corrections" in REASONING_AGENT_TOOL_SYSTEM
+        assert "Implicit corrections" in REASONING_AGENT_TOOL_SYSTEM
+
+    def test_comm_style_rules_in_planning_system(self):
+        """PLANNING_AGENT_TOOL_SYSTEM also includes communication style signal rules."""
+        from backend.reasoning_agent import PLANNING_AGENT_TOOL_SYSTEM
+
+        assert "reli_communication" in PLANNING_AGENT_TOOL_SYSTEM
+        assert "Explicit corrections" in PLANNING_AGENT_TOOL_SYSTEM
+
+    def test_comm_style_signal_examples_present(self):
+        """Key explicit correction examples are present in the prompt."""
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+
+        assert "don't use emoji" in REASONING_AGENT_TOOL_SYSTEM
+        assert "be more concise" in REASONING_AGENT_TOOL_SYSTEM
+        assert "stop using bullet points" in REASONING_AGENT_TOOL_SYSTEM
+
+    def test_comm_style_confidence_levels_documented(self):
+        """Confidence escalation rules are in the prompt."""
+        from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+
+        assert "emerging" in REASONING_AGENT_TOOL_SYSTEM
+        assert "established" in REASONING_AGENT_TOOL_SYSTEM
+        assert "strong" in REASONING_AGENT_TOOL_SYSTEM
+
+    def test_get_system_prompt_includes_comm_style(self):
+        """get_system_prompt_for_mode returns prompt with comm style rules."""
+        from backend.reasoning_agent import get_system_prompt_for_mode
+
+        for mode in ("normal", "planning"):
+            for style in ("auto", "coach", "consultant"):
+                prompt = get_system_prompt_for_mode(mode, style)
+                assert "reli_communication" in prompt, (
+                    f"reli_communication missing from mode={mode}, style={style}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Communication style signal — create_thing structure
+# ---------------------------------------------------------------------------
+
+
+class TestCommStylePreferenceStructure:
+    """Verify that create_thing can store reli_communication preference data."""
+
+    def test_create_reli_comm_preference_thing(self):
+        """create_thing stores a reli_communication preference with correct structure."""
+        mock_conn = MagicMock()
+        mock_db_ctx = MagicMock()
+        mock_db_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_db_ctx.__exit__ = MagicMock(return_value=False)
+
+        pref_data_str = json.dumps({
+            "category": "reli_communication",
+            "patterns": [
+                {
+                    "pattern": "Avoid using emoji in responses",
+                    "confidence": "established",
+                    "observations": 1,
+                }
+            ],
+        })
+
+        # First fetchone: no existing thing (dedup check returns None)
+        # Second fetchone: newly inserted row
+        new_row = {
+            "id": "pref-uuid",
+            "title": "How the user wants Reli to communicate",
+            "type_hint": "preference",
+            "data": pref_data_str,
+            "active": 1,
+            "surface": 0,
+            "open_questions": None,
+        }
+        mock_new = MagicMock()
+        mock_new.__getitem__ = lambda self, key: new_row[key]
+        mock_new.keys = lambda: new_row.keys()
+
+        mock_conn.execute.return_value.fetchone = MagicMock(side_effect=[None, mock_new])
+
+        with (
+            patch("backend.reasoning_agent.db", return_value=mock_db_ctx),
+            patch("backend.reasoning_agent.upsert_thing") as mock_upsert,
+            patch("backend.reasoning_agent.vs_delete"),
+        ):
+            from backend.reasoning_agent import _make_reasoning_tools
+
+            tools, applied, _fetched = _make_reasoning_tools("test-user")
+            create_fn = tools[2]
+
+            result = create_fn(
+                title="How the user wants Reli to communicate",
+                type_hint="preference",
+                data_json=pref_data_str,
+                surface=False,
+            )
+
+        assert "error" not in result
+        assert len(applied["created"]) == 1
+        created = applied["created"][0]
+        assert created["type_hint"] == "preference"
+
+        # Verify the stored data has the right structure
+        stored_data = json.loads(created["data"])
+        assert stored_data["category"] == "reli_communication"
+        assert stored_data["patterns"][0]["pattern"] == "Avoid using emoji in responses"
+        assert stored_data["patterns"][0]["confidence"] == "established"
+        mock_upsert.assert_called_once()
+
+    def test_update_existing_reli_comm_preference(self):
+        """update_thing can reinforce an existing reli_communication preference."""
+        mock_conn = MagicMock()
+        mock_db_ctx = MagicMock()
+        mock_db_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_db_ctx.__exit__ = MagicMock(return_value=False)
+
+        existing_data = json.dumps({
+            "category": "reli_communication",
+            "patterns": [
+                {
+                    "pattern": "Be concise",
+                    "confidence": "emerging",
+                    "observations": 1,
+                }
+            ],
+        })
+        existing_row = {
+            "id": "pref-uuid",
+            "title": "How the user wants Reli to communicate",
+            "data": existing_data,
+            "checkin_date": None,
+            "open_questions": None,
+        }
+        mock_existing = MagicMock()
+        mock_existing.__getitem__ = lambda self, key: existing_row[key]
+        mock_existing.keys = lambda: existing_row.keys()
+
+        updated_data = json.dumps({
+            "category": "reli_communication",
+            "patterns": [
+                {
+                    "pattern": "Be concise",
+                    "confidence": "established",
+                    "observations": 2,
+                }
+            ],
+        })
+        updated_row = {**existing_row, "data": updated_data}
+        mock_updated = MagicMock()
+        mock_updated.__getitem__ = lambda self, key: updated_row[key]
+        mock_updated.keys = lambda: updated_row.keys()
+
+        mock_conn.execute.return_value.fetchone = MagicMock(
+            side_effect=[mock_existing, mock_updated]
+        )
+
+        with (
+            patch("backend.reasoning_agent.db", return_value=mock_db_ctx),
+            patch("backend.reasoning_agent.upsert_thing"),
+            patch("backend.reasoning_agent.vs_delete"),
+        ):
+            from backend.reasoning_agent import _make_reasoning_tools
+
+            tools, applied, _fetched = _make_reasoning_tools("test-user")
+            update_fn = tools[3]
+
+            new_data = json.dumps({
+                "category": "reli_communication",
+                "patterns": [
+                    {
+                        "pattern": "Be concise",
+                        "confidence": "established",
+                        "observations": 2,
+                    }
+                ],
+            })
+
+            result = update_fn(thing_id="pref-uuid", data_json=new_data)
+
+        assert "error" not in result
+        assert len(applied["updated"]) == 1


### PR DESCRIPTION
## Summary
- Added `_COMM_STYLE_SIGNAL_RULES` to reasoning agent system prompts (normal and planning modes)
- Detects explicit corrections (no emoji, be concise, stop bullet points) and implicit signals (just/shorter/simpler)
- Creates/updates preference Things with `category=reli_communication` and `patterns[]` structure
- 7 new tests added

Part of #193

## Test plan
- [ ] Backend tests pass (646 passed, 9 skipped)
- [ ] Communication style signals are detected and stored as preference Things
- [ ] Both explicit corrections and implicit signals are handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)