### PR TITLE
feat: add get_preferences and update_preference MCP tools (re-mcp8)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -360,6 +360,52 @@ def get_conflicts(window: int = 14) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# Preference Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def get_preferences() -> list[dict[str, Any]]:
+    """Get all user preference Things.
+
+    Returns all Things with type_hint='preference'. Load these at session
+    start to understand the user's communication style, proactivity level,
+    and other behavioral preferences that override the PA defaults.
+    """
+    result: list[dict[str, Any]] = _api_get("/api/things", params={"type_hint": "preference", "active_only": False})
+    return result
+
+
+@mcp.tool()
+def update_preference(
+    thing_id: str,
+    patterns: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Update the patterns array on a preference Thing.
+
+    Only modifies the patterns key inside the Thing's data dict — all other
+    fields (title, priority, etc.) are preserved.
+
+    Args:
+        thing_id: The UUID of the preference Thing to update.
+        patterns: List of pattern objects. Each must have:
+            - pattern (str): Description of the observed preference.
+            - confidence (str): "emerging" (1 obs), "moderate" (2-3), or "strong" (4+).
+            - observations (int): Number of times this pattern was observed.
+    """
+    valid_confidence = {"emerging", "moderate", "strong"}
+    for p in patterns:
+        if p.get("confidence") not in valid_confidence:
+            return {"error": f"Invalid confidence '{p.get('confidence')}'. Must be one of: emerging, moderate, strong"}
+
+    current: dict[str, Any] = _api_get(f"/api/things/{thing_id}")
+    existing_data: dict[str, Any] = current.get("data") or {}
+    updated_data = {**existing_data, "patterns": patterns}
+    result: dict[str, Any] = _api_patch(f"/api/things/{thing_id}", json_body={"data": updated_data})
+    return result
+
+
+# ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # MCP Prompt Resources — PA behavior guidance for calling agents

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -240,6 +240,7 @@ def search_things(
 @router.get("", response_model=list[Thing], summary="List Things")
 def list_things(
     active_only: bool = Query(True, description="Filter to active Things only"),
+    type_hint: str | None = Query(None, description="Filter by type_hint (e.g. 'preference', 'task')"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum number of results"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     user_id: str = Depends(require_user),
@@ -253,6 +254,9 @@ def list_things(
         params.extend(uf_params)
         if active_only:
             where += " AND active = 1"
+        if type_hint:
+            where += " AND type_hint = ?"
+            params.append(type_hint)
         params.extend([limit, offset])
         rows = conn.execute(
             f"SELECT * FROM things {where} ORDER BY checkin_date ASC, priority ASC LIMIT ? OFFSET ?",

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ from backend.mcp_server import (
     delete_thing,
     get_briefing,
     get_conflicts,
+    get_preferences,
     get_thing,
     mcp,
     merge_things,
@@ -25,6 +26,7 @@ from backend.mcp_server import (
     relationship_patterns_guide,
     search_things,
     thing_creation_guide,
+    update_preference,
     update_thing,
 )
 
@@ -354,6 +356,8 @@ class TestMcpMetadata:
             "delete_relationship",
             "get_briefing",
             "get_conflicts",
+            "get_preferences",
+            "update_preference",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -943,3 +947,98 @@ class TestTokenAuthMiddleware:
         resp = client.get("/", headers={"Authorization": "Bearer bad"})
         assert resp.status_code == 401
         assert "Bearer" in resp.headers.get("www-authenticate", "")
+
+
+# ---------------------------------------------------------------------------
+# get_preferences
+# ---------------------------------------------------------------------------
+
+
+class TestGetPreferences:
+    @patch("backend.mcp_server._api_get")
+    def test_returns_all_preference_things(self, mock_get: MagicMock) -> None:
+        prefs = [
+            {"id": "p1", "title": "Communication style", "type_hint": "preference", "data": {"patterns": []}},
+            {"id": "p2", "title": "Proactivity level", "type_hint": "preference", "data": {"patterns": []}},
+        ]
+        mock_get.return_value = prefs
+        result = get_preferences()
+        mock_get.assert_called_once_with("/api/things", params={"type_hint": "preference", "active_only": False})
+        assert len(result) == 2
+        assert result[0]["type_hint"] == "preference"
+
+    @patch("backend.mcp_server._api_get")
+    def test_returns_empty_when_no_preferences(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        result = get_preferences()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# update_preference
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePreference:
+    @patch("backend.mcp_server._api_patch")
+    @patch("backend.mcp_server._api_get")
+    def test_updates_patterns_array(self, mock_get: MagicMock, mock_patch: MagicMock) -> None:
+        mock_get.return_value = {
+            "id": "p1",
+            "title": "Communication style",
+            "type_hint": "preference",
+            "data": {"other_field": "preserved"},
+        }
+        updated = {
+            "id": "p1",
+            "title": "Communication style",
+            "type_hint": "preference",
+            "data": {"other_field": "preserved", "patterns": [{"pattern": "Concise", "confidence": "strong", "observations": 5}]},
+        }
+        mock_patch.return_value = updated
+
+        patterns = [{"pattern": "Concise", "confidence": "strong", "observations": 5}]
+        result = update_preference("p1", patterns)
+
+        mock_get.assert_called_once_with("/api/things/p1")
+        mock_patch.assert_called_once_with(
+            "/api/things/p1",
+            json_body={"data": {"other_field": "preserved", "patterns": patterns}},
+        )
+        assert result["data"]["patterns"][0]["confidence"] == "strong"
+
+    @patch("backend.mcp_server._api_patch")
+    @patch("backend.mcp_server._api_get")
+    def test_preserves_existing_data_fields(self, mock_get: MagicMock, mock_patch: MagicMock) -> None:
+        mock_get.return_value = {
+            "id": "p1",
+            "data": {"category": "communication", "patterns": [{"pattern": "Old", "confidence": "emerging", "observations": 1}]},
+        }
+        mock_patch.return_value = {"id": "p1"}
+
+        patterns = [{"pattern": "New", "confidence": "moderate", "observations": 2}]
+        update_preference("p1", patterns)
+
+        call_args = mock_patch.call_args[1]["json_body"]
+        assert call_args["data"]["category"] == "communication"
+        assert call_args["data"]["patterns"] == patterns
+
+    @patch("backend.mcp_server._api_get")
+    def test_rejects_invalid_confidence(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = {"id": "p1", "data": {}}
+        patterns = [{"pattern": "Bad", "confidence": "ultra", "observations": 1}]
+        result = update_preference("p1", patterns)
+        assert "error" in result
+        assert "ultra" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("backend.mcp_server._api_patch")
+    @patch("backend.mcp_server._api_get")
+    def test_accepts_all_valid_confidence_levels(self, mock_get: MagicMock, mock_patch: MagicMock) -> None:
+        mock_get.return_value = {"id": "p1", "data": {}}
+        mock_patch.return_value = {"id": "p1"}
+
+        for level in ["emerging", "moderate", "strong"]:
+            patterns = [{"pattern": "x", "confidence": level, "observations": 1}]
+            result = update_preference("p1", patterns)
+            assert "error" not in result


### PR DESCRIPTION
Add `get_preferences` and `update_preference` MCP tools.

Part of #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)