### PR TITLE
feat: add get_open_questions MCP tool and API endpoint (re-mcp9)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -103,7 +103,9 @@ mcp = FastMCP(
         "read, update, and delete Things (tasks, notes, projects, people, ideas, "
         "goals) and the typed relationships between them. "
         "Use get_briefing to see what needs attention today (checkin-due items and "
-        "sweep findings). Use get_conflicts to detect blockers, schedule overlaps, "
+        "sweep findings). Use get_open_questions to find Things with unresolved "
+        "knowledge gaps and ask the user proactively. "
+        "Use get_conflicts to detect blockers, schedule overlaps, "
         "and deadline conflicts. "
         "Use the prompt resources (thing-creation, relationship-patterns, "
         "proactive-surfacing, pa-behavior) to learn how to act as a Reli-powered PA."
@@ -339,6 +341,21 @@ def get_briefing(as_of: str | None = None) -> dict[str, Any]:
     if as_of:
         params["as_of"] = as_of
     result: dict[str, Any] = _api_get("/api/briefing", params=params)
+    return result
+
+
+@mcp.tool()
+def get_open_questions(limit: int = 50) -> list[dict[str, Any]]:
+    """Get Things that have unresolved open questions, ordered by priority then recency.
+
+    Returns active Things with non-empty open_questions arrays. The calling agent
+    can use these to proactively ask the user clarifying questions during conversation.
+
+    Args:
+        limit: Maximum number of Things to return (1-200, default 50).
+    """
+    params: dict[str, Any] = {"limit": min(max(limit, 1), 200)}
+    result: list[dict[str, Any]] = _api_get("/api/things/open-questions", params=params)
     return result
 
 

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -165,6 +165,26 @@ def get_user_thing(user_id: str = Depends(require_user)) -> UserProfileDetail:
     return UserProfileDetail(thing=thing, relationships=relationships)
 
 
+@router.get("/open-questions", response_model=list[Thing], summary="List Things with open questions")
+def get_open_questions(
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
+    user_id: str = Depends(require_user),
+) -> list[Thing]:
+    """Return active Things that have non-empty open_questions arrays, ordered by priority then recency."""
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        rows = conn.execute(
+            f"""SELECT * FROM things
+               WHERE active = 1
+                 AND open_questions IS NOT NULL
+                 AND open_questions != '[]'{uf_sql}
+               ORDER BY priority ASC, updated_at DESC
+               LIMIT ?""",
+            [*uf_params, limit],
+        ).fetchall()
+    return [_row_to_thing(r) for r in rows]
+
+
 @router.get("/search", response_model=list[Thing], summary="Search Things across the full graph")
 def search_things(
     q: str = Query("", description="Free-text search query matched against title, data, type_hint, and relationships"),

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ from backend.mcp_server import (
     delete_thing,
     get_briefing,
     get_conflicts,
+    get_open_questions,
     get_thing,
     mcp,
     merge_things,
@@ -353,6 +354,7 @@ class TestMcpMetadata:
             "create_relationship",
             "delete_relationship",
             "get_briefing",
+            "get_open_questions",
             "get_conflicts",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
@@ -506,6 +508,49 @@ class TestGetBriefing:
         result = get_briefing()
         assert result["things"] == []
         assert result["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_open_questions
+# ---------------------------------------------------------------------------
+
+
+class TestGetOpenQuestions:
+    @patch("backend.mcp_server._api_get")
+    def test_returns_things_with_open_questions(self, mock_get: MagicMock) -> None:
+        things = [
+            {"id": "t1", "title": "Plan vacation", "open_questions": ["What destination?", "When?"]},
+            {"id": "t2", "title": "Fix bug", "open_questions": ["Which release?"]},
+        ]
+        mock_get.return_value = things
+        result = get_open_questions()
+        mock_get.assert_called_once_with("/api/things/open-questions", params={"limit": 50})
+        assert len(result) == 2
+        assert result[0]["id"] == "t1"
+
+    @patch("backend.mcp_server._api_get")
+    def test_empty_when_no_open_questions(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        result = get_open_questions()
+        assert result == []
+
+    @patch("backend.mcp_server._api_get")
+    def test_custom_limit(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        get_open_questions(limit=10)
+        mock_get.assert_called_once_with("/api/things/open-questions", params={"limit": 10})
+
+    @patch("backend.mcp_server._api_get")
+    def test_limit_clamped_min(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        get_open_questions(limit=0)
+        mock_get.assert_called_once_with("/api/things/open-questions", params={"limit": 1})
+
+    @patch("backend.mcp_server._api_get")
+    def test_limit_clamped_max(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        get_open_questions(limit=999)
+        mock_get.assert_called_once_with("/api/things/open-questions", params={"limit": 200})
 
 
 # ---------------------------------------------------------------------------
@@ -890,6 +935,35 @@ class TestMCPTools:
             headers=headers,
         )
         assert resp.status_code == 204
+
+    def test_open_questions_endpoint(self, token_client_with_user):
+        """Things with open_questions appear in the /api/things/open-questions endpoint."""
+        headers = {"Authorization": "Bearer test-mcp-token"}
+
+        # Create a thing WITH open questions
+        resp = token_client_with_user.post(
+            "/api/things",
+            json={"title": "Plan birthday party", "type_hint": "task", "open_questions": ["Who to invite?", "Venue?"]},
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        thing_id = resp.json()["id"]
+
+        # Create a thing WITHOUT open questions
+        token_client_with_user.post(
+            "/api/things",
+            json={"title": "Buy milk", "type_hint": "task"},
+            headers=headers,
+        )
+
+        # Only the thing with open questions should appear
+        resp = token_client_with_user.get("/api/things/open-questions", headers=headers)
+        assert resp.status_code == 200
+        results = resp.json()
+        ids = [t["id"] for t in results]
+        assert thing_id in ids
+        thing = next(t for t in results if t["id"] == thing_id)
+        assert thing["open_questions"] == ["Who to invite?", "Venue?"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add `get_open_questions` MCP tool and corresponding API endpoint.

Part of #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)