### PR TITLE
feat: get_user_profile MCP tool (re-hwm)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -102,6 +102,8 @@ mcp = FastMCP(
         "Reli is a personal knowledge graph. Use these tools to search, create, "
         "read, update, and delete Things (tasks, notes, projects, people, ideas, "
         "goals) and the typed relationships between them. "
+        "Call get_user_profile once at session start to load the user's anchor Thing "
+        "(who they are) and their relationships. "
         "Use get_briefing to see what needs attention today (checkin-due items and "
         "sweep findings). Use get_open_questions to find Things with unresolved "
         "knowledge gaps and ask the user proactively. "
@@ -384,6 +386,21 @@ def get_conflicts(window: int = 14) -> list[dict[str, Any]]:
     """
     params: dict[str, Any] = {"window": min(max(window, 1), 90)}
     result: list[dict[str, Any]] = _api_get("/api/conflicts", params=params)
+    return result
+
+
+@mcp.tool()
+def get_user_profile() -> dict[str, Any]:
+    """Get the current user's profile Thing with all resolved relationships.
+
+    Returns the user's anchor Thing (type_hint=person, surface=false) — the
+    "who am I" context a calling agent should load at session start. Includes
+    all relationships with direction (incoming/outgoing) and related Thing
+    titles and IDs.
+
+    Returns a clear error if no user profile Thing exists.
+    """
+    result: dict[str, Any] = _api_get("/api/things/me")
     return result
 
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -19,6 +19,7 @@ from backend.mcp_server import (
     get_conflicts,
     get_open_questions,
     get_thing,
+    get_user_profile,
     list_relationships,
     mcp,
     merge_things,
@@ -395,6 +396,7 @@ class TestMcpMetadata:
             "get_briefing",
             "get_open_questions",
             "get_conflicts",
+            "get_user_profile",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -672,6 +674,66 @@ class TestGetConflicts:
         assert len(result) == 2
         assert result[0]["severity"] == "critical"
         assert result[1]["alert_type"] == "schedule_overlap"
+
+
+# get_user_profile
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserProfile:
+    @patch("backend.mcp_server._api_get")
+    def test_returns_profile_with_relationships(self, mock_get: MagicMock) -> None:
+        profile = {
+            "thing": {
+                "id": "u1",
+                "title": "Alice",
+                "type_hint": "person",
+                "surface": False,
+                "priority": 3,
+                "active": True,
+            },
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationship_type": "works_with",
+                    "direction": "outgoing",
+                    "related_thing_id": "t2",
+                    "related_thing_title": "Bob",
+                }
+            ],
+        }
+        mock_get.return_value = profile
+        result = get_user_profile()
+        mock_get.assert_called_once_with("/api/things/me")
+        assert result["thing"]["title"] == "Alice"
+        assert result["thing"]["type_hint"] == "person"
+        assert len(result["relationships"]) == 1
+        assert result["relationships"][0]["direction"] == "outgoing"
+        assert result["relationships"][0]["related_thing_title"] == "Bob"
+
+    @patch("backend.mcp_server._api_get")
+    def test_no_relationships(self, mock_get: MagicMock) -> None:
+        profile = {
+            "thing": {"id": "u1", "title": "Alice", "type_hint": "person"},
+            "relationships": [],
+        }
+        mock_get.return_value = profile
+        result = get_user_profile()
+        assert result["relationships"] == []
+
+    @patch("backend.mcp_server._api_get")
+    def test_propagates_404_error(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = httpx.HTTPStatusError(
+            "404",
+            request=httpx.Request("GET", "http://test/api/things/me"),
+            response=httpx.Response(
+                status_code=404,
+                json={"detail": "User profile Thing not found"},
+                request=httpx.Request("GET", "http://test/api/things/me"),
+            ),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            get_user_profile()
 
 
 # MCP Prompt Resources (Phase 2)


### PR DESCRIPTION
## Summary

Implements `get_user_profile` MCP tool per issue #242.

Part of #242

---
*Automated pull request published by Gastown Refinery.*

- Issue: re-hwm
- Branch: feat/mcp-get-user-profile-re-hwm
- Target: master