### PR TITLE
Fix #437: Add startup validation for required secrets

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -10,6 +10,8 @@ Usage:
     settings.DATA_DIR
 """
 
+import os
+import warnings
 from pathlib import Path
 from typing import Literal
 
@@ -106,6 +108,25 @@ class Settings(BaseSettings):
         if self.DATABASE_URL:
             return self.DATABASE_URL
         return f"sqlite:///{Path(self.DATA_DIR) / 'reli.db'}"
+
+    @model_validator(mode="after")
+    def _validate_production_secrets(self) -> "Settings":
+        """Fail fast if required secrets are missing in production."""
+        if os.getenv("RAILWAY_ENVIRONMENT_NAME") or os.getenv("PRODUCTION"):
+            required = {
+                "SECRET_KEY": self.SECRET_KEY,
+                "REQUESTY_API_KEY": self.REQUESTY_API_KEY,
+            }
+            missing = [k for k, v in required.items() if not v]
+            if missing:
+                raise ValueError(
+                    f"Missing required production env vars: {', '.join(missing)}"
+                )
+        if not self.SECRET_KEY:
+            warnings.warn(
+                "SECRET_KEY is empty — authentication is DISABLED", stacklevel=2
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_supabase_config(self) -> "Settings":

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,9 +1,11 @@
 """Tests for config.yaml loading and per-stage model routing."""
 
 import textwrap
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 
 
@@ -153,3 +155,62 @@ def test_estimate_cost_unknown_model():
 
     cost = estimate_cost("unknown/nonexistent-model-xyz", 1000, 1000)
     assert cost == 0.0
+
+
+# --- Settings production secret validation tests (#437) ---
+
+
+def test_settings_production_missing_secrets_raises():
+    """Settings must raise ValueError when required secrets are missing in production."""
+    from backend.config import Settings
+
+    with patch.dict("os.environ", {"RAILWAY_ENVIRONMENT_NAME": "production"}, clear=False):
+        with pytest.raises(ValueError, match="Missing required production env vars"):
+            Settings(SECRET_KEY="", REQUESTY_API_KEY="")
+
+
+def test_settings_production_with_secrets_passes():
+    """Settings should not raise when required secrets are provided in production."""
+    from backend.config import Settings
+
+    with patch.dict(
+        "os.environ", {"RAILWAY_ENVIRONMENT_NAME": "production"}, clear=False
+    ):
+        s = Settings(SECRET_KEY="supersecret", REQUESTY_API_KEY="key123")
+        assert s.SECRET_KEY == "supersecret"
+        assert s.REQUESTY_API_KEY == "key123"
+
+
+def test_settings_dev_mode_allows_empty_secrets():
+    """In dev mode (no RAILWAY_ENVIRONMENT_NAME/PRODUCTION), empty secrets are allowed."""
+    from backend.config import Settings
+
+    env_overrides = {
+        "RAILWAY_ENVIRONMENT_NAME": "",
+        "PRODUCTION": "",
+    }
+    with patch.dict("os.environ", env_overrides, clear=False):
+        # Should not raise, just warn
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            s = Settings(SECRET_KEY="", REQUESTY_API_KEY="")
+            assert s.SECRET_KEY == ""
+            # Check that a warning was emitted about SECRET_KEY
+            secret_warnings = [x for x in w if "SECRET_KEY" in str(x.message)]
+            assert len(secret_warnings) >= 1
+
+
+def test_settings_empty_secret_key_warns():
+    """An empty SECRET_KEY should emit a warning even in dev mode."""
+    from backend.config import Settings
+
+    env_overrides = {
+        "RAILWAY_ENVIRONMENT_NAME": "",
+        "PRODUCTION": "",
+    }
+    with patch.dict("os.environ", env_overrides, clear=False):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Settings(SECRET_KEY="", REQUESTY_API_KEY="somekey")
+            secret_warnings = [x for x in w if "authentication is DISABLED" in str(x.message)]
+            assert len(secret_warnings) >= 1


### PR DESCRIPTION
## Summary

- Add a `model_validator` to `Settings` that raises `ValueError` when `SECRET_KEY` or `REQUESTY_API_KEY` are missing in production (detected via `RAILWAY_ENVIRONMENT_NAME` or `PRODUCTION` env vars)
- Emit a warning when `SECRET_KEY` is empty in any environment so developers know auth is disabled
- Add tests for production validation failure, production passthrough with secrets set, dev mode allowing empty secrets, and the dev-mode warning

Closes #437

## Test plan

- [x] `test_settings_production_missing_secrets_raises` — verifies ValueError in production with empty secrets
- [x] `test_settings_production_with_secrets_passes` — verifies no error when secrets are provided
- [x] `test_settings_dev_mode_allows_empty_secrets` — verifies dev mode allows empty secrets with warning
- [x] `test_settings_empty_secret_key_warns` — verifies warning emitted for empty SECRET_KEY
- [x] Full test suite: 732 passed, 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)