### PR TITLE
fix: qualify user_id with table alias in find_information_gaps JOIN query

### DIFF
--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -596,6 +596,7 @@ def find_information_gaps(
     today = today or date.today()
     age_cutoff = (today - timedelta(days=min_age_days)).isoformat()
     uf_sql, uf_params = user_filter(user_id)
+    uf_sql_p, uf_params_p = user_filter(user_id, "p")
 
     candidates: list[SweepCandidate] = []
 
@@ -630,10 +631,10 @@ def find_information_gaps(
            WHERE p.active = 1
              AND p.type_hint = 'project'
              AND p.checkin_date IS NULL
-             AND (p.open_questions IS NULL OR p.open_questions = '[]' OR p.open_questions = 'null'){uf_sql}
+             AND (p.open_questions IS NULL OR p.open_questions = '[]' OR p.open_questions = 'null'){uf_sql_p}
            GROUP BY p.id
            HAVING child_count > 0""",
-        uf_params,
+        uf_params_p,
     ).fetchall()
     for row in proj_rows:
         # Check data JSON for deadline/due_date fields

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -665,6 +665,23 @@ class TestGenerateGapQuestions:
         questions = json.loads(row["open_questions"])
         assert len(questions) >= 1
 
+    def test_no_ambiguous_user_id_with_join(self, patched_db):
+        """Regression: find_information_gaps must not raise OperationalError: ambiguous column name: user_id
+        when called with a user_id and the project-with-children JOIN query executes."""
+        today = date.today()
+        with db() as conn:
+            conn.execute(
+                "INSERT INTO users (id, email, name, google_id) VALUES ('u-test', 'test@example.com', 'Test', 'g-test')"
+            )
+            _insert_thing(conn, "proj1", "My Project", type_hint="project")
+            _insert_thing(conn, "task1", "Child Task", parent_id="proj1")
+            conn.execute("UPDATE things SET user_id = 'u-test' WHERE id IN ('proj1', 'task1')")
+        with db() as conn:
+            # This must not raise OperationalError: ambiguous column name: user_id
+            results = find_information_gaps(conn, today, min_age_days=0, user_id="u-test")
+        proj_gaps = [r for r in results if r.thing_id == "proj1"]
+        assert any(r.extra.get("gap_type") == "no_deadline_project" for r in proj_gaps)
+
 
 # ---------------------------------------------------------------------------
 # collect_candidates integration


### PR DESCRIPTION
## Summary
- `find_information_gaps` used `user_filter(user_id)` (no alias) for a JOIN query on `things p JOIN things c`, making `user_id` ambiguous in the WHERE clause
- Fix: generate a second `user_filter(user_id, "p")` variant for the JOIN query only; single-table queries keep the unaliased version
- Added regression test that verifies no `OperationalError: ambiguous column name: user_id` when `user_id` filtering is active with the project-children JOIN

## Test plan
- [ ] `pytest backend/tests/test_sweep.py` — all 83 tests pass
- [ ] Specifically: `TestGenerateGapQuestions::test_no_ambiguous_user_id_with_join`

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)