### PR TITLE
feat: search_things and get_thing MCP tools (re-t4w)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -145,13 +145,18 @@ def search_things(
 
 @mcp.tool()
 def get_thing(thing_id: str) -> dict[str, Any]:
-    """Get a single Thing by its ID, including all fields.
+    """Get a single Thing by its ID, including all fields and its relationships.
+
+    Returns a dict with two keys:
+    - "thing": the Thing record (all fields)
+    - "relationships": list of all relationships where this Thing is source or target
 
     Args:
         thing_id: The UUID of the Thing to retrieve.
     """
-    result: dict[str, Any] = _api_get(f"/api/things/{thing_id}")
-    return result
+    thing: dict[str, Any] = _api_get(f"/api/things/{thing_id}")
+    relationships: list[dict[str, Any]] = _api_get(f"/api/things/{thing_id}/relationships")
+    return {"thing": thing, "relationships": relationships}
 
 
 @mcp.tool()

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -28,7 +28,7 @@ from ..models import (
     ThingUpdate,
 )
 from ..vector_store import delete_thing as vs_delete
-from ..vector_store import reindex_all, upsert_thing
+from ..vector_store import reindex_all, upsert_thing, vector_search
 
 router = APIRouter(prefix="/things", tags=["things"])
 
@@ -193,11 +193,21 @@ def search_things(
     limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
     user_id: str = Depends(require_user),
 ) -> list[Thing]:
-    """Search Things by text query across title, data, type_hint, and related Things."""
+    """Search Things by hybrid query: SQLite LIKE text search merged with ChromaDB vector similarity."""
     if not q.strip():
         return []
 
     pattern = f"%{q}%"
+
+    # --- Vector search (ChromaDB) — may return empty list if index is empty ---
+    vector_ids = vector_search(
+        queries=[q],
+        n_results=limit,
+        active_only=active_only,
+        type_hint=type_hint,
+        user_id=user_id,
+    )
+
     with db() as conn:
         # Build a WHERE filter applied to all branches of the UNION
         filters = ""
@@ -252,9 +262,24 @@ def search_things(
             " LIMIT ?"
         )
         params = [*direct_params, *rel_params, limit]
-        rows = conn.execute(sql, params).fetchall()
+        sql_rows = conn.execute(sql, params).fetchall()
+        sql_things = [_row_to_thing(r) for r in sql_rows]
 
-    return [_row_to_thing(r) for r in rows]
+        # Merge vector results: fetch any vector IDs not already in SQL results
+        sql_ids = {t.id for t in sql_things}
+        extra_ids = [vid for vid in vector_ids if vid not in sql_ids]
+        vector_things: list[Thing] = []
+        if extra_ids:
+            placeholders = ",".join("?" * len(extra_ids))
+            vec_rows = conn.execute(
+                f"SELECT * FROM things WHERE id IN ({placeholders})",
+                extra_ids,
+            ).fetchall()
+            vector_things = [_row_to_thing(r) for r in vec_rows]
+
+    # SQL matches first (ranked by relevance), then vector-only matches
+    combined = sql_things + vector_things
+    return combined[:limit]
 
 
 @router.get("", response_model=list[Thing], summary="List Things")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -63,6 +63,7 @@ def mock_vector_store():
         patch("backend.routers.auth.upsert_thing", return_value=None),
         patch("backend.routers.things.upsert_thing", return_value=None) as mock_upsert,
         patch("backend.routers.things.vs_delete", return_value=None) as mock_delete,
+        patch("backend.routers.things.vector_search", return_value=[]) as mock_vector_search,
         patch("backend.pipeline.vector_count", return_value=0) as mock_count,
         patch("backend.pipeline.vector_search", return_value=[]) as mock_search,
     ):
@@ -71,6 +72,7 @@ def mock_vector_store():
             "delete": mock_delete,
             "count": mock_count,
             "search": mock_search,
+            "vector_search": mock_vector_search,
         }
 
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -91,18 +91,33 @@ class TestSearchThings:
 
 class TestGetThing:
     @patch("backend.mcp_server._api_get")
-    def test_get_existing(self, mock_get: MagicMock) -> None:
+    def test_get_existing_with_relationships(self, mock_get: MagicMock) -> None:
         thing = {
             "id": "abc-123",
             "title": "My Task",
             "type_hint": "task",
             "priority": 2,
         }
-        mock_get.return_value = thing
+        relationships = [
+            {"id": "rel-1", "from_thing_id": "abc-123", "to_thing_id": "other-1", "relationship_type": "depends_on"}
+        ]
+        mock_get.side_effect = [thing, relationships]
         result = get_thing(thing_id="abc-123")
-        mock_get.assert_called_once_with("/api/things/abc-123")
-        assert result["id"] == "abc-123"
-        assert result["title"] == "My Task"
+        assert mock_get.call_count == 2
+        mock_get.assert_any_call("/api/things/abc-123")
+        mock_get.assert_any_call("/api/things/abc-123/relationships")
+        assert result["thing"]["id"] == "abc-123"
+        assert result["thing"]["title"] == "My Task"
+        assert len(result["relationships"]) == 1
+        assert result["relationships"][0]["relationship_type"] == "depends_on"
+
+    @patch("backend.mcp_server._api_get")
+    def test_get_thing_no_relationships(self, mock_get: MagicMock) -> None:
+        thing = {"id": "abc-123", "title": "My Task", "type_hint": "task", "priority": 2}
+        mock_get.side_effect = [thing, []]
+        result = get_thing(thing_id="abc-123")
+        assert result["thing"]["id"] == "abc-123"
+        assert result["relationships"] == []
 
     @patch("backend.mcp_server._api_get")
     def test_get_not_found(self, mock_get: MagicMock) -> None:
@@ -450,10 +465,11 @@ class TestIntegration:
         assert created["title"] == "MCP Test Thing"
         thing_id = created["id"]
 
-        # Get
+        # Get — returns {"thing": ..., "relationships": [...]}
         fetched = get_thing(thing_id=thing_id)
-        assert fetched["id"] == thing_id
-        assert fetched["type_hint"] == "task"
+        assert fetched["thing"]["id"] == thing_id
+        assert fetched["thing"]["type_hint"] == "task"
+        assert isinstance(fetched["relationships"], list)
 
         # Update
         updated = update_thing(thing_id=thing_id, title="Updated MCP Thing", priority=1)
@@ -471,7 +487,7 @@ class TestIntegration:
 
         # Thing still exists in the DB (soft-deleted)
         fetched_after = get_thing(thing_id=thing_id)
-        assert fetched_after["active"] is False
+        assert fetched_after["thing"]["active"] is False
 
     def test_merge_lifecycle(self, api_server: None) -> None:
         """Create two Things, merge them, verify the duplicate is gone."""
@@ -486,7 +502,7 @@ class TestIntegration:
 
         # Kept thing still exists
         kept = get_thing(thing_id=keep["id"])
-        assert kept["id"] == keep["id"]
+        assert kept["thing"]["id"] == keep["id"]
 
     def test_relationship_lifecycle(self, api_server: None) -> None:
         """Create two Things, link them, list, then delete the relationship."""

--- a/backend/tests/test_things.py
+++ b/backend/tests/test_things.py
@@ -1,5 +1,7 @@
 """Tests for Things CRUD endpoints."""
 
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 
 from backend.database import db
@@ -361,3 +363,59 @@ class TestOrphanRelationships:
         assert resp.status_code == 200
         assert resp.json()["deleted_count"] == 0
         assert resp.json()["deleted_ids"] == []
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search (SQL LIKE + ChromaDB vector)
+# ---------------------------------------------------------------------------
+
+
+class TestHybridSearch:
+    def test_search_empty_query_returns_empty(self, client):
+        resp = client.get("/api/things/search", params={"q": ""})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_search_sql_match(self, client):
+        create_thing(client, title="Buy milk")
+        create_thing(client, title="Call dentist")
+        resp = client.get("/api/things/search", params={"q": "milk"})
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [t["title"] for t in data]
+        assert "Buy milk" in titles
+        assert "Call dentist" not in titles
+
+    def test_search_merges_vector_results(self, client):
+        t1 = create_thing(client, title="Buy milk")
+        t2 = create_thing(client, title="Walk dog")  # won't match SQL for "milk"
+        with patch("backend.routers.things.vector_search", return_value=[t2["id"]]):
+            resp = client.get("/api/things/search", params={"q": "milk"})
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [t["id"] for t in data]
+        # SQL match comes first
+        assert ids[0] == t1["id"]
+        # Vector-only result appended
+        assert t2["id"] in ids
+
+    def test_search_no_duplicates_when_vector_overlaps_sql(self, client):
+        t1 = create_thing(client, title="Buy milk")
+        # Vector returns the same ID as SQL — should not duplicate
+        with patch("backend.routers.things.vector_search", return_value=[t1["id"]]):
+            resp = client.get("/api/things/search", params={"q": "milk"})
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [t["id"] for t in data]
+        assert ids.count(t1["id"]) == 1
+
+    def test_search_active_only_filter(self, client):
+        t_active = create_thing(client, title="Active task", active=True)
+        t_inactive = create_thing(client, title="Active task archived")
+        client.patch(f"/api/things/{t_inactive['id']}", json={"active": False})
+        resp = client.get("/api/things/search", params={"q": "Active task", "active_only": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [t["id"] for t in data]
+        assert t_active["id"] in ids
+        assert t_inactive["id"] not in ids


### PR DESCRIPTION
## Summary

Implements `search_things` and `get_thing` MCP tools per issue #238.

Part of #238

---
*Automated pull request published by Gastown Refinery.*

- Issue: re-t4w
- Branch: gc-polecat-5-re-t4w
- Target: master