### PR TITLE
chore: parallelize CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [master]
 
 jobs:
-  gates:
-    name: Quality Gates
+  lint-and-typecheck:
+    name: Lint & Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,11 +45,46 @@ jobs:
       - name: Setup
         run: ./scripts/gates.sh setup
 
-      - name: Lint
-        run: ./scripts/gates.sh lint
+      - name: Lint & Typecheck
+        run: ./scripts/gates.sh lint & ./scripts/gates.sh typecheck & wait
 
-      - name: Typecheck
-        run: ./scripts/gates.sh typecheck
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Python dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Setup
+        run: ./scripts/gates.sh setup
 
       - name: Test
         run: ./scripts/gates.sh test
@@ -57,7 +92,6 @@ jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
-    needs: [gates]
     permissions:
       contents: read
       packages: write
@@ -99,7 +133,7 @@ jobs:
   deploy:
     name: Deploy to server
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [lint-and-typecheck, test, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
       packages: read


### PR DESCRIPTION
## Summary
- Split the single sequential `gates` job into three parallel jobs: **Lint & Typecheck**, **Test**, and **Build Docker image**
- Deploy job now waits for all three to pass (master only)
- Updated branch protection to require all three new status checks

## Test plan
- [ ] Verify all three jobs run in parallel on the PR
- [ ] Confirm deploy job only triggers on master push after all three pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)