### PR TITLE
fix: force SECRET_KEY="" in test env to prevent 401s when run from rig dir (re-7ty)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,12 @@ os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 # Prevent test errors from polluting production Sentry (re-icdi)
 os.environ.setdefault("SENTRY_DSN", "")
 
+# Force auth to disabled in tests: prevent production .env credentials from
+# being loaded by pydantic-settings when tests run from the rig directory.
+# test_auth.py patches backend.auth.SECRET_KEY directly for auth-enabled tests.
+os.environ["SECRET_KEY"] = ""
+os.environ["RELI_API_TOKEN"] = ""
+
 # ---------------------------------------------------------------------------
 # Database fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix pre-existing test failures in `test_api_contracts` and `test_briefing` that were returning 401.

**Root cause:** pydantic-settings loads production `.env` (which has `SECRET_KEY` set) when tests run from the rig directory. This caused the auth middleware to enable authentication in the test environment.

**Fix:** Force `SECRET_KEY=''` and `RELI_API_TOKEN=''` in `conftest.py` before backend imports, ensuring tests always run with auth disabled regardless of working directory.

641 tests pass.

Part of #re-7ty