### PR TITLE
Fix #442: Make sweep scheduler thread-safe with proper shutdown

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -79,7 +79,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if not _settings.DATABASE_URL:
         init_db()
         clean_orphan_relationships()
-    start_scheduler()
+    await start_scheduler()
 
     # Start MCP session manager (required for streamable HTTP transport).
     # When mounted as a sub-app, Starlette's lifespan doesn't trigger,
@@ -104,7 +104,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 yield
         else:
             yield
-    stop_scheduler()
+    await stop_scheduler()
     shutdown_tracing()
 
 

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -356,21 +356,28 @@ async def sweep_loop() -> None:
 
 
 _task: asyncio.Task[None] | None = None
+_scheduler_lock = asyncio.Lock()
 
 
-def start_scheduler() -> None:
+async def start_scheduler() -> None:
     """Start the sweep background task.  Safe to call multiple times."""
     global _task
-    if _task is not None and not _task.done():
-        return
-    _task = asyncio.create_task(sweep_loop())
-    logger.info("Sweep scheduler task created")
+    async with _scheduler_lock:
+        if _task is not None and not _task.done():
+            return
+        _task = asyncio.create_task(sweep_loop())
+        logger.info("Sweep scheduler task created")
 
 
-def stop_scheduler() -> None:
-    """Cancel the sweep background task if running."""
+async def stop_scheduler() -> None:
+    """Cancel the sweep background task if running and await cleanup."""
     global _task
-    if _task is not None and not _task.done():
-        _task.cancel()
-        logger.info("Sweep scheduler task cancelled")
-    _task = None
+    async with _scheduler_lock:
+        if _task is not None and not _task.done():
+            _task.cancel()
+            try:
+                await _task
+            except asyncio.CancelledError:
+                pass
+            logger.info("Sweep scheduler task cancelled")
+        _task = None

--- a/backend/tests/test_sweep_scheduler.py
+++ b/backend/tests/test_sweep_scheduler.py
@@ -240,11 +240,11 @@ class TestStartStop:
         import backend.sweep_scheduler as mod
 
         mod._task = None
-        start_scheduler()
+        await start_scheduler()
         assert mod._task is not None
         # Let the task start and exit (disabled -> returns immediately)
         await asyncio.sleep(0.1)
-        stop_scheduler()
+        await stop_scheduler()
         assert mod._task is None
 
     @pytest.mark.asyncio
@@ -252,5 +252,5 @@ class TestStartStop:
         import backend.sweep_scheduler as mod
 
         mod._task = None
-        stop_scheduler()  # should not raise
+        await stop_scheduler()  # should not raise
         assert mod._task is None


### PR DESCRIPTION
## Summary
- Added `asyncio.Lock` to guard `_task` access in `start_scheduler()` and `stop_scheduler()`, preventing double-start races
- Made both functions `async` so `stop_scheduler()` properly awaits task cancellation before clearing the reference, ensuring DB locks are released during shutdown
- Updated `main.py` lifespan and tests to `await` the now-async scheduler functions

## Test plan
- [x] All 732 existing tests pass
- [x] `test_start_creates_task` verifies start/stop lifecycle
- [x] `test_stop_idempotent` verifies safe no-op when no task exists

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)