### PR TITLE
feat: get_user_profile MCP tool (#242)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -282,6 +282,29 @@ def merge_things(keep_id: str, remove_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def get_user_profile() -> dict[str, Any]:
+    """Get the current user's profile Thing with all resolved relationships.
+
+    Returns the user's anchor Thing (type_hint=person, surface=false) — the
+    "who am I" context a calling agent should load at session start.
+
+    Each relationship includes direction (incoming/outgoing), the related
+    Thing's title, and its ID.
+
+    Returns:
+        Dict with:
+        - thing: the user's anchor Thing
+        - relationships: list of {id, relationship_type, direction,
+          related_thing_id, related_thing_title}
+
+    Raises:
+        httpx.HTTPStatusError (404): if no user profile Thing exists.
+    """
+    result: dict[str, Any] = _api_get("/api/things/me")
+    return result
+
+
+@mcp.tool()
 def create_relationship(
     from_thing_id: str,
     to_thing_id: str,

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ from backend.mcp_server import (
     get_briefing,
     get_conflicts,
     get_thing,
+    get_user_profile,
     mcp,
     merge_things,
     pa_behavior_guide,
@@ -244,6 +245,63 @@ class TestMergeThings:
 
 
 # ---------------------------------------------------------------------------
+# get_user_profile
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserProfile:
+    @patch("backend.mcp_server._api_get")
+    def test_returns_profile(self, mock_get: MagicMock) -> None:
+        profile = {
+            "thing": {
+                "id": "u-1",
+                "title": "Alice",
+                "type_hint": "person",
+                "surface": False,
+                "active": True,
+                "priority": 3,
+            },
+            "relationships": [
+                {
+                    "id": "rel-1",
+                    "relationship_type": "works_at",
+                    "direction": "outgoing",
+                    "related_thing_id": "org-1",
+                    "related_thing_title": "Acme Corp",
+                }
+            ],
+        }
+        mock_get.return_value = profile
+        result = get_user_profile()
+        mock_get.assert_called_once_with("/api/things/me")
+        assert result["thing"]["id"] == "u-1"
+        assert result["thing"]["title"] == "Alice"
+        assert len(result["relationships"]) == 1
+        assert result["relationships"][0]["direction"] == "outgoing"
+        assert result["relationships"][0]["related_thing_title"] == "Acme Corp"
+
+    @patch("backend.mcp_server._api_get")
+    def test_no_relationships(self, mock_get: MagicMock) -> None:
+        profile = {
+            "thing": {"id": "u-2", "title": "Bob", "type_hint": "person"},
+            "relationships": [],
+        }
+        mock_get.return_value = profile
+        result = get_user_profile()
+        assert result["relationships"] == []
+
+    @patch("backend.mcp_server._api_get")
+    def test_not_found_raises(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=httpx.Request("GET", "http://test"),
+            response=httpx.Response(404),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            get_user_profile()
+
+
+# ---------------------------------------------------------------------------
 # create_relationship
 # ---------------------------------------------------------------------------
 
@@ -350,6 +408,7 @@ class TestMcpMetadata:
             "update_thing",
             "delete_thing",
             "merge_things",
+            "get_user_profile",
             "create_relationship",
             "delete_relationship",
             "get_briefing",


### PR DESCRIPTION
## Summary
- Adds `get_user_profile` tool wrapping `GET /api/things/me`
- Returns user's anchor Thing with resolved relationships

Part of #190 (sub-issue #242)

## Test plan
- [ ] `pytest backend/tests/test_mcp_server.py` passes
- [ ] Returns anchor thing with relationships populated