### PR TITLE
fix: copy prompts/ directory into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN pip install --no-cache-dir -r backend/requirements.txt
 # Copy config
 COPY config.yaml ./config.yaml
 
-# Copy backend
+# Copy backend and prompts
 COPY backend/ ./backend/
+COPY prompts/ ./prompts/
 
 # Copy frontend build from stage 1
 COPY --from=frontend-build /app/frontend/dist/ ./frontend/dist/


### PR DESCRIPTION
## Summary
- Add `COPY prompts/ ./prompts/` to Dockerfile
- PR #329 extracted agent prompts to `prompts/*.md` files but didn't update the Dockerfile, causing `FileNotFoundError` on container startup

**This is blocking deployment** — the current production image crashes on startup.

## Test plan
- [ ] Container starts without FileNotFoundError
- [ ] Health check passes
- [ ] MCP prompt resources return content

🤖 Generated with [Claude Code](https://claude.com/claude-code)