### PR TITLE
fix: reset MCP session manager state on lifespan restart (re-254)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -76,8 +76,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         app.state.httpx_client = client
-        # Guard against double-start (tests create multiple app instances)
-        if _mcp_server._session_manager and not _mcp_server._session_manager._has_started:
+        sm = _mcp_server._session_manager
+        if sm is not None:
+            if sm._has_started:
+                # The session manager's run() is one-shot per instance. After it exits
+                # (e.g., hot-reload, uvicorn worker restart, or test teardown), _has_started
+                # remains True and _task_group is None. Reset the one-shot state so we can
+                # call run() again on the same instance — the ASGI handler holds a reference
+                # to this object, so creating a new instance would leave the handler broken.
+                import anyio as _anyio
+
+                sm._has_started = False
+                sm._run_lock = _anyio.Lock()
             async with _mcp_server.session_manager.run():
                 yield
         else:

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1053,3 +1053,38 @@ class TestTokenAuthMiddleware:
         resp = client.get("/", headers={"Authorization": "Bearer bad"})
         assert resp.status_code == 401
         assert "Bearer" in resp.headers.get("www-authenticate", "")
+
+
+class TestSessionManagerRestart:
+    """Regression test: session manager must restart after a previous run completes.
+
+    Re: GH#312, #313 — "Task group is not initialized. Make sure to use run()."
+    The bug: _has_started stays True after run() exits, so the lifespan skips
+    run() on the next startup, leaving _task_group = None.
+    """
+
+    def test_session_manager_restarts_after_previous_run(self, patched_db) -> None:
+        """Verify that a second TestClient (= second lifespan) still serves MCP."""
+        from backend.main import app
+        from backend.mcp_server import mcp
+
+        # First app lifecycle: start and stop
+        with TestClient(app):
+            pass  # lifespan runs and exits; _has_started = True, _task_group = None
+
+        sm = mcp._session_manager
+        assert sm is not None
+        assert sm._has_started, "session manager should have been started"
+        assert sm._task_group is None, "task group should be None after shutdown"
+
+        # Second app lifecycle: the lifespan must reset and restart the session manager
+        with TestClient(app) as client:
+            # If the fix is absent, any MCP request would raise
+            # "Task group is not initialized" and the app would return 500.
+            resp = client.get("/mcp/", headers={"Authorization": "Bearer "})
+            # The session manager is running — it handles the request (400/422/200 are all ok;
+            # 500 means the task group was not restarted).
+            assert resp.status_code != 500, (
+                f"MCP returned 500 — session manager task group was not restarted. "
+                f"Response: {resp.text}"
+            )


### PR DESCRIPTION
## Summary

- fix: reset MCP session manager state so it can restart after lifespan shutdown
- Fixes #313

## Issue

- Bead: re-254
- Branch: fix/mcp-task-group-restart-re-254
- Target: master

🤖 Published by Gastown Refinery