### PR TITLE
Fix #435: Add user_id ownership checks to tools.py

### DIFF
--- a/backend/tests/test_user_isolation.py
+++ b/backend/tests/test_user_isolation.py
@@ -1,0 +1,105 @@
+"""Tests for user_id ownership checks in tools.py (issue #435).
+
+Verifies that update_thing, delete_thing, merge_things, delete_relationship,
+and create_relationship reject operations when user_id doesn't match the
+Thing's owner.
+"""
+
+from backend.tools import (
+    create_thing,
+    update_thing,
+    delete_thing,
+    merge_things,
+    create_relationship,
+    delete_relationship,
+)
+
+
+USER_A = "user-a"
+USER_B = "user-b"
+
+
+def _make_thing(title: str = "Test Thing", user_id: str = USER_A) -> dict:
+    result = create_thing(title=title, user_id=user_id)
+    assert "id" in result, f"Failed to create thing: {result}"
+    return result
+
+
+class TestUpdateThingIsolation:
+    def test_owner_can_update(self, patched_db):
+        thing = _make_thing()
+        result = update_thing(thing["id"], title="Updated", user_id=USER_A)
+        assert result.get("title") == "Updated"
+        assert "error" not in result
+
+    def test_other_user_cannot_update(self, patched_db):
+        thing = _make_thing()
+        result = update_thing(thing["id"], title="Hacked", user_id=USER_B)
+        assert result == {"error": "Unauthorized"}
+
+    def test_no_user_id_skips_check(self, patched_db):
+        """When no user_id is provided (e.g. system/admin), allow access."""
+        thing = _make_thing()
+        result = update_thing(thing["id"], title="System Update", user_id="")
+        assert result.get("title") == "System Update"
+
+
+class TestDeleteThingIsolation:
+    def test_owner_can_delete(self, patched_db):
+        thing = _make_thing()
+        result = delete_thing(thing["id"], user_id=USER_A)
+        assert result.get("deleted") == thing["id"]
+
+    def test_other_user_cannot_delete(self, patched_db):
+        thing = _make_thing()
+        result = delete_thing(thing["id"], user_id=USER_B)
+        assert result == {"error": "Unauthorized"}
+
+
+class TestMergeThingsIsolation:
+    def test_owner_can_merge(self, patched_db):
+        keep = _make_thing(title="Keep")
+        remove = _make_thing(title="Remove")
+        result = merge_things(keep["id"], remove["id"], user_id=USER_A)
+        assert result.get("keep_id") == keep["id"]
+
+    def test_other_user_cannot_merge_keep(self, patched_db):
+        keep = _make_thing(title="Keep")
+        remove = _make_thing(title="Remove")
+        result = merge_things(keep["id"], remove["id"], user_id=USER_B)
+        assert result == {"error": "Unauthorized"}
+
+    def test_other_user_cannot_merge_remove(self, patched_db):
+        """Even if user owns keep but not remove, merge is rejected."""
+        keep = _make_thing(title="Keep", user_id=USER_B)
+        remove = _make_thing(title="Remove", user_id=USER_A)
+        result = merge_things(keep["id"], remove["id"], user_id=USER_B)
+        assert result == {"error": "Unauthorized"}
+
+
+class TestDeleteRelationshipIsolation:
+    def test_owner_can_delete_relationship(self, patched_db):
+        t1 = _make_thing(title="Thing 1")
+        t2 = _make_thing(title="Thing 2")
+        rel = create_relationship(t1["id"], t2["id"], "related", user_id=USER_A)
+        assert "id" in rel
+
+        result = delete_relationship(rel["id"], user_id=USER_A)
+        assert result == {"ok": True}
+
+    def test_other_user_cannot_delete_relationship(self, patched_db):
+        t1 = _make_thing(title="Thing 1")
+        t2 = _make_thing(title="Thing 2")
+        rel = create_relationship(t1["id"], t2["id"], "related", user_id=USER_A)
+        assert "id" in rel
+
+        result = delete_relationship(rel["id"], user_id=USER_B)
+        assert result == {"error": "Unauthorized"}
+
+
+class TestCreateRelationshipIsolation:
+    def test_other_user_cannot_create_relationship(self, patched_db):
+        t1 = _make_thing(title="Thing 1")
+        t2 = _make_thing(title="Thing 2")
+        result = create_relationship(t1["id"], t2["id"], "related", user_id=USER_B)
+        assert result == {"error": "Unauthorized"}

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -334,6 +334,9 @@ def update_thing(
         if not record:
             return {"error": f"Thing {thing_id} not found"}
 
+        if record.user_id and user_id and record.user_id != user_id:
+            return {"error": "Unauthorized"}
+
         changed = False
         if title:
             record.title = title
@@ -405,6 +408,10 @@ def delete_thing(thing_id: str, user_id: str = "") -> dict[str, Any]:
         record = session.get(ThingRecord, thing_id)
         if not record:
             return {"error": f"Thing {thing_id} not found"}
+
+        if record.user_id and user_id and record.user_id != user_id:
+            return {"error": "Unauthorized"}
+
         title = record.title
         session.delete(record)
         session.commit()
@@ -449,6 +456,11 @@ def merge_things(
         remove_rec = session.get(ThingRecord, remove_id)
         if not keep_rec or not remove_rec:
             return {"error": "one or both Things not found"}
+
+        if keep_rec.user_id and user_id and keep_rec.user_id != user_id:
+            return {"error": "Unauthorized"}
+        if remove_rec.user_id and user_id and remove_rec.user_id != user_id:
+            return {"error": "Unauthorized"}
 
         remove_title = remove_rec.title
 
@@ -570,6 +582,12 @@ def create_relationship(
             if not to_row:
                 missing.append(f"to={to_id}")
             return {"error": f"Thing(s) not found: {', '.join(missing)}"}
+
+        # Verify ownership
+        if from_row.user_id and user_id and from_row.user_id != user_id:
+            return {"error": "Unauthorized"}
+        if to_row.user_id and user_id and to_row.user_id != user_id:
+            return {"error": "Unauthorized"}
 
         rel_id = str(uuid.uuid4())
         record = ThingRelationshipRecord(
@@ -718,6 +736,16 @@ def delete_relationship(relationship_id: str, user_id: str = "") -> dict[str, An
         record = session.get(ThingRelationshipRecord, relationship_id)
         if not record:
             return {"error": f"Relationship {relationship_id} not found"}
+
+        # Verify both Things in the relationship belong to the user
+        if user_id:
+            from_thing = session.get(ThingRecord, record.from_thing_id)
+            to_thing = session.get(ThingRecord, record.to_thing_id)
+            if from_thing and from_thing.user_id and from_thing.user_id != user_id:
+                return {"error": "Unauthorized"}
+            if to_thing and to_thing.user_id and to_thing.user_id != user_id:
+                return {"error": "Unauthorized"}
+
         session.delete(record)
         session.commit()
     return {"ok": True}


### PR DESCRIPTION
## Summary
- Adds user_id ownership validation to `update_thing()`, `delete_thing()`, `merge_things()`, `delete_relationship()`, and `create_relationship()` in `backend/tools.py`
- Each function now returns `{"error": "Unauthorized"}` when the requesting user_id doesn't match the Thing's owner, preventing cross-user data access
- Adds `backend/tests/test_user_isolation.py` with 11 tests covering owner access, non-owner rejection, and system/admin passthrough (empty user_id)

## Test plan
- [x] All 11 new isolation tests pass
- [x] Full test suite (714 tests) passes with no regressions

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)