### PR TITLE
Add vision docs and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,49 @@
 # Reli
 
-Reli is a personal AI information manager that learns about you through conversation. It stores knowledge as "Things" in a graph and uses a multi-agent pipeline to understand context, reason about changes, and respond naturally.
+Reli is a personal AI assistant that builds a structured model of who you are and uses it to be genuinely helpful. It stores knowledge as "Things" in a knowledge graph, learns your preferences and patterns over time, and proactively surfaces what matters — not just when you ask, but when you need it.
 
-Everything you tell Reli — tasks, notes, ideas, people, projects — becomes a Thing in your personal knowledge graph. Ask Reli to remember something, and it figures out what to create or update. Ask it a question, and it searches your graph to answer.
+The goal is a PA that says "bring a change of clothes today, you have that event tonight" or "it's Saturday morning — your energy contract expires next month, want me to find a better deal?" — one that understands your life context, your schedule, your routines, and the right moment to act.
 
-## Architecture
+## How it works
 
-Reli processes every message through a 4-stage agent pipeline:
+Everything you tell Reli — tasks, notes, ideas, people, projects — becomes a **Thing** in your personal knowledge graph. Things are typed, linked by relationships, and enriched over time. Ask Reli to remember something, and it figures out what to create, update, or connect. Ask it a question, and it searches your graph to answer.
+
+Reli also learns *how you operate*. Preferences like "avoids morning meetings" or "does venue-before-budget when planning events" are tracked as first-class Things with confidence levels that strengthen or decay based on your behavior.
+
+Every message flows through a multi-stage agent pipeline:
 
 ```
 User Message
-    │
-    ▼
-┌─────────────────┐
-│ Context Agent    │  Decides what to search (generates queries)
-│ (The Librarian)  │
-└────────┬────────┘
-         ▼
-┌─────────────────┐
-│ Reasoning Agent  │  Decides what to change (outputs structured JSON)
-│ (The Brain)      │
-└────────┬────────┘
-         ▼
-┌─────────────────┐
-│ Validator        │  Applies changes to the database
-│ (Logic/Code)     │
-└────────┬────────┘
-         ▼
-┌─────────────────┐
-│ Response Agent   │  Explains what happened in natural language
-│ (The Voice)      │
-└─────────────────┘
+    |
+    v
++------------------+
+| Context Agent    |  Searches your knowledge graph for relevant Things
++--------+---------+
+         v
++------------------+
+| Reasoning Agent  |  Decides what to create/update/link, extracts preferences
++--------+---------+
+         v
++------------------+
+| Validator        |  Applies changes to the database
++--------+---------+
+         v
++------------------+
+| Response Agent   |  Responds naturally, shaped by your learned preferences
++------------------+
 ```
 
-Each agent stage uses a model optimized for its task. All LLM calls route through [Requesty](https://requesty.ai), an OpenAI-compatible gateway that handles model routing and cost tracking. Models are configured in `config.yaml`.
+## Vision
+
+Reli aims to be a true personal assistant — one that models you, manages your **concerns**, and gets better over time. See the [vision document](docs/vision.md) for the full picture, including:
+
+- **Concerns** — modular domains of life (health, finance, travel) that Reli monitors on your behalf
+- **The learning flywheel** — how every interaction makes Reli smarter about you
+- **The nightly sweep** — Reli's planning session: gap detection, pattern aggregation, briefings
+- **MCP** — Reli as an intelligence service that any AI tool can tap into
+- **Multi-channel delivery** — Telegram, Claude Code, email — the intelligence isn't tied to one UI
+
+For how Reli compares to related projects, see [comparisons](docs/comparisons.md).
 
 ## Tech Stack
 
@@ -75,24 +85,22 @@ Edit `.env` and set at minimum:
 
 - `REQUESTY_API_KEY` — Get from [requesty.ai](https://requesty.ai)
 - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — For Google OAuth login
+- `GOOGLE_SEARCH_API_KEY` / `GOOGLE_SEARCH_CX` — Enable web search in chat
 - `SECRET_KEY` — JWT signing key
 
 Optional:
 - `OLLAMA_MODEL` — Use a local LLM for the context agent (reduces API costs)
-- `GOOGLE_SEARCH_API_KEY` / `GOOGLE_SEARCH_CX` — Enable web search in chat
 - `CLOUDFLARE_TUNNEL_TOKEN` — Expose the app publicly via Cloudflare Tunnel
 
 ### 3. Run in development
 
 ```bash
-# Start the backend (serves frontend from frontend/dist/ if built)
+# Start the backend
 uvicorn backend.main:app --reload --port 8000
 
 # In another terminal, start the frontend dev server
 cd frontend && npm run dev
 ```
-
-The frontend dev server proxies `/api` requests to the backend on port 8000.
 
 ### 4. Run with Docker (production)
 
@@ -110,12 +118,12 @@ The app is available at `http://localhost:8000`. Data persists in `./data/` via 
 llm:
   base_url: https://router.requesty.ai/v1
   models:
-    context: google/gemini-2.5-flash-lite    # Fast query generation
-    reasoning: google/gemini-2.5-flash  # Structured decision-making
-    response: google/gemini-2.5-flash-lite    # Natural language replies
+    context: google/gemini-2.5-flash-lite
+    reasoning: google/gemini-2.5-flash
+    response: google/gemini-2.5-flash-lite
 
 embedding:
-  model: text-embedding-3-small  # Vector embeddings for search
+  model: text-embedding-3-small
 ```
 
 Models can also be overridden via environment variables (`REQUESTY_MODEL`, `REQUESTY_REASONING_MODEL`, `REQUESTY_RESPONSE_MODEL`).
@@ -123,10 +131,7 @@ Models can also be overridden via environment variables (`REQUESTY_MODEL`, `REQU
 ## Testing
 
 ```bash
-# All gates (setup, lint, typecheck, test, build)
-./scripts/gates.sh
-
-# Individual stages
+./scripts/gates.sh              # All gates
 ./scripts/gates.sh test          # Backend (pytest) + Frontend (vitest)
 ./scripts/gates.sh lint          # Backend (ruff) + Frontend (eslint)
 ./scripts/gates.sh typecheck     # Backend (mypy) + Frontend (tsc)
@@ -137,7 +142,7 @@ Models can also be overridden via environment variables (`REQUESTY_MODEL`, `REQU
 ```
 backend/
   main.py              # FastAPI app, static file serving
-  agents.py            # 4-stage agent pipeline
+  agents.py            # Multi-stage agent pipeline
   database.py          # SQLite schema, migrations, queries
   vector_store.py      # ChromaDB embeddings
   models.py            # Pydantic models
@@ -149,10 +154,10 @@ backend/
     calendar.py        # /api/calendar — Google Calendar
     gmail.py           # /api/gmail — Gmail integration
     settings.py        # /api/settings
-    sweep.py           # /api/sweep — nightly cleanup
+    sweep.py           # /api/sweep — nightly analysis
 frontend/
   src/                 # React app (TypeScript)
-  package.json
+docs/                  # Vision, architecture, and design documents
 config.yaml            # Model configuration
 docker-compose.yml     # Production deployment
 Dockerfile             # Multi-stage build (Node + Python)

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,0 +1,47 @@
+# Comparisons
+
+How Reli relates to other projects in the personal AI space.
+
+## OB1 (Open Brain)
+
+[OB1](https://github.com/NateBJones-Projects/OB1) is a shared memory layer for AI tools — Postgres + pgvector, accessible via MCP. Its tagline: "One database, one AI gateway, one chat channel."
+
+**Overlap:** Both want to be the persistent memory that follows you across AI clients, both use MCP as the integration protocol, both are self-hosted.
+
+**Where Reli goes further:**
+
+| | OB1 | Reli |
+|---|---|---|
+| Storage | Flat "thoughts" + vector search | Typed Things with relationships (graph) |
+| Reasoning | None — the calling agent figures it out | Reasoning pipeline + PA prompts via MCP |
+| Learning | None — it's a database | Preference extraction, confidence tracking, pattern detection |
+| Proactive | None | Sweep, briefings, gap detection |
+| Domain intelligence | None | Concerns (health, finance, travel...) |
+| Ingestion | Slack messages | Conversation + calendar + email |
+
+**The key difference:** OB1 solves "my AI tools don't share memory." Reli solves "I want an AI that knows me and acts on my behalf." OB1 is what you'd build if you only wanted the storage layer.
+
+**Could Reli use OB1 as storage?** In theory, but you'd lose the graph structure that makes Reli's intelligence work — typed relationships, preference schemas with confidence tracking, Thing-level metadata for concerns, and the sweep's ability to query over structure ("find all appointments not updated in 6 months"). The graph earns its keep.
+
+## OpenClaw
+
+[OpenClaw](https://github.com/openclaw/openclaw) is a self-hosted AI assistant framework focused on multi-channel delivery — 23+ messaging platforms (WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Teams, etc.) with device pairing, voice integration, and a skills platform.
+
+**Overlap:** Both want to be a personal AI assistant. Both are self-hosted.
+
+**Complementary strengths:**
+
+| | OpenClaw | Reli |
+|---|---|---|
+| Focus | Delivery and routing | Intelligence and knowledge |
+| Channels | 23+ messaging platforms | Web UI (expanding) |
+| Memory | Conversation history with pruning/compaction | Structured knowledge graph |
+| User model | None | Preferences, patterns, concerns |
+| Proactive | None | Sweep, briefings, gap detection |
+| Device integration | macOS/iOS/Android nodes | None |
+
+**OpenClaw is a routing and delivery layer.** It's excellent at getting messages to/from you across platforms and executing tools. But it doesn't have a structured model of *you* — no knowledge graph, no preference learning, no proactive intelligence.
+
+**Reli is the opposite** — strong on user modeling, weak on delivery. Reli has the knowledge graph, the preference system, the learning flywheel, and the sweep... but currently only delivers through a web chat UI.
+
+**Potential integration:** Reli's MCP server could be consumed by OpenClaw as a skill/tool, giving Reli's intelligence access to 23+ delivery channels without building each integration from scratch. The security model would need careful evaluation — OpenClaw's broad agent capabilities and multi-channel surface area create a larger attack surface for context poisoning and unintended actions. But architecturally, it's a natural fit: Reli provides the thinking, OpenClaw provides the delivery.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,0 +1,73 @@
+# Next Steps
+
+Immediate priorities and the path forward.
+
+## Current state
+
+The core pipeline works: context agent, reasoning agent, validator, response agent. Things are created, updated, linked. Google Calendar and Gmail integrations exist. The preference learning system is partially landed (personality schema, response agent loading, sweep aggregation are merged; reasoning agent signal detection is in progress).
+
+The system is currently stabilizing — bugs in both Reli and the development tooling need resolution before pushing further on features.
+
+## Immediate priorities
+
+### 1. Stabilize the core
+
+Before adding new capabilities, the existing system needs to be reliable:
+- Fix outstanding bugs in the pipeline
+- Ensure Things operations (create, update, link, delete) are consistently correct
+- Verify the sweep runs reliably
+
+### 2. Complete preference learning (#191, #193)
+
+The foundation for everything else. Remaining work:
+- Finish reasoning agent signal detection (explicit, implicit, positive, negative, behavioral signals)
+- Wire signals to preference Thing creation/updates
+- Validate that preferences actually improve responses over time
+
+### 3. Rolling conversation context (#188)
+
+One conversation per user, running indefinitely. Three-layer memory:
+- Long-term: Things DB
+- Short-term: rolling summary (compressed every N messages)
+- Task context: per-request retrieval
+
+### 4. Structured Thing references (#187)
+
+Response agent outputs which Things it mentions as structured JSON, not string concatenation. Clean content, structured metadata, frontend inline linking.
+
+### 5. Context agent as reasoning sub-agent (#165)
+
+Move from rigid pipeline to on-demand context retrieval:
+- Warm start with last 3 messages + their context
+- Reasoning agent calls context search when it needs more
+- ~80% of turns are follow-ups that don't need fresh retrieval
+
+## Near-term roadmap
+
+### Proactive learning (#192)
+
+The reasoning agent generates a `priority_question` every turn — the single most valuable question to ask right now. The response agent decides whether to actually ask it based on conversation flow. The sweep detects gaps in Things and attaches open questions.
+
+### Concerns (new)
+
+Modular domain intelligence. Each concern (health, finance, travel) brings knowledge about what to care about and what questions to ask. Lifecycle: initialize (scan sources, build understanding, surface questions) → watch (react to relevant new inputs). See [vision](vision.md#concerns).
+
+### MCP server (#190)
+
+Expose Reli's intelligence to any MCP-compatible client:
+- CRUD + search tools for Things
+- PA behavior prompts (how to act on the user's behalf)
+- Retrieval of preferences and the user model
+- Briefing/sweep results
+
+### Prompt evals (#160)
+
+Golden datasets + ADK eval + Phoenix observability. Gate PRs on eval score thresholds. This is infrastructure for confident iteration on the prompts that drive Reli's intelligence.
+
+## Future possibilities
+
+- **Telegram bot** for proactive delivery (morning briefings, nudges, quick interactions)
+- **Supabase migration** (#189) for multi-user support with RLS
+- **OpenClaw integration** for broad multi-channel delivery (see [comparisons](comparisons.md#openclaw))
+- **Mutations journal** for audit and rollback of knowledge graph changes
+- **Additional ingestion sources** beyond calendar and email

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,137 @@
+# Vision
+
+Reli is an attempt to push the concept of a personal AI assistant to its limits. Not a chatbot with memory bolted on, but a system that genuinely models you and gets better over time.
+
+## A system that models you
+
+The core insight is that a PA's value comes from understanding the person it serves. Reli builds this understanding through three mechanisms:
+
+**The knowledge graph.** Everything Reli knows is stored as typed Things with relationships. People, events, tasks, preferences, patterns — all linked. This structure is what allows Reli to reason across domains: "your dentist is near the restaurant you're going to Thursday."
+
+**Preference learning.** Every interaction is a data point. Explicit corrections ("I hate morning meetings") create immediate preferences. Implicit patterns (you keep rescheduling mornings) are detected over time. Preferences are first-class Things with confidence levels:
+
+- **Emerging** — first observation, a hypothesis
+- **Moderate** — 2-3 observations, gaining confidence
+- **Strong** — 4+ observations, reliable pattern
+
+Preferences can conflict ("prefers working alone" but "always invites Tom to brainstorms"). Context determines which applies — that's fine. They evolve, and the user can see and edit them.
+
+**Personality adaptation.** Reli's communication style itself is learnable. How verbose to be, whether to use bullet points or prose, how often to ask clarifying questions, how proactive to be with suggestions. New users get a sensible default. Long-term users get a PA that communicates the way they prefer.
+
+### Signals that drive learning
+
+| Signal type | Example | Effect |
+|------------|---------|--------|
+| Positive | User follows a suggestion, says "thanks" | Strengthen the approach used |
+| Negative | User says "too much detail", ignores suggestion | Weaken that approach |
+| Explicit correction | "Don't use emoji" / "Be more concise" | Immediate strong preference |
+| Implicit correction | User consistently edits Thing titles after creation | Naming patterns don't match expectations |
+| Behavioral | User reads briefings but ignores staleness alerts | Briefings valued, staleness alerts aren't |
+
+## Concerns
+
+Reli's domain intelligence is modular. A **concern** is an area of life that Reli monitors on your behalf:
+
+- **Health** — knows "dentist every 6 months" is worth tracking, searches your calendar/email to find when you last went, asks you about it when appropriate
+- **Finance** — watches for contract expiry dates, suggests renegotiation at the right time
+- **Travel** — checks visa requirements when you book a flight to a new country
+
+Each concern has a lifecycle:
+
+1. **Initialize** — scan email, calendar, and existing Things to build an understanding of where you stand in this domain. Surface open questions ("when did you last go to the dentist?")
+2. **Watch** — react to new inputs that match this domain (a billing email, a calendar appointment, a conversation mention) rather than polling everything. Update Things and questions as new information arrives.
+
+The user doesn't teach Reli everything from scratch — the concern provides the domain framework (what matters, what cadences to track, what questions to ask), and Reli fills it in with *your* specifics.
+
+Concerns also connect to the preference system. A health concern might start by asking lots of questions, but over time it learns what you care about (dental, exercise) and what you ignore (sleep tracking suggestions), and adjusts.
+
+## The nightly sweep
+
+The sweep is Reli's planning session. It's not a cleanup job — it's when Reli *thinks* about your life.
+
+**What the sweep does:**
+
+- **Coordinates concerns** — checks if any watched conditions have triggered across all active concerns
+- **Calendar lookahead** — what's coming this week that needs preparation or attention?
+- **Gap detection** — "you mentioned a conference but never said which days"
+- **Pattern aggregation** — "you've rescheduled 3 morning meetings this month" → strengthen "avoids mornings" preference
+- **Briefing assembly** — prioritized by urgency and your patterns, not just chronological
+
+**What the sweep doesn't do:**
+
+- Run every concern fully every night. Once a concern is initialized and stable, it waits for relevant updates before resurfacing.
+- Replace real-time learning. The reasoning agent catches obvious signals during conversation. The sweep catches subtler patterns across many interactions.
+
+The sweep output is a briefing — delivered through whatever channel makes sense (web UI, Telegram, email). Not just "here's your calendar" but "here's what needs your attention, across all the domains you care about."
+
+## Memory layers
+
+Reli maintains three layers of memory:
+
+| Layer | Storage | Purpose |
+|-------|---------|---------|
+| **Long-term** | Things DB (knowledge graph) | Persistent structured knowledge — people, events, preferences, relationships |
+| **Short-term** | Rolling conversation summary | Compressed conversation context for continuity across sessions |
+| **Task context** | Context agent retrieval | Only what's needed for the current request |
+
+The knowledge graph is long-term memory. The rolling conversation summary captures flow, intent, and recent decisions without duplicating what's already stored as Things. The context agent retrieves only what's relevant per request.
+
+This means conversations can go indefinitely without context window issues, while maintaining continuity ("last time you mentioned wanting to move the trip...").
+
+## MCP: intelligence as a service
+
+Reli's value isn't tied to its chat UI. Through MCP (Model Context Protocol), any agent can tap into Reli's intelligence:
+
+- **Prompts** that encode PA behavior — how to create Things, track preferences, handle relationships
+- **Schema** contracts — what a Thing looks like, how confidence tracking works, what relationship types exist
+- **Retrieval** — search the knowledge graph for relevant Things given any context
+- **The accumulated user model** — preferences, patterns, and relationships that make any calling agent smarter about *you*
+
+The key architectural decision: the calling agent (Claude Code, a Telegram bot, a voice assistant) does its own reasoning using Reli's prompts and data. Reli provides the intelligence substrate — the structured knowledge, the learned preferences, the domain framework from concerns — but doesn't force an extra LLM call. The client's model follows Reli's prompts to act as a PA.
+
+This means your PA knowledge follows you across every tool you use. Claude Code knows your scheduling preferences. A Telegram bot knows your health concerns. A voice assistant knows your travel patterns. All from the same knowledge graph.
+
+### Data integrity
+
+When multiple clients write to the same knowledge graph, there's a risk of corruption — a lesser model might misinterpret the schema and make destructive updates. The current approach is to keep a mutations journal (append-only log of all changes) so the sweep can audit and roll back bad changes. A validation layer (where changes are proposed and reviewed before committing) is a future consideration for multi-user scenarios.
+
+## Multi-channel delivery
+
+The web UI is one interface. Reli's proactive intelligence should reach you where you are:
+
+- **Telegram bot** — morning briefings, quick questions, proactive nudges ("bring a change of clothes today")
+- **Claude Code** via MCP — development context ("what did I decide about the auth rewrite?")
+- **Email** — weekly summaries or time-sensitive alerts
+
+The intelligence is decoupled from delivery. Adding a new channel means connecting to Reli's API/MCP, not rebuilding the PA logic.
+
+Integration with projects like [OpenClaw](https://github.com/openclaw/openclaw) (a multi-channel AI assistant framework supporting 23+ messaging platforms) could provide broad delivery coverage without building each channel integration from scratch. The security model would need evaluation, but architecturally Reli's MCP server would be a natural fit as an OpenClaw skill/tool.
+
+## External source ingestion
+
+Conversation is one input channel. Reli also learns from:
+
+- **Google Calendar** — schedule, recurring patterns, time preferences
+- **Gmail** — confirmations, receipts, appointments, contracts
+- **Documents** — anything you feed it
+
+These sources feed the knowledge graph. Concerns know what to look for in each source: a health concern scans for appointment confirmations, a finance concern watches for billing emails and contract renewals.
+
+## The learning flywheel
+
+Everything connects into a reinforcing loop:
+
+```
+Real-time (every interaction):
+  Reasoning agent -> extracts preferences + generates questions
+                                    |
+Background (nightly sweep):
+  Sweep -> coordinates concerns, detects gaps, aggregates patterns
+  Sweep -> generates briefing with questions + insights
+                                    |
+Next interaction:
+  Context agent -> retrieves Things + preferences + open questions
+  Reasoning agent -> acts with full knowledge of who you are
+```
+
+Interactions produce preferences. Preferences improve context. Better context produces better interactions. The system compounds — a month of use produces a deeply personalized PA that a fresh install can't match.


### PR DESCRIPTION
## Summary

- Rewrote README to lead with the PA vision and concrete examples, keeping setup/config/testing sections intact
- Added `docs/vision.md` — full vision document covering concerns, learning flywheel, sweep, MCP, multi-channel delivery, external ingestion
- Added `docs/comparisons.md` — how Reli relates to OB1 and OpenClaw
- Added `docs/next-steps.md` — prioritized immediate roadmap and future possibilities

Captures the thinking from a design session about where Reli is heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)