### PR TITLE
Use Google AI Studio directly for evals, add chat_history stub

### DIFF
--- a/eval/_eval_model.py
+++ b/eval/_eval_model.py
@@ -1,0 +1,50 @@
+"""Eval model factory — uses Google AI Studio directly to avoid Requesty quota issues.
+
+If GOOGLE_API_KEY is set, evals use the Gemini API directly via LiteLlm's
+gemini/ prefix. Otherwise, falls back to Requesty routing.
+"""
+
+import os
+
+from google.adk.models.lite_llm import LiteLlm
+
+from backend.agents import (
+    REQUESTY_API_KEY,
+    REQUESTY_MODEL,
+    REQUESTY_REASONING_MODEL,
+    REQUESTY_RESPONSE_MODEL,
+)
+
+_STAGE_MODELS = {
+    "context": REQUESTY_MODEL,
+    "reasoning": REQUESTY_REASONING_MODEL,
+    "response": REQUESTY_RESPONSE_MODEL,
+}
+
+
+def make_eval_model(stage: str = "reasoning") -> LiteLlm:
+    """Create a LiteLlm model for evals.
+
+    Uses Google AI Studio directly if GOOGLE_API_KEY is set (avoids
+    Requesty shared quota limits on preview models). Falls back to
+    Requesty routing otherwise.
+    """
+    google_api_key = os.environ.get("GOOGLE_API_KEY")
+    model_name = _STAGE_MODELS.get(stage, REQUESTY_REASONING_MODEL)
+
+    # Strip provider prefix to get the base model name
+    base_name = model_name.rsplit("/", 1)[-1] if "/" in model_name else model_name
+
+    if google_api_key:
+        # Use Google AI Studio directly: gemini/ prefix for LiteLlm
+        return LiteLlm(
+            model=f"gemini/{base_name}",
+            api_key=google_api_key,
+        )
+    else:
+        # Fall back to Requesty
+        effective = model_name if model_name.startswith("openai/") else f"openai/{model_name}"
+        return LiteLlm(
+            model=effective,
+            api_key=REQUESTY_API_KEY,
+        )

--- a/eval/context_agent/agent.py
+++ b/eval/context_agent/agent.py
@@ -11,9 +11,9 @@ from google.adk.agents import LlmAgent
 from google.genai import types as genai_types
 
 from backend.agents import CONTEXT_AGENT_SYSTEM
-from backend.context_agent import _make_litellm_model
+from eval._eval_model import make_eval_model
 
-model = _make_litellm_model()
+model = make_eval_model("context")
 
 root_agent = LlmAgent(
     name="context_agent",

--- a/eval/reasoning_agent/agent.py
+++ b/eval/reasoning_agent/agent.py
@@ -18,6 +18,7 @@ from google.adk.agents import LlmAgent
 
 from backend.context_agent import _make_litellm_model
 from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM
+from eval._eval_model import make_eval_model
 
 # ---------------------------------------------------------------------------
 # Stub tools — same signatures as production, but no DB
@@ -97,6 +98,14 @@ def create_relationship(
     }
 
 
+def chat_history(
+    n: int = 10,
+    search_query: str = "",
+) -> dict[str, Any]:
+    """Retrieve older messages from the current conversation (eval stub)."""
+    return {"messages": [], "count": 0}
+
+
 # ---------------------------------------------------------------------------
 # Agent construction
 # ---------------------------------------------------------------------------
@@ -104,7 +113,7 @@ def create_relationship(
 
 def _build_agent() -> LlmAgent:
     """Build the reasoning agent wired with stub tools."""
-    model = _make_litellm_model()
+    model = make_eval_model("reasoning")
     return LlmAgent(
         name="reasoning_agent",
         description="Reasoning agent for Reli — decides storage changes via tool calls.",
@@ -117,6 +126,7 @@ def _build_agent() -> LlmAgent:
             delete_thing,
             merge_things,
             create_relationship,
+            chat_history,
         ],
     )
 


### PR DESCRIPTION
## Summary

- Evals now use **Google AI Studio directly** (via `GOOGLE_API_KEY`) instead of routing through Requesty, avoiding Vertex shared quota limits on preview models
- Added **`chat_history` stub** to reasoning agent eval tools — gemini-3 is smart enough to call tools referenced in the system prompt, so missing stubs cause crashes
- Falls back to Requesty if `GOOGLE_API_KEY` is not set

## Why

Requesty routes `gemini-3-flash-preview` through Vertex AI, which has very strict per-minute quotas on preview models. Running 9 eval tests back-to-back was hitting 429s after 2-3 requests. Using a direct Google API key gives us our own quota.

## Results

**9/9 evals pass** with gemini-3-flash-preview (reasoning) and gemini-3.1-flash-lite-preview (context) in ~5 minutes.

## Test plan

- [x] `RUN_EVALS=1 pytest backend/tests/test_evals.py -v --no-cov` — 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)