### PR TITLE
fix: update deploy path to ext4 NVMe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             docker pull "$IMAGE:$NEW_TAG"
 
             # Update and restart
-            cd /home/asiri/gc/rigs/reli
+            cd /mnt/ext-fast/gc/rigs/reli
             git pull --rebase
             RELI_IMAGE_TAG="$NEW_TAG" docker compose up -d
 


### PR DESCRIPTION
## Summary
- CI deploy step was using `/home/asiri/gc/rigs/reli` which no longer exists
- City moved to `/mnt/ext-fast/gc` on ext4 NVMe partition

One-line change in the SSH deploy script path.

## Test plan
- [ ] CI passes (no code changes, only deploy path)
- [ ] Next merge to master triggers successful deploy