### PR TITLE
feat: MCP mutations journal for audit and rollback (re-x3z)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -8,9 +8,12 @@ Supports two backends controlled by ``settings.STORAGE_BACKEND``:
 
 from __future__ import annotations
 
+import json
 import sqlite3
+import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -432,6 +435,49 @@ def clean_orphan_relationships() -> tuple[int, list[str]]:
     return len(orphan_ids), orphan_ids
 
 
+def _migrate_mcp_mutations(conn: sqlite3.Connection) -> None:
+    """Create mcp_mutations table and indexes if they don't exist."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS mcp_mutations (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            client_id TEXT,
+            operation TEXT NOT NULL,
+            thing_id TEXT,
+            before_snapshot TEXT,
+            after_snapshot TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_mutations_thing ON mcp_mutations(thing_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_mutations_timestamp ON mcp_mutations(timestamp)")
+
+
+def log_mutation(
+    conn: sqlite3.Connection,
+    operation: str,
+    thing_id: str | None,
+    before: dict | None,
+    after: dict | None,
+    client_id: str | None = None,
+) -> None:
+    """Append a mutation record to mcp_mutations. Never updates or deletes rows."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO mcp_mutations (id, timestamp, client_id, operation, thing_id, before_snapshot, after_snapshot)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            str(uuid.uuid4()),
+            now,
+            client_id,
+            operation,
+            thing_id,
+            json.dumps(before, default=str) if before is not None else None,
+            json.dumps(after, default=str) if after is not None else None,
+        ),
+    )
+
+
 def init_db() -> None:
     """Create tables if they don't exist."""
     if settings.STORAGE_BACKEND == "supabase":
@@ -574,4 +620,5 @@ def init_db() -> None:
         _migrate_connection_suggestions(conn)
         _migrate_morning_briefings(conn)
         _migrate_conversation_summaries(conn)
+        _migrate_mcp_mutations(conn)
         _seed_thing_types(conn)

--- a/backend/main.py
+++ b/backend/main.py
@@ -47,6 +47,7 @@ from .routers import (  # noqa: E402
     focus,
     gmail,
     mcp_oauth,
+    mutations,
     proactive,
     settings,
     staleness,
@@ -238,6 +239,7 @@ app.include_router(staleness.router, prefix="/api", dependencies=_api_deps)
 app.include_router(feedback.router, prefix="/api", dependencies=_api_deps)
 app.include_router(connections.router, prefix="/api", dependencies=_api_deps)
 app.include_router(think.router, prefix="/api", dependencies=_api_deps)
+app.include_router(mutations.router, prefix="/api", dependencies=_api_deps)
 
 
 @app.get("/healthz", tags=["health"], summary="Health check", description="Returns service health status.")

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -387,7 +387,33 @@ def get_conflicts(window: int = 14) -> list[dict[str, Any]]:
     return result
 
 
-# ---------------------------------------------------------------------------
+@mcp.tool()
+def get_mutations(
+    thing_id: str | None = None,
+    operation: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Query the MCP mutations journal for audit and rollback purposes.
+
+    Returns a log of write operations performed via MCP, newest first.
+    Each entry includes before/after snapshots of the affected Thing so that
+    manual rollback is possible by examining the journal.
+
+    Args:
+        thing_id: Filter to mutations affecting a specific Thing UUID.
+        operation: Filter by operation type: create_thing, update_thing,
+                   delete_thing, merge_things, create_relationship,
+                   delete_relationship.
+        limit: Maximum number of entries to return (1-500, default 50).
+    """
+    params: dict[str, Any] = {"limit": min(max(limit, 1), 500)}
+    if thing_id:
+        params["thing_id"] = thing_id
+    if operation:
+        params["operation"] = operation
+    result: list[dict[str, Any]] = _api_get("/api/mutations", params=params)
+    return result
+
 
 # ---------------------------------------------------------------------------
 # MCP Prompt Resources — PA behavior guidance for calling agents

--- a/backend/routers/mutations.py
+++ b/backend/routers/mutations.py
@@ -1,0 +1,71 @@
+"""Endpoints for querying the MCP mutations journal."""
+
+import json
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from ..auth import require_user
+from ..database import db
+
+router = APIRouter(prefix="/mutations", tags=["mutations"])
+
+
+def _row_to_mutation(row: Any) -> dict[str, Any]:
+    before = row["before_snapshot"]
+    after = row["after_snapshot"]
+    if isinstance(before, str) and before:
+        try:
+            before = json.loads(before)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    if isinstance(after, str) and after:
+        try:
+            after = json.loads(after)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return {
+        "id": row["id"],
+        "timestamp": row["timestamp"],
+        "client_id": row["client_id"],
+        "operation": row["operation"],
+        "thing_id": row["thing_id"],
+        "before_snapshot": before,
+        "after_snapshot": after,
+        "created_at": row["created_at"],
+    }
+
+
+@router.get("", summary="List MCP mutations")
+def list_mutations(
+    thing_id: str | None = Query(None, description="Filter by Thing ID"),
+    operation: str | None = Query(None, description="Filter by operation type"),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of results"),
+    _user_id: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Return recent MCP write operations from the mutations journal, newest first.
+
+    Can be filtered by thing_id or operation type (create_thing, update_thing,
+    delete_thing, merge_things, create_relationship, delete_relationship).
+    """
+    where_clauses = []
+    params: list[Any] = []
+
+    if thing_id:
+        where_clauses.append("thing_id = ?")
+        params.append(thing_id)
+    if operation:
+        where_clauses.append("operation = ?")
+        params.append(operation)
+
+    where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+    params.append(limit)
+
+    with db() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM mcp_mutations {where} ORDER BY timestamp DESC LIMIT ?",
+            params,
+        ).fetchall()
+
+    return [_row_to_mutation(r) for r in rows]

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 from pydantic import BaseModel
 
 from ..auth import require_user, user_filter
-from ..database import clean_orphan_relationships, db
+from ..database import clean_orphan_relationships, db, log_mutation
 from ..models import (
     GraphEdge,
     GraphNode,
@@ -372,6 +372,7 @@ def create_thing(body: ThingCreate, background_tasks: BackgroundTasks, user_id: 
             ),
         )
         row = conn.execute("SELECT * FROM things WHERE id = ?", (thing_id,)).fetchone()
+        log_mutation(conn, "create_thing", thing_id, None, dict(row))
     background_tasks.add_task(upsert_thing, dict(row))
     return _row_to_thing(row)
 
@@ -447,6 +448,7 @@ def update_thing(
         row = conn.execute(f"SELECT * FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail=f"Thing '{thing_id}' not found")
+        before_snapshot = dict(row)
 
         if body.parent_id is not None:
             if body.parent_id == thing_id:
@@ -480,6 +482,7 @@ def update_thing(
         values = list(fields.values()) + [thing_id]
         conn.execute(f"UPDATE things SET {set_clause} WHERE id = ?", values)
         row = conn.execute("SELECT * FROM things WHERE id = ?", (thing_id,)).fetchone()
+        log_mutation(conn, "update_thing", thing_id, before_snapshot, dict(row))
     background_tasks.add_task(upsert_thing, dict(row))
     return _row_to_thing(row)
 
@@ -489,10 +492,12 @@ def delete_thing(thing_id: str, background_tasks: BackgroundTasks, user_id: str 
     """Delete a Thing and remove it from the vector index."""
     uf_sql, uf_params = user_filter(user_id)
     with db() as conn:
-        row = conn.execute(f"SELECT id FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
+        row = conn.execute(f"SELECT * FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params]).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail=f"Thing '{thing_id}' not found")
+        before_snapshot = dict(row)
         conn.execute(f"DELETE FROM things WHERE id = ?{uf_sql}", [thing_id, *uf_params])
+        log_mutation(conn, "delete_thing", thing_id, before_snapshot, None)
     background_tasks.add_task(vs_delete, thing_id)
 
 
@@ -603,6 +608,7 @@ def merge_things(
         if body.keep_id == body.remove_id:
             raise HTTPException(status_code=422, detail="Cannot merge a Thing with itself")
 
+        merge_before = {"keep": dict(keep_row), "remove": dict(remove_row)}
         now = datetime.now(timezone.utc).isoformat()
 
         # 1. Merge data dicts
@@ -705,6 +711,7 @@ def merge_things(
 
         # 7. Re-embed the kept thing
         updated = conn.execute("SELECT * FROM things WHERE id = ?", (body.keep_id,)).fetchone()
+        log_mutation(conn, "merge_things", body.keep_id, merge_before, dict(updated) if updated else None)
 
     background_tasks.add_task(vs_delete, body.remove_id)
     if updated:
@@ -806,6 +813,7 @@ def create_relationship(body: RelationshipCreate, user_id: str = Depends(require
             (rel_id, body.from_thing_id, body.to_thing_id, body.relationship_type, meta_json),
         )
         row = conn.execute("SELECT * FROM thing_relationships WHERE id = ?", (rel_id,)).fetchone()
+        log_mutation(conn, "create_relationship", body.from_thing_id, None, dict(row))
     return _parse_rel_row(row)
 
 
@@ -813,7 +821,9 @@ def create_relationship(body: RelationshipCreate, user_id: str = Depends(require
 def delete_relationship(rel_id: str) -> None:
     """Delete a relationship by ID."""
     with db() as conn:
-        row = conn.execute("SELECT id FROM thing_relationships WHERE id = ?", (rel_id,)).fetchone()
+        row = conn.execute("SELECT * FROM thing_relationships WHERE id = ?", (rel_id,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail=f"Relationship '{rel_id}' not found")
+        before_snapshot = dict(row)
         conn.execute("DELETE FROM thing_relationships WHERE id = ?", (rel_id,))
+        log_mutation(conn, "delete_relationship", row["from_thing_id"], before_snapshot, None)

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -1011,6 +1011,145 @@ def find_cross_project_duplicate_effort(
 
 
 # ---------------------------------------------------------------------------
+# Mutation pattern analysis
+# ---------------------------------------------------------------------------
+
+_BULK_DELETE_THRESHOLD = 5  # deactivations within a 1-hour window
+_BULK_FIELD_REMOVAL_THRESHOLD = 5  # data keys removed in a single update
+
+
+def find_suspicious_mutations(
+    conn: sqlite3.Connection,
+    window_hours: int = 24,
+) -> list[SweepCandidate]:
+    """Detect suspicious patterns in recent MCP mutations.
+
+    Checks:
+    - Bulk deactivations: 5+ things deactivated (active set to false) in one hour.
+    - Mass field removal: a single update removes 5+ data keys from a Thing.
+    - Bulk relationship deletions: 5+ relationships deleted in one hour.
+    """
+    candidates: list[SweepCandidate] = []
+
+    # Check if mcp_mutations table exists (may not if DB is pre-migration)
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    if "mcp_mutations" not in tables:
+        return candidates
+
+    window_start = (datetime.now(timezone.utc) - timedelta(hours=window_hours)).isoformat()
+
+    # 1. Bulk deactivations: update_thing mutations with active=false in a 1h window
+    update_rows = conn.execute(
+        """SELECT id, thing_id, timestamp, before_snapshot, after_snapshot
+           FROM mcp_mutations
+           WHERE operation = 'update_thing'
+             AND timestamp >= ?
+           ORDER BY timestamp""",
+        (window_start,),
+    ).fetchall()
+
+    deactivations: list[tuple[str, str]] = []  # (timestamp, thing_id)
+    for row in update_rows:
+        try:
+            after = json.loads(row["after_snapshot"]) if isinstance(row["after_snapshot"], str) else row["after_snapshot"]
+            if isinstance(after, dict) and after.get("active") in (0, False):
+                before = json.loads(row["before_snapshot"]) if isinstance(row["before_snapshot"], str) else row["before_snapshot"]
+                if isinstance(before, dict) and before.get("active") in (1, True):
+                    deactivations.append((row["timestamp"], row["thing_id"] or ""))
+        except (json.JSONDecodeError, TypeError, KeyError):
+            pass
+
+    # Find if any 1-hour window contains >= threshold deactivations
+    for ts_i, _tid in deactivations:
+        try:
+            t_i = datetime.fromisoformat(ts_i.replace("Z", "+00:00"))
+            group = [
+                d for d in deactivations
+                if abs((datetime.fromisoformat(d[0].replace("Z", "+00:00")) - t_i).total_seconds()) <= 3600
+            ]
+        except Exception:
+            group = []
+        if len(group) >= _BULK_DELETE_THRESHOLD:
+            candidates.append(
+                SweepCandidate(
+                    thing_id=None,
+                    thing_title="MCP mutation alert",
+                    finding_type="suspicious_mutation",
+                    message=(
+                        f"Suspicious activity: {len(group)} Things were deactivated within 1 hour "
+                        f"via MCP (around {ts_i[:16]}). Review the mutations journal with get_mutations."
+                    ),
+                    priority=1,
+                )
+            )
+            break  # one alert per sweep is enough
+
+    # 2. Mass field removal in a single update
+    for row in update_rows:
+        try:
+            before = json.loads(row["before_snapshot"]) if isinstance(row["before_snapshot"], str) else row["before_snapshot"]
+            after = json.loads(row["after_snapshot"]) if isinstance(row["after_snapshot"], str) else row["after_snapshot"]
+            if not isinstance(before, dict) or not isinstance(after, dict):
+                continue
+            before_data = json.loads(before.get("data") or "{}") if isinstance(before.get("data"), str) else (before.get("data") or {})
+            after_data = json.loads(after.get("data") or "{}") if isinstance(after.get("data"), str) else (after.get("data") or {})
+            if not isinstance(before_data, dict) or not isinstance(after_data, dict):
+                continue
+            removed_keys = set(before_data.keys()) - set(after_data.keys())
+            if len(removed_keys) >= _BULK_FIELD_REMOVAL_THRESHOLD:
+                candidates.append(
+                    SweepCandidate(
+                        thing_id=row["thing_id"],
+                        thing_title=str(before.get("title", "Unknown")),
+                        finding_type="suspicious_mutation",
+                        message=(
+                            f"{len(removed_keys)} data fields were removed from "
+                            f"\"{before.get('title', row['thing_id'])}\" in a single MCP update "
+                            f"({', '.join(sorted(removed_keys)[:5])}{'...' if len(removed_keys) > 5 else ''}). "
+                            "Review via get_mutations if this was unintentional."
+                        ),
+                        priority=1,
+                        extra={"removed_keys": list(removed_keys)},
+                    )
+                )
+        except (json.JSONDecodeError, TypeError, KeyError):
+            pass
+
+    # 3. Bulk relationship deletions in 1 hour
+    rel_delete_rows = conn.execute(
+        """SELECT timestamp FROM mcp_mutations
+           WHERE operation = 'delete_relationship'
+             AND timestamp >= ?
+           ORDER BY timestamp""",
+        (window_start,),
+    ).fetchall()
+
+    if len(rel_delete_rows) >= _BULK_DELETE_THRESHOLD:
+        try:
+            times = [datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00")) for r in rel_delete_rows]
+            for i, t_i in enumerate(times):
+                group_count = sum(1 for t in times if abs((t - t_i).total_seconds()) <= 3600)
+                if group_count >= _BULK_DELETE_THRESHOLD:
+                    candidates.append(
+                        SweepCandidate(
+                            thing_id=None,
+                            thing_title="MCP mutation alert",
+                            finding_type="suspicious_mutation",
+                            message=(
+                                f"Suspicious activity: {group_count} relationships were deleted within 1 hour "
+                                f"via MCP. Review the mutations journal with get_mutations."
+                            ),
+                            priority=1,
+                        )
+                    )
+                    break
+        except Exception:
+            pass
+
+    return candidates
+
+
+# ---------------------------------------------------------------------------
 # Main sweep entry point
 # ---------------------------------------------------------------------------
 
@@ -1048,6 +1187,7 @@ def collect_candidates(
             + find_cross_project_resource_conflicts(conn, today, stale_days)
             + find_cross_project_thematic_connections(conn)
             + find_cross_project_duplicate_effort(conn)
+            + find_suspicious_mutations(conn)
         )
 
     # Deduplicate: keep the highest-priority (lowest number) candidate per (thing_id, finding_type)


### PR DESCRIPTION
## Summary

- Implements `mcp_mutations` table for write operation logging with before/after snapshots
- Adds `GET /api/mutations` endpoint for querying mutation history
- Adds `get_mutations` MCP tool
- Adds sweep phase for detecting suspicious patterns

Part of #247

---
*Automated pull request published by Gastown Refinery.*

- Issue: re-x3z
- Branch: feat/mutations-journal-re-x3z
- Target: master