### PR TITLE
fix: add production host to MCP DNS rebinding allowed_hosts

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -96,6 +96,19 @@ def _api_delete(path: str) -> Any:
 # MCP Server
 # ---------------------------------------------------------------------------
 
+from mcp.server.fastmcp.server import TransportSecuritySettings
+
+# Allow the production host through MCP's DNS rebinding protection.
+# Derive from RELI_BASE_URL or GOOGLE_AUTH_REDIRECT_URI.
+_RELI_HOST = os.environ.get("RELI_BASE_URL", "").replace("https://", "").replace("http://", "").rstrip("/")
+if not _RELI_HOST:
+    _redirect_uri = os.environ.get("GOOGLE_AUTH_REDIRECT_URI", "")
+    if _redirect_uri:
+        _RELI_HOST = _redirect_uri.split("/")[2] if len(_redirect_uri.split("/")) > 2 else ""
+_allowed_hosts = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+if _RELI_HOST:
+    _allowed_hosts.append(_RELI_HOST)
+
 mcp = FastMCP(
     "Reli",
     instructions=(
@@ -113,6 +126,10 @@ mcp = FastMCP(
     ),
     # Path is "/" because FastAPI mounts us at /mcp — the combined path is /mcp/
     streamable_http_path="/",
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=_allowed_hosts,
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- Fix 421 "Invalid Host header" from MCP library's DNS rebinding protection
- MCP SDK defaults `allowed_hosts` to localhost only — production host gets rejected
- Derive production hostname from `RELI_BASE_URL` or `GOOGLE_AUTH_REDIRECT_URI` and add to allowed list

## Test plan
- [ ] `curl -X POST https://reli.interstellarai.net/mcp/` with valid token returns MCP response (not 421)
- [ ] Claude Code `/mcp` connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)