### PR TITLE
feat: get_preferences and update_preference MCP tools (re-i7h)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -102,6 +102,8 @@ mcp = FastMCP(
         "Reli is a personal knowledge graph. Use these tools to search, create, "
         "read, update, and delete Things (tasks, notes, projects, people, ideas, "
         "goals) and the typed relationships between them. "
+        "Use get_preferences and update_preference to load and record the user's "
+        "learned behavioral preferences at session start and end. "
         "Use get_briefing to see what needs attention today (checkin-due items and "
         "sweep findings). Use get_open_questions to find Things with unresolved "
         "knowledge gaps and ask the user proactively. "
@@ -334,6 +336,46 @@ def delete_relationship(relationship_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Server-side intelligence tools
 # ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def get_preferences() -> list[dict[str, Any]]:
+    """Get all preference Things — the user's learned behavioral preferences.
+
+    Returns Things with type_hint='preference'. Each preference Thing has a
+    patterns array in its data field describing how the user wants the PA to
+    behave (communication style, proactivity level, question frequency, etc.).
+
+    Should be called at session start alongside get_user_profile to load the
+    user's behavioral configuration.
+    """
+    result: list[dict[str, Any]] = _api_get("/api/things/preferences")
+    return result
+
+
+@mcp.tool()
+def update_preference(
+    thing_id: str,
+    patterns: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Update the patterns array on a preference Thing.
+
+    Replaces the patterns array in the Thing's data field without touching
+    other fields. Use this to record behavioral signals observed during
+    a conversation.
+
+    Args:
+        thing_id: UUID of the preference Thing to update.
+        patterns: List of pattern dicts, each with:
+            - pattern (str): Description of the observed preference pattern.
+            - confidence (str): One of 'emerging' (1 obs), 'moderate' (2-3), 'strong' (4+).
+            - observations (int): Number of times this pattern was observed.
+    """
+    result: dict[str, Any] = _api_patch(
+        f"/api/things/{thing_id}/preferences",
+        json_body={"patterns": patterns},
+    )
+    return result
 
 
 @mcp.tool()

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -165,6 +165,80 @@ def get_user_thing(user_id: str = Depends(require_user)) -> UserProfileDetail:
     return UserProfileDetail(thing=thing, relationships=relationships)
 
 
+@router.get("/preferences", response_model=list[Thing], summary="List all preference Things")
+def get_preferences(user_id: str = Depends(require_user)) -> list[Thing]:
+    """Return all Things with type_hint='preference', ordered by priority."""
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM things WHERE type_hint = 'preference'{uf_sql} ORDER BY priority ASC, updated_at DESC",
+            uf_params,
+        ).fetchall()
+    return [_row_to_thing(r) for r in rows]
+
+
+class PreferencePatternItem(BaseModel):
+    pattern: str
+    confidence: str
+    observations: int
+
+
+class PreferencePatternsUpdate(BaseModel):
+    patterns: list[PreferencePatternItem]
+
+
+VALID_CONFIDENCE = {"emerging", "moderate", "strong"}
+
+
+@router.patch("/{thing_id}/preferences", response_model=Thing, summary="Update patterns on a preference Thing")
+def update_preference_patterns(
+    thing_id: str,
+    body: PreferencePatternsUpdate,
+    background_tasks: BackgroundTasks,
+    user_id: str = Depends(require_user),
+) -> Thing:
+    """Replace the patterns array in a preference Thing's data field.
+
+    Only updates data.patterns — other data fields and top-level Thing fields
+    are left untouched.
+    """
+    for item in body.patterns:
+        if item.confidence not in VALID_CONFIDENCE:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid confidence '{item.confidence}'. Must be one of: {sorted(VALID_CONFIDENCE)}",
+            )
+        if item.observations < 0:
+            raise HTTPException(status_code=422, detail="observations must be non-negative")
+
+    uf_sql, uf_params = user_filter(user_id)
+    with db() as conn:
+        row = conn.execute(
+            f"SELECT * FROM things WHERE id = ? AND type_hint = 'preference'{uf_sql}",
+            [thing_id, *uf_params],
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail=f"Preference Thing '{thing_id}' not found")
+
+        existing_data = row["data"]
+        if isinstance(existing_data, str) and existing_data:
+            try:
+                existing_data = json.loads(existing_data)
+            except (json.JSONDecodeError, ValueError):
+                existing_data = {}
+        if not isinstance(existing_data, dict):
+            existing_data = {}
+
+        existing_data["patterns"] = [p.model_dump() for p in body.patterns]
+        conn.execute(
+            "UPDATE things SET data = ?, updated_at = ? WHERE id = ?",
+            [json.dumps(existing_data), datetime.now(timezone.utc).isoformat(), thing_id],
+        )
+        row = conn.execute("SELECT * FROM things WHERE id = ?", (thing_id,)).fetchone()
+    background_tasks.add_task(upsert_thing, dict(row))
+    return _row_to_thing(row)
+
+
 @router.get("/open-questions", response_model=list[Thing], summary="List Things with open questions")
 def get_open_questions(
     limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ from backend.mcp_server import (
     get_briefing,
     get_conflicts,
     get_open_questions,
+    get_preferences,
     get_thing,
     list_relationships,
     mcp,
@@ -28,6 +29,7 @@ from backend.mcp_server import (
     search_things,
     thing_creation_guide,
     thing_schema_reference,
+    update_preference,
     update_thing,
 )
 
@@ -395,6 +397,8 @@ class TestMcpMetadata:
             "get_briefing",
             "get_open_questions",
             "get_conflicts",
+            "get_preferences",
+            "update_preference",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -600,6 +604,73 @@ class TestGetOpenQuestions:
         mock_get.return_value = []
         get_open_questions(limit=999)
         mock_get.assert_called_once_with("/api/things/open-questions", params={"limit": 200})
+
+
+# ---------------------------------------------------------------------------
+# get_preferences
+# ---------------------------------------------------------------------------
+
+
+class TestGetPreferences:
+    @patch("backend.mcp_server._api_get")
+    def test_returns_preference_things(self, mock_get: MagicMock) -> None:
+        prefs = [
+            {
+                "id": "p1",
+                "title": "Communication style",
+                "type_hint": "preference",
+                "data": {"patterns": [{"pattern": "concise", "confidence": "strong", "observations": 5}]},
+            }
+        ]
+        mock_get.return_value = prefs
+        result = get_preferences()
+        mock_get.assert_called_once_with("/api/things/preferences")
+        assert len(result) == 1
+        assert result[0]["type_hint"] == "preference"
+
+    @patch("backend.mcp_server._api_get")
+    def test_empty_when_no_preferences(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = []
+        result = get_preferences()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# update_preference
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePreference:
+    @patch("backend.mcp_server._api_patch")
+    def test_updates_patterns(self, mock_patch: MagicMock) -> None:
+        updated = {
+            "id": "p1",
+            "title": "Communication style",
+            "type_hint": "preference",
+            "data": {"patterns": [{"pattern": "concise", "confidence": "strong", "observations": 5}]},
+        }
+        mock_patch.return_value = updated
+        patterns = [{"pattern": "concise", "confidence": "strong", "observations": 5}]
+        result = update_preference("p1", patterns)
+        mock_patch.assert_called_once_with(
+            "/api/things/p1/preferences",
+            json_body={"patterns": patterns},
+        )
+        assert result["id"] == "p1"
+        assert result["data"]["patterns"][0]["confidence"] == "strong"
+
+    @patch("backend.mcp_server._api_patch")
+    def test_multiple_patterns(self, mock_patch: MagicMock) -> None:
+        mock_patch.return_value = {"id": "p1"}
+        patterns = [
+            {"pattern": "uses bullet points", "confidence": "emerging", "observations": 1},
+            {"pattern": "prefers brevity", "confidence": "moderate", "observations": 3},
+        ]
+        update_preference("p1", patterns)
+        mock_patch.assert_called_once_with(
+            "/api/things/p1/preferences",
+            json_body={"patterns": patterns},
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements `get_preferences` and `update_preference` MCP tools per issue #244.

Part of #244

---
*Automated pull request published by Gastown Refinery.*

- Issue: re-i7h
- Branch: feat/mcp-get-preferences-update-preference-re-i7h
- Target: master