### PR TITLE
test: complete coverage for create_thing and update_thing MCP tools (#239)

### DIFF
--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -155,6 +155,24 @@ class TestCreateThing:
         assert call_body["checkin_date"] == "2026-03-25T09:00:00Z"
         assert call_body["open_questions"] == ["What time?"]
 
+    @patch("backend.mcp_server._api_post")
+    def test_create_with_parent_id(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = {"id": "child-1", "title": "Sub-task", "parent_id": "parent-1"}
+        create_thing(title="Sub-task", parent_id="parent-1")
+        call_body = mock_post.call_args[1]["json_body"]
+        assert call_body["parent_id"] == "parent-1"
+
+    @patch("backend.mcp_server._api_post")
+    def test_create_omits_none_optional_fields(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = {"id": "new-3", "title": "Note"}
+        create_thing(title="Note")
+        call_body = mock_post.call_args[1]["json_body"]
+        assert "type_hint" not in call_body
+        assert "data" not in call_body
+        assert "parent_id" not in call_body
+        assert "checkin_date" not in call_body
+        assert "open_questions" not in call_body
+
 
 # ---------------------------------------------------------------------------
 # update_thing
@@ -180,6 +198,34 @@ class TestUpdateThing:
         update_thing(thing_id="t1", priority=1, active=False)
         call_body = mock_patch.call_args[1]["json_body"]
         assert call_body == {"priority": 1, "active": False}
+
+    @patch("backend.mcp_server._api_patch")
+    def test_update_all_optional_fields(self, mock_patch: MagicMock) -> None:
+        mock_patch.return_value = {"id": "t2", "title": "Updated"}
+        update_thing(
+            thing_id="t2",
+            title="Updated",
+            type_hint="task",
+            data={"note": "extra"},
+            priority=2,
+            parent_id="p-1",
+            checkin_date="2026-04-01",
+            active=True,
+            surface=False,
+            open_questions=["When?"],
+        )
+        call_body = mock_patch.call_args[1]["json_body"]
+        assert call_body == {
+            "title": "Updated",
+            "type_hint": "task",
+            "data": {"note": "extra"},
+            "priority": 2,
+            "parent_id": "p-1",
+            "checkin_date": "2026-04-01",
+            "active": True,
+            "surface": False,
+            "open_questions": ["When?"],
+        }
 
     def test_update_no_fields(self) -> None:
         result = update_thing(thing_id="t1")


### PR DESCRIPTION
## Summary
- Add missing test coverage for `create_thing` and `update_thing` MCP tools
- Test `parent_id` parameter in `create_thing`
- Test that `None` optional fields are omitted from the request body in `create_thing`
- Test all optional fields in `update_thing` (type_hint, data, parent_id, checkin_date, surface, open_questions)

The `create_thing` and `update_thing` tools were implemented in the initial MCP scaffold. This PR closes the tracking issue by completing test coverage for all documented parameters.

Fixes #239
Part of #190

## Test plan
- [x] `pytest backend/tests/test_mcp_server.py::TestCreateThing` — 4 tests pass
- [x] `pytest backend/tests/test_mcp_server.py::TestUpdateThing` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)