### PR TITLE
fix: update deploy path to new city location on ext4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             docker pull "$IMAGE:$NEW_TAG"
 
             # Update and restart
-            cd /home/asiri/gc/rigs/reli
+            cd /mnt/ext-fast/gc/rigs/reli
             git pull --rebase
             RELI_IMAGE_TAG="$NEW_TAG" docker compose up -d
 


### PR DESCRIPTION
CI was deploying to /home/asiri/gc/rigs/reli which no longer exists. City moved to /mnt/ext-fast/gc on ext4 NVMe partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)