### PR TITLE
feat: MCP Streamable HTTP transport at /mcp (#237)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -59,6 +59,9 @@ class Settings(BaseSettings):
     RELI_API_TOKEN: str = ""  # Shared secret; set to enable token-based auth for MCP
     RELI_API_URL: str = "http://localhost:8000"  # Base URL for MCP server to reach REST API
 
+    # --- MCP HTTP server token (for Claude Code → MCP server auth) ---
+    MCP_API_TOKEN: str = ""  # Bearer token required to connect to /mcp endpoint
+
     @property
     def allowed_emails_set(self) -> set[str]:
         """Parse ALLOWED_EMAILS into a lowercase set. Empty string means allow all."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from starlette.responses import Response as StarletteResponse  # noqa: E402
 
 from .auth import COOKIE_NAME, JWT_ALGORITHM, SECRET_KEY, require_user  # noqa: E402
 from .database import clean_orphan_relationships, init_db  # noqa: E402
+from .mcp_server import create_mcp_asgi_app  # noqa: E402
 from .metrics import MetricsMiddleware, metrics_response  # noqa: E402
 from .rate_limit import RateLimitMiddleware, get_rate_limit_config  # noqa: E402
 from .response_metrics import ResponseMetricsMiddleware, metrics_store  # noqa: E402
@@ -284,6 +285,10 @@ def health_detailed() -> dict:
 def metrics() -> StarletteResponse:
     return metrics_response()
 
+
+# MCP server — Streamable HTTP transport, mounted at /mcp
+# Protected by MCP_API_TOKEN bearer token (empty = dev/open mode)
+app.mount("/mcp", create_mcp_asgi_app(_app_settings.MCP_API_TOKEN))
 
 # Serve React SPA (only when the built dist directory exists)
 if _FRONTEND_DIST.is_dir():

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -1,13 +1,14 @@
 """Reli MCP server — knowledge graph tools wrapping the REST API.
 
 Exposes Things, Relationships, briefing, conflict detection, and reli_think
-reasoning-as-a-service as MCP tools over stdio transport.  Connects to a
-running Reli API instance via HTTP.
+reasoning-as-a-service as MCP tools.
 
-Usage:
-    RELI_API_URL=http://localhost:8000 RELI_API_TOKEN=<jwt> python -m backend.mcp_server
+Supports two transports:
+- Streamable HTTP (primary): mounted at /mcp inside the FastAPI app.
+  Protected by MCP_API_TOKEN bearer token.
+- stdio (legacy): run via ``python -m backend.mcp_server`` for local clients.
 
-Environment variables:
+Environment variables (stdio mode):
     RELI_API_URL   — Base URL of the Reli API (default: http://localhost:8000)
     RELI_API_TOKEN — JWT session token for authentication (required)
 """
@@ -17,10 +18,14 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 
@@ -681,6 +686,58 @@ def reli_think(
         body["context"] = context
     result: dict[str, Any] = _api_post("/api/think", json_body=body)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport (for mounting inside FastAPI)
+# ---------------------------------------------------------------------------
+
+
+class _TokenAuthMiddleware:
+    """ASGI middleware that enforces Bearer token authentication.
+
+    If ``mcp_api_token`` is empty, all requests are allowed (dev mode).
+    Otherwise, requests must carry ``Authorization: Bearer <token>``.
+    """
+
+    def __init__(self, app: ASGIApp, mcp_api_token: str) -> None:
+        self._app = app
+        self._token = mcp_api_token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self._app(scope, receive, send)
+            return
+
+        if self._token:
+            headers = dict(scope.get("headers", []))
+            auth_header = headers.get(b"authorization", b"").decode()
+            if auth_header != f"Bearer {self._token}":
+                response = Response(
+                    content='{"detail":"Unauthorized"}',
+                    status_code=401,
+                    media_type="application/json",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+                await response(scope, receive, send)
+                return
+
+        await self._app(scope, receive, send)
+
+
+def create_mcp_asgi_app(mcp_api_token: str = "") -> ASGIApp:
+    """Return the MCP Streamable HTTP ASGI app, wrapped with token auth.
+
+    Mount this at ``/mcp`` in the FastAPI app:
+
+        from backend.mcp_server import create_mcp_asgi_app
+        app.mount("/mcp", create_mcp_asgi_app(settings.MCP_API_TOKEN))
+
+    Args:
+        mcp_api_token: Required Bearer token. Empty string disables auth (dev mode).
+    """
+    starlette_app = mcp.streamable_http_app()
+    return _TokenAuthMiddleware(starlette_app, mcp_api_token)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -822,3 +822,56 @@ class TestMCPTools:
             headers=headers,
         )
         assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# _TokenAuthMiddleware — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenAuthMiddleware:
+    """Test the ASGI middleware that guards the /mcp endpoint."""
+
+    def _make_client(self, mcp_api_token: str) -> TestClient:
+        """Wrap a trivial echo app with _TokenAuthMiddleware."""
+        from starlette.applications import Starlette
+        from starlette.requests import Request
+        from starlette.responses import PlainTextResponse
+        from starlette.routing import Route
+
+        from backend.mcp_server import _TokenAuthMiddleware
+
+        def echo(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("ok")
+
+        inner = Starlette(routes=[Route("/", echo)])
+        wrapped = _TokenAuthMiddleware(inner, mcp_api_token)
+        return TestClient(wrapped, raise_server_exceptions=True)
+
+    def test_correct_token_allowed(self) -> None:
+        client = self._make_client("secret-token")
+        resp = client.get("/", headers={"Authorization": "Bearer secret-token"})
+        assert resp.status_code == 200
+        assert resp.text == "ok"
+
+    def test_wrong_token_rejected(self) -> None:
+        client = self._make_client("secret-token")
+        resp = client.get("/", headers={"Authorization": "Bearer wrong"})
+        assert resp.status_code == 401
+
+    def test_missing_auth_header_rejected(self) -> None:
+        client = self._make_client("secret-token")
+        resp = client.get("/")
+        assert resp.status_code == 401
+
+    def test_empty_token_allows_all(self) -> None:
+        """Empty MCP_API_TOKEN = dev mode, no auth required."""
+        client = self._make_client("")
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_www_authenticate_header_on_401(self) -> None:
+        client = self._make_client("secret-token")
+        resp = client.get("/", headers={"Authorization": "Bearer bad"})
+        assert resp.status_code == 401
+        assert "Bearer" in resp.headers.get("www-authenticate", "")


### PR DESCRIPTION
## Summary
- Adds Streamable HTTP transport for the MCP server, mounted at `/mcp` in FastAPI
- Bearer token auth middleware (MCP_API_TOKEN setting, permissive when empty for dev)
- Keeps existing stdio transport intact

Part of #190 (sub-issue #237)

## Test plan
- [ ] `pytest backend/tests/test_mcp_server.py` passes
- [ ] `/mcp` endpoint responds to MCP protocol requests
- [ ] Auth middleware rejects bad tokens, allows when MCP_API_TOKEN unset