### PR TITLE
feat: add MCP mutations journal for audit and rollback (re-mcp11)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -432,6 +432,96 @@ def clean_orphan_relationships() -> tuple[int, list[str]]:
     return len(orphan_ids), orphan_ids
 
 
+def _migrate_mcp_mutations(conn: sqlite3.Connection) -> None:
+    """Create mcp_mutations table for append-only audit log of MCP write operations."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS mcp_mutations (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            client_id TEXT,
+            operation TEXT NOT NULL,
+            thing_id TEXT,
+            before_snapshot TEXT,
+            after_snapshot TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_mutations_thing ON mcp_mutations(thing_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_mutations_created ON mcp_mutations(created_at)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_mutations_operation ON mcp_mutations(operation)")
+
+
+def log_mcp_mutation(
+    operation: str,
+    thing_id: str | None = None,
+    before_snapshot: dict[str, Any] | None = None,
+    after_snapshot: dict[str, Any] | None = None,
+    client_id: str | None = None,
+) -> str:
+    """Append an MCP write operation to the mutations journal. Returns the new row id."""
+    import json
+    import uuid
+    from datetime import datetime, timezone
+
+    row_id = str(uuid.uuid4())
+    ts = datetime.now(timezone.utc).isoformat()
+    with db() as conn:
+        conn.execute(
+            "INSERT INTO mcp_mutations (id, timestamp, client_id, operation, thing_id,"
+            " before_snapshot, after_snapshot) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                row_id,
+                ts,
+                client_id,
+                operation,
+                thing_id,
+                json.dumps(before_snapshot) if before_snapshot is not None else None,
+                json.dumps(after_snapshot) if after_snapshot is not None else None,
+            ),
+        )
+    return row_id
+
+
+def query_mcp_mutations(
+    thing_id: str | None = None,
+    limit: int = 50,
+    since: str | None = None,
+) -> list[dict[str, Any]]:
+    """Query the mutations journal. Optionally filter by thing_id or timestamp."""
+    import json
+
+    params: list[Any] = []
+    where_clauses: list[str] = []
+    if thing_id:
+        where_clauses.append("thing_id = ?")
+        params.append(thing_id)
+    if since:
+        where_clauses.append("timestamp >= ?")
+        params.append(since)
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    params.append(min(max(limit, 1), 500))
+    with db() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM mcp_mutations {where_sql} ORDER BY timestamp DESC LIMIT ?",
+            params,
+        ).fetchall()
+    result = []
+    for row in rows:
+        r = dict(row)
+        if r.get("before_snapshot"):
+            try:
+                r["before_snapshot"] = json.loads(r["before_snapshot"])
+            except Exception:
+                pass
+        if r.get("after_snapshot"):
+            try:
+                r["after_snapshot"] = json.loads(r["after_snapshot"])
+            except Exception:
+                pass
+        result.append(r)
+    return result
+
+
 def init_db() -> None:
     """Create tables if they don't exist."""
     if settings.STORAGE_BACKEND == "supabase":
@@ -574,4 +664,5 @@ def init_db() -> None:
         _migrate_connection_suggestions(conn)
         _migrate_morning_briefings(conn)
         _migrate_conversation_summaries(conn)
+        _migrate_mcp_mutations(conn)
         _seed_thing_types(conn)

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -92,6 +92,30 @@ def _api_delete(path: str) -> Any:
         return {"ok": True}
 
 
+def _log_mutation(
+    operation: str,
+    thing_id: str | None = None,
+    before_snapshot: dict[str, Any] | None = None,
+    after_snapshot: dict[str, Any] | None = None,
+    client_id: str = "mcp",
+) -> None:
+    """Log an MCP mutation to the journal. Errors are swallowed to not break the tool."""
+    try:
+        body: dict[str, Any] = {
+            "operation": operation,
+            "client_id": client_id,
+        }
+        if thing_id is not None:
+            body["thing_id"] = thing_id
+        if before_snapshot is not None:
+            body["before_snapshot"] = before_snapshot
+        if after_snapshot is not None:
+            body["after_snapshot"] = after_snapshot
+        _api_post("/api/things/mutations", json_body=body)
+    except Exception:
+        logger.exception("Failed to log MCP mutation for operation=%s thing_id=%s", operation, thing_id)
+
+
 # ---------------------------------------------------------------------------
 # MCP Server
 # ---------------------------------------------------------------------------
@@ -189,6 +213,7 @@ def create_thing(
     if open_questions is not None:
         body["open_questions"] = open_questions
     result: dict[str, Any] = _api_post("/api/things", json_body=body)
+    _log_mutation("create_thing", thing_id=result.get("id"), after_snapshot=result)
     return result
 
 
@@ -240,7 +265,13 @@ def update_thing(
         body["open_questions"] = open_questions
     if not body:
         return {"error": "No fields provided to update"}
+    before: dict[str, Any] | None = None
+    try:
+        before = _api_get(f"/api/things/{thing_id}")
+    except Exception:
+        pass
     result: dict[str, Any] = _api_patch(f"/api/things/{thing_id}", json_body=body)
+    _log_mutation("update_thing", thing_id=thing_id, before_snapshot=before, after_snapshot=result)
     return result
 
 
@@ -255,7 +286,13 @@ def delete_thing(thing_id: str) -> dict[str, Any]:
     Args:
         thing_id: The UUID of the Thing to deactivate.
     """
+    before: dict[str, Any] | None = None
+    try:
+        before = _api_get(f"/api/things/{thing_id}")
+    except Exception:
+        pass
     result: dict[str, Any] = _api_patch(f"/api/things/{thing_id}", json_body={"active": False})
+    _log_mutation("delete_thing", thing_id=thing_id, before_snapshot=before, after_snapshot=result)
     return result
 
 
@@ -274,9 +311,22 @@ def merge_things(keep_id: str, remove_id: str) -> dict[str, Any]:
     Returns:
         Dict with keep_id, remove_id, keep_title, remove_title.
     """
+    before_keep: dict[str, Any] | None = None
+    before_remove: dict[str, Any] | None = None
+    try:
+        before_keep = _api_get(f"/api/things/{keep_id}")
+        before_remove = _api_get(f"/api/things/{remove_id}")
+    except Exception:
+        pass
     result: dict[str, Any] = _api_post(
         "/api/things/merge",
         json_body={"keep_id": keep_id, "remove_id": remove_id},
+    )
+    _log_mutation(
+        "merge_things",
+        thing_id=keep_id,
+        before_snapshot={"keep": before_keep, "remove": before_remove},
+        after_snapshot=result,
     )
     return result
 
@@ -304,6 +354,11 @@ def create_relationship(
     if metadata is not None:
         body["metadata"] = metadata
     result: dict[str, Any] = _api_post("/api/things/relationships", json_body=body)
+    _log_mutation(
+        "create_relationship",
+        thing_id=from_thing_id,
+        after_snapshot=result,
+    )
     return result
 
 
@@ -315,6 +370,7 @@ def delete_relationship(relationship_id: str) -> dict[str, Any]:
         relationship_id: The UUID of the relationship to delete.
     """
     result: dict[str, Any] = _api_delete(f"/api/things/relationships/{relationship_id}")
+    _log_mutation("delete_relationship", after_snapshot={"relationship_id": relationship_id})
     return result
 
 
@@ -359,7 +415,30 @@ def get_conflicts(window: int = 14) -> list[dict[str, Any]]:
     return result
 
 
-# ---------------------------------------------------------------------------
+@mcp.tool()
+def get_mutations(
+    thing_id: str | None = None,
+    limit: int = 50,
+    since: str | None = None,
+) -> list[dict[str, Any]]:
+    """Query the MCP mutations journal for audit and rollback purposes.
+
+    Returns logged MCP write operations (create, update, delete, merge, relationship
+    changes) with before and after snapshots of the affected Things.
+
+    Args:
+        thing_id: Optional UUID to filter mutations to a specific Thing.
+        limit: Maximum number of mutations to return (1-500, default 50).
+        since: Optional ISO 8601 timestamp to return only mutations after this time.
+    """
+    params: dict[str, Any] = {"limit": min(max(limit, 1), 500)}
+    if thing_id is not None:
+        params["thing_id"] = thing_id
+    if since is not None:
+        params["since"] = since
+    result: list[dict[str, Any]] = _api_get("/api/things/mutations", params=params)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # MCP Prompt Resources — PA behavior guidance for calling agents

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 from pydantic import BaseModel
 
 from ..auth import require_user, user_filter
-from ..database import clean_orphan_relationships, db
+from ..database import clean_orphan_relationships, db, log_mcp_mutation, query_mcp_mutations
 from ..models import (
     GraphEdge,
     GraphNode,
@@ -406,6 +406,43 @@ def list_merge_history(
     return results
 
 
+# ---------------------------------------------------------------------------
+# MCP Mutations Journal
+# ---------------------------------------------------------------------------
+
+
+class MutationLog(BaseModel):
+    operation: str
+    thing_id: str | None = None
+    before_snapshot: dict[str, Any] | None = None
+    after_snapshot: dict[str, Any] | None = None
+    client_id: str | None = None
+
+
+@router.post("/mutations", status_code=status.HTTP_201_CREATED, summary="Log an MCP mutation")
+def log_mutation(body: MutationLog, _user_id: str = Depends(require_user)) -> dict[str, str]:
+    """Append an MCP write operation to the mutations journal."""
+    row_id = log_mcp_mutation(
+        operation=body.operation,
+        thing_id=body.thing_id,
+        before_snapshot=body.before_snapshot,
+        after_snapshot=body.after_snapshot,
+        client_id=body.client_id,
+    )
+    return {"id": row_id}
+
+
+@router.get("/mutations", summary="Query the MCP mutations journal")
+def get_mutations_endpoint(
+    thing_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    since: str | None = Query(default=None),
+    _user_id: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Query logged MCP mutations, optionally filtered by thing_id or timestamp."""
+    return query_mcp_mutations(thing_id=thing_id, limit=limit, since=since)
+
+
 @router.get("/{thing_id}", response_model=Thing, summary="Get a Thing")
 def get_thing(thing_id: str, user_id: str = Depends(require_user)) -> Thing:
     """Retrieve a single Thing by ID."""
@@ -797,3 +834,4 @@ def delete_relationship(rel_id: str) -> None:
         if not row:
             raise HTTPException(status_code=404, detail=f"Relationship '{rel_id}' not found")
         conn.execute("DELETE FROM thing_relationships WHERE id = ?", (rel_id,))
+

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -21,6 +21,7 @@ Finding types:
   - cross_project_duplicate_effort: Tasks with near-identical titles in different projects
   - information_gap: Active Thing missing key information (no dates, minimal data, etc.)
   - llm_insight: LLM-generated finding from reflection phase
+  - suspicious_mcp_mutations: Unusual MCP write patterns (bulk deletes, bulk field removal)
 
 Preference aggregation (separate phase, see preference_sweep.py):
   - Analyzes chat interaction patterns to detect/update user preference Things
@@ -1015,6 +1016,83 @@ def find_cross_project_duplicate_effort(
 # ---------------------------------------------------------------------------
 
 
+def find_suspicious_mcp_mutations(
+    conn: sqlite3.Connection,
+    window_hours: int = 24,
+    bulk_delete_threshold: int = 5,
+    bulk_field_removal_threshold: int = 10,
+) -> list[SweepCandidate]:
+    """Scan recent MCP mutations for suspicious patterns.
+
+    Detects:
+    - Bulk deletes: many things deactivated in a short window
+    - Bulk field removal: update that removes many data fields at once
+    """
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=window_hours)).isoformat()
+
+    rows = conn.execute(
+        "SELECT * FROM mcp_mutations WHERE timestamp >= ? ORDER BY timestamp DESC",
+        (cutoff,),
+    ).fetchall()
+
+    candidates: list[SweepCandidate] = []
+
+    # Detect bulk deletes
+    delete_ops = [r for r in rows if dict(r).get("operation") == "delete_thing"]
+    if len(delete_ops) >= bulk_delete_threshold:
+        candidates.append(
+            SweepCandidate(
+                thing_id="",
+                thing_title="MCP mutations",
+                finding_type="suspicious_mcp_mutations",
+                message=(
+                    f"{len(delete_ops)} Things were deactivated via MCP in the last "
+                    f"{window_hours}h. Review the mutations journal to confirm this was intentional."
+                ),
+                priority=1,
+                extra={"pattern": "bulk_delete", "count": len(delete_ops)},
+            )
+        )
+
+    # Detect bulk field removal in a single update
+    for row in rows:
+        r = dict(row)
+        if r.get("operation") != "update_thing":
+            continue
+        before_raw = r.get("before_snapshot")
+        after_raw = r.get("after_snapshot")
+        if not (before_raw and after_raw):
+            continue
+        try:
+            before = json.loads(before_raw) if isinstance(before_raw, str) else before_raw
+            after = json.loads(after_raw) if isinstance(after_raw, str) else after_raw
+            before_data = before.get("data") or {}
+            after_data = after.get("data") or {}
+            removed_keys = set(before_data.keys()) - set(after_data.keys())
+            if len(removed_keys) >= bulk_field_removal_threshold:
+                thing_id = r.get("thing_id", "")
+                thing_title = (after.get("title") or before.get("title") or thing_id)
+                candidates.append(
+                    SweepCandidate(
+                        thing_id=thing_id,
+                        thing_title=thing_title,
+                        finding_type="suspicious_mcp_mutations",
+                        message=(
+                            f"{len(removed_keys)} data fields were removed from \"{thing_title}\" "
+                            f"in a single MCP update. Removed: {', '.join(sorted(removed_keys)[:5])}."
+                        ),
+                        priority=1,
+                        extra={"pattern": "bulk_field_removal", "removed_keys": list(removed_keys)},
+                    )
+                )
+        except Exception:
+            pass
+
+    return candidates
+
+
 def collect_candidates(
     today: date | None = None,
     window_days: int = 7,
@@ -1048,6 +1126,7 @@ def collect_candidates(
             + find_cross_project_resource_conflicts(conn, today, stale_days)
             + find_cross_project_thematic_connections(conn)
             + find_cross_project_duplicate_effort(conn)
+            + find_suspicious_mcp_mutations(conn)
         )
 
     # Deduplicate: keep the highest-priority (lowest number) candidate per (thing_id, finding_type)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ from backend.mcp_server import (
     delete_thing,
     get_briefing,
     get_conflicts,
+    get_mutations,
     get_thing,
     mcp,
     merge_things,
@@ -118,8 +119,9 @@ class TestGetThing:
 
 
 class TestCreateThing:
+    @patch("backend.mcp_server._log_mutation")
     @patch("backend.mcp_server._api_post")
-    def test_create_minimal(self, mock_post: MagicMock) -> None:
+    def test_create_minimal(self, mock_post: MagicMock, mock_log: MagicMock) -> None:
         mock_post.return_value = {"id": "new-1", "title": "Hello"}
         result = create_thing(title="Hello")
         mock_post.assert_called_once_with(
@@ -132,9 +134,13 @@ class TestCreateThing:
             },
         )
         assert result["id"] == "new-1"
+        mock_log.assert_called_once_with(
+            "create_thing", thing_id="new-1", after_snapshot={"id": "new-1", "title": "Hello"}
+        )
 
+    @patch("backend.mcp_server._log_mutation")
     @patch("backend.mcp_server._api_post")
-    def test_create_with_all_fields(self, mock_post: MagicMock) -> None:
+    def test_create_with_all_fields(self, mock_post: MagicMock, mock_log: MagicMock) -> None:
         mock_post.return_value = {"id": "new-2", "title": "Meeting with Tom"}
         create_thing(
             title="Meeting with Tom",
@@ -159,15 +165,21 @@ class TestCreateThing:
 
 
 class TestUpdateThing:
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_patch")
-    def test_update_title(self, mock_patch: MagicMock) -> None:
+    def test_update_title(self, mock_patch: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
+        mock_get.return_value = {"id": "t1", "title": "Old"}
         mock_patch.return_value = {"id": "t1", "title": "Updated"}
         result = update_thing(thing_id="t1", title="Updated")
         mock_patch.assert_called_once_with("/api/things/t1", json_body={"title": "Updated"})
         assert result["title"] == "Updated"
 
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_patch")
-    def test_update_multiple_fields(self, mock_patch: MagicMock) -> None:
+    def test_update_multiple_fields(self, mock_patch: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
+        mock_get.return_value = {"id": "t1", "title": "Task", "priority": 3, "active": True}
         mock_patch.return_value = {
             "id": "t1",
             "title": "Task",
@@ -189,17 +201,23 @@ class TestUpdateThing:
 
 
 class TestDeleteThing:
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_patch")
-    def test_soft_delete(self, mock_patch: MagicMock) -> None:
+    def test_soft_delete(self, mock_patch: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
+        mock_get.return_value = {"id": "t1", "title": "My Task", "active": True}
         mock_patch.return_value = {"id": "t1", "title": "My Task", "active": False}
         result = delete_thing(thing_id="t1")
         mock_patch.assert_called_once_with("/api/things/t1", json_body={"active": False})
         assert result["active"] is False
         assert result["id"] == "t1"
 
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_patch")
-    def test_soft_delete_returns_thing(self, mock_patch: MagicMock) -> None:
+    def test_soft_delete_returns_thing(self, mock_patch: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
         thing = {"id": "abc", "title": "Buy milk", "active": False, "type_hint": "task"}
+        mock_get.return_value = {"id": "abc", "title": "Buy milk", "active": True, "type_hint": "task"}
         mock_patch.return_value = thing
         result = delete_thing(thing_id="abc")
         assert result["title"] == "Buy milk"
@@ -212,8 +230,14 @@ class TestDeleteThing:
 
 
 class TestMergeThings:
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_post")
-    def test_merge_basic(self, mock_post: MagicMock) -> None:
+    def test_merge_basic(self, mock_post: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
+        mock_get.side_effect = [
+            {"id": "a", "title": "Alice Johnson"},
+            {"id": "b", "title": "A. Johnson"},
+        ]
         mock_post.return_value = {
             "keep_id": "a",
             "remove_id": "b",
@@ -230,8 +254,14 @@ class TestMergeThings:
         assert result["keep_title"] == "Alice Johnson"
         assert result["remove_title"] == "A. Johnson"
 
+    @patch("backend.mcp_server._log_mutation")
+    @patch("backend.mcp_server._api_get")
     @patch("backend.mcp_server._api_post")
-    def test_merge_returns_titles(self, mock_post: MagicMock) -> None:
+    def test_merge_returns_titles(self, mock_post: MagicMock, mock_get: MagicMock, mock_log: MagicMock) -> None:
+        mock_get.side_effect = [
+            {"id": "x", "title": "Project Alpha"},
+            {"id": "y", "title": "proj alpha"},
+        ]
         mock_post.return_value = {
             "keep_id": "x",
             "remove_id": "y",
@@ -249,8 +279,9 @@ class TestMergeThings:
 
 
 class TestCreateRelationship:
+    @patch("backend.mcp_server._log_mutation")
     @patch("backend.mcp_server._api_post")
-    def test_create_basic(self, mock_post: MagicMock) -> None:
+    def test_create_basic(self, mock_post: MagicMock, mock_log: MagicMock) -> None:
         mock_post.return_value = {
             "id": "rel-1",
             "from_thing_id": "a",
@@ -272,8 +303,9 @@ class TestCreateRelationship:
         )
         assert result["id"] == "rel-1"
 
+    @patch("backend.mcp_server._log_mutation")
     @patch("backend.mcp_server._api_post")
-    def test_create_with_metadata(self, mock_post: MagicMock) -> None:
+    def test_create_with_metadata(self, mock_post: MagicMock, mock_log: MagicMock) -> None:
         mock_post.return_value = {"id": "rel-2"}
         create_relationship(
             from_thing_id="a",
@@ -291,12 +323,52 @@ class TestCreateRelationship:
 
 
 class TestDeleteRelationship:
+    @patch("backend.mcp_server._log_mutation")
     @patch("backend.mcp_server._api_delete")
-    def test_delete(self, mock_delete: MagicMock) -> None:
+    def test_delete(self, mock_delete: MagicMock, mock_log: MagicMock) -> None:
         mock_delete.return_value = {"ok": True}
         result = delete_relationship(relationship_id="rel-1")
         mock_delete.assert_called_once_with("/api/things/relationships/rel-1")
         assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# get_mutations
+# ---------------------------------------------------------------------------
+
+
+class TestGetMutations:
+    @patch("backend.mcp_server._api_get")
+    def test_basic(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = [
+            {
+                "id": "m1",
+                "operation": "create_thing",
+                "thing_id": "t1",
+                "before_snapshot": None,
+                "after_snapshot": {"id": "t1", "title": "Hello"},
+            }
+        ]
+        result = get_mutations()
+        mock_get.assert_called_once_with("/api/things/mutations", params={"limit": 50})
+        assert len(result) == 1
+        assert result[0]["operation"] == "create_thing"
+
+    @patch("backend.mcp_server._api_get")
+    def test_with_filters(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        get_mutations(thing_id="t1", limit=10, since="2026-01-01T00:00:00Z")
+        mock_get.assert_called_once_with(
+            "/api/things/mutations",
+            params={"limit": 10, "thing_id": "t1", "since": "2026-01-01T00:00:00Z"},
+        )
+
+    @patch("backend.mcp_server._api_get")
+    def test_limit_clamped(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        get_mutations(limit=9999)
+        params = mock_get.call_args[1]["params"]
+        assert params["limit"] == 500
 
 
 # ---------------------------------------------------------------------------
@@ -890,6 +962,103 @@ class TestMCPTools:
             headers=headers,
         )
         assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Mutations REST endpoint — integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestMutationsEndpoint:
+    """Integration tests for POST/GET /api/things/mutations."""
+
+    def test_log_and_query_mutations(self, token_client_with_user: TestClient) -> None:
+        headers = {"Authorization": "Bearer test-mcp-token"}
+
+        # Create a thing to reference
+        resp = token_client_with_user.post(
+            "/api/things",
+            json={"title": "Auditable Thing"},
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        thing_id = resp.json()["id"]
+
+        # Log a mutation via POST
+        resp = token_client_with_user.post(
+            "/api/things/mutations",
+            json={
+                "operation": "create_thing",
+                "thing_id": thing_id,
+                "after_snapshot": {"id": thing_id, "title": "Auditable Thing"},
+                "client_id": "test-client",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        assert "id" in resp.json()
+
+        # Query mutations via GET (no filter)
+        resp = token_client_with_user.get("/api/things/mutations", headers=headers)
+        assert resp.status_code == 200
+        mutations = resp.json()
+        assert len(mutations) >= 1
+        ops = [m["operation"] for m in mutations]
+        assert "create_thing" in ops
+
+    def test_query_mutations_by_thing_id(self, token_client_with_user: TestClient) -> None:
+        headers = {"Authorization": "Bearer test-mcp-token"}
+
+        # Create a thing
+        resp = token_client_with_user.post(
+            "/api/things", json={"title": "Filtered Thing"}, headers=headers
+        )
+        thing_id = resp.json()["id"]
+
+        # Log two mutations with different thing_ids
+        token_client_with_user.post(
+            "/api/things/mutations",
+            json={"operation": "update_thing", "thing_id": thing_id},
+            headers=headers,
+        )
+        token_client_with_user.post(
+            "/api/things/mutations",
+            json={"operation": "delete_thing", "thing_id": "other-id"},
+            headers=headers,
+        )
+
+        # Filter by thing_id
+        resp = token_client_with_user.get(
+            f"/api/things/mutations?thing_id={thing_id}", headers=headers
+        )
+        assert resp.status_code == 200
+        mutations = resp.json()
+        assert all(m["thing_id"] == thing_id for m in mutations)
+
+    def test_log_mutation_with_before_after_snapshots(self, token_client_with_user: TestClient) -> None:
+        headers = {"Authorization": "Bearer test-mcp-token"}
+        before = {"id": "t1", "title": "Before", "active": True}
+        after = {"id": "t1", "title": "After", "active": False}
+
+        resp = token_client_with_user.post(
+            "/api/things/mutations",
+            json={
+                "operation": "update_thing",
+                "thing_id": "t1",
+                "before_snapshot": before,
+                "after_snapshot": after,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201
+
+        # Retrieve and verify snapshots
+        resp = token_client_with_user.get("/api/things/mutations?thing_id=t1", headers=headers)
+        found = [m for m in resp.json() if m.get("thing_id") == "t1"]
+        assert len(found) >= 1
+        m = found[0]
+        assert m["before_snapshot"]["title"] == "Before"
+        assert m["after_snapshot"]["active"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add mutations journal for audit trail and rollback capability on MCP operations.

Part of #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)