### PR TITLE
feat: list_relationships MCP tool (#241)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -282,6 +282,17 @@ def merge_things(keep_id: str, remove_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def list_relationships(thing_id: str) -> list[dict[str, Any]]:
+    """List all relationships where a Thing is source or target.
+
+    Args:
+        thing_id: The UUID of the Thing whose relationships to retrieve.
+    """
+    result: list[dict[str, Any]] = _api_get(f"/api/things/{thing_id}/relationships")
+    return result
+
+
+@mcp.tool()
 def create_relationship(
     from_thing_id: str,
     to_thing_id: str,

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ from backend.mcp_server import (
     get_briefing,
     get_conflicts,
     get_thing,
+    list_relationships,
     mcp,
     merge_things,
     pa_behavior_guide,
@@ -244,6 +245,42 @@ class TestMergeThings:
 
 
 # ---------------------------------------------------------------------------
+# list_relationships
+# ---------------------------------------------------------------------------
+
+
+class TestListRelationships:
+    @patch("backend.mcp_server._api_get")
+    def test_list_returns_relationships(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = [
+            {"id": "rel-1", "from_thing_id": "a", "to_thing_id": "b", "relationship_type": "works_with"},
+            {"id": "rel-2", "from_thing_id": "c", "to_thing_id": "a", "relationship_type": "blocks"},
+        ]
+        result = list_relationships(thing_id="a")
+        mock_get.assert_called_once_with("/api/things/a/relationships")
+        assert len(result) == 2
+        assert result[0]["id"] == "rel-1"
+        assert result[1]["relationship_type"] == "blocks"
+
+    @patch("backend.mcp_server._api_get")
+    def test_list_empty(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        result = list_relationships(thing_id="no-rels")
+        mock_get.assert_called_once_with("/api/things/no-rels/relationships")
+        assert result == []
+
+    @patch("backend.mcp_server._api_get")
+    def test_list_not_found(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(404),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            list_relationships(thing_id="nonexistent")
+
+
+# ---------------------------------------------------------------------------
 # create_relationship
 # ---------------------------------------------------------------------------
 
@@ -350,6 +387,7 @@ class TestMcpMetadata:
             "update_thing",
             "delete_thing",
             "merge_things",
+            "list_relationships",
             "create_relationship",
             "delete_relationship",
             "get_briefing",
@@ -448,7 +486,7 @@ class TestIntegration:
         assert kept["id"] == keep["id"]
 
     def test_relationship_lifecycle(self, api_server: None) -> None:
-        """Create two Things, link them, then delete the relationship."""
+        """Create two Things, link them, list, then delete the relationship."""
         t1 = create_thing(title="Thing A", type_hint="person")
         t2 = create_thing(title="Thing B", type_hint="project")
 
@@ -462,9 +500,19 @@ class TestIntegration:
         assert rel["to_thing_id"] == t2["id"]
         assert rel["relationship_type"] == "works_on"
 
+        # List relationships
+        rels = list_relationships(thing_id=t1["id"])
+        assert len(rels) == 1
+        assert rels[0]["id"] == rel["id"]
+        assert rels[0]["relationship_type"] == "works_on"
+
         # Delete relationship
         result = delete_relationship(relationship_id=rel["id"])
         assert result["ok"] is True
+
+        # Verify deleted
+        rels_after = list_relationships(thing_id=t1["id"])
+        assert len(rels_after) == 0
 
         # Clean up (soft-delete)
         delete_thing(thing_id=t1["id"])


### PR DESCRIPTION
## Summary
- Adds `list_relationships` tool wrapping `GET /api/things/{id}/relationships`
- Completes the relationship management suite (list, create, delete)
- Includes scaffold HTTP transport from #257

Part of #190 (sub-issue #241)

## Test plan
- [ ] `pytest backend/tests/test_mcp_server.py` passes
- [ ] list_relationships returns correct relationships for a thing