### PR TITLE
Fix #440: Add LLM retry for 429/503 errors

### DIFF
--- a/backend/llm.py
+++ b/backend/llm.py
@@ -28,12 +28,16 @@ REQUESTY_BASE_URL: str = settings.REQUESTY_BASE_URL or "https://router.requesty.
 REQUESTY_API_KEY: str = settings.REQUESTY_API_KEY
 
 # ---------------------------------------------------------------------------
-# Retry config for transient 404s (Gemini/Vertex AI via LiteLLM)
+# Retry config for transient errors (404, 429, 503)
 # ---------------------------------------------------------------------------
 
 _RETRY_MAX_ATTEMPTS: int = 4
 _RETRY_BASE_DELAY: float = 0.5  # seconds
 _RETRY_MAX_DELAY: float = 8.0  # seconds
+
+# Errors worth retrying: transient 404s (Gemini/Vertex AI), 429 rate limits,
+# and 503 service unavailable.
+_RETRYABLE_ERRORS = (litellm.NotFoundError, litellm.RateLimitError, litellm.ServiceUnavailableError)
 
 
 def _litellm_model(model: str) -> str:
@@ -66,8 +70,8 @@ async def acomplete(
     LiteLLM's dynamic return types).  Callers can access ``.choices``, ``.usage``,
     and ``.model`` as usual.
 
-    Retries with exponential backoff on transient 404 errors (common with
-    Gemini/Vertex AI models via LiteLLM).
+    Retries with exponential backoff on transient errors: 404 (Gemini/Vertex AI),
+    429 (rate limit), and 503 (service unavailable).
     """
     last_exc: Exception | None = None
     for attempt in range(_RETRY_MAX_ATTEMPTS):
@@ -79,12 +83,13 @@ async def acomplete(
                 api_base=REQUESTY_BASE_URL,
                 **kwargs,
             )
-        except litellm.NotFoundError as exc:
+        except _RETRYABLE_ERRORS as exc:
             last_exc = exc
             if attempt < _RETRY_MAX_ATTEMPTS - 1:
                 delay = min(_RETRY_BASE_DELAY * (2**attempt), _RETRY_MAX_DELAY)
                 logger.warning(
-                    "LiteLLM 404 on attempt %d/%d for model %s, retrying in %.1fs",
+                    "LiteLLM %s on attempt %d/%d for model %s, retrying in %.1fs",
+                    type(exc).__name__,
                     attempt + 1,
                     _RETRY_MAX_ATTEMPTS,
                     model,
@@ -105,8 +110,8 @@ async def acomplete_stream(
 
     Yields ``litellm`` chunk objects (same shape as OpenAI streaming chunks).
 
-    Retries with exponential backoff on transient 404 errors (common with
-    Gemini/Vertex AI models via LiteLLM).
+    Retries with exponential backoff on transient errors: 404 (Gemini/Vertex AI),
+    429 (rate limit), and 503 (service unavailable).
     """
     last_exc: Exception | None = None
     for attempt in range(_RETRY_MAX_ATTEMPTS):
@@ -123,12 +128,13 @@ async def acomplete_stream(
             async for chunk in response:
                 yield chunk
             return
-        except litellm.NotFoundError as exc:
+        except _RETRYABLE_ERRORS as exc:
             last_exc = exc
             if attempt < _RETRY_MAX_ATTEMPTS - 1:
                 delay = min(_RETRY_BASE_DELAY * (2**attempt), _RETRY_MAX_DELAY)
                 logger.warning(
-                    "LiteLLM 404 on attempt %d/%d for model %s (stream), retrying in %.1fs",
+                    "LiteLLM %s on attempt %d/%d for model %s (stream), retrying in %.1fs",
+                    type(exc).__name__,
                     attempt + 1,
                     _RETRY_MAX_ATTEMPTS,
                     model,

--- a/backend/tests/test_litellm_connector.py
+++ b/backend/tests/test_litellm_connector.py
@@ -301,3 +301,166 @@ async def test_acomplete_retry_uses_exponential_backoff():
     # First retry: 0.5s, second retry: 1.0s
     assert mock_sleep.call_args_list[0].args[0] == pytest.approx(0.5)
     assert mock_sleep.call_args_list[1].args[0] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Retry on 429 (rate limit) and 503 (service unavailable)
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_error() -> litellm.RateLimitError:
+    """Create a litellm.RateLimitError for testing."""
+    return litellm.RateLimitError(
+        message="Rate limit exceeded",
+        model="google/gemini-2.5-flash-lite",
+        llm_provider="openai",
+    )
+
+
+def _make_service_unavailable_error() -> litellm.ServiceUnavailableError:
+    """Create a litellm.ServiceUnavailableError for testing."""
+    return litellm.ServiceUnavailableError(
+        message="Service unavailable",
+        model="google/gemini-2.5-flash-lite",
+        llm_provider="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_acomplete_retries_on_429_then_succeeds():
+    """acomplete retries on 429 rate limit errors and returns on success."""
+    mock_resp = _fake_response("recovered")
+    mock_call = AsyncMock(side_effect=[_make_rate_limit_error(), mock_resp])
+
+    with (
+        patch("backend.llm.litellm.acompletion", mock_call),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await acomplete(
+            [{"role": "user", "content": "hi"}],
+            "google/gemini-2.5-flash-lite",
+        )
+
+    assert result.choices[0].message.content == "recovered"
+    assert mock_call.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_acomplete_retries_on_503_then_succeeds():
+    """acomplete retries on 503 service unavailable errors and returns on success."""
+    mock_resp = _fake_response("recovered")
+    mock_call = AsyncMock(side_effect=[_make_service_unavailable_error(), mock_resp])
+
+    with (
+        patch("backend.llm.litellm.acompletion", mock_call),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await acomplete(
+            [{"role": "user", "content": "hi"}],
+            "google/gemini-2.5-flash-lite",
+        )
+
+    assert result.choices[0].message.content == "recovered"
+    assert mock_call.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_acomplete_raises_429_after_max_retries():
+    """acomplete raises RateLimitError after exhausting all retries."""
+    mock_call = AsyncMock(side_effect=[_make_rate_limit_error()] * _RETRY_MAX_ATTEMPTS)
+
+    with (
+        patch("backend.llm.litellm.acompletion", mock_call),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(litellm.RateLimitError):
+            await acomplete(
+                [{"role": "user", "content": "hi"}],
+                "google/gemini-2.5-flash-lite",
+            )
+
+    assert mock_call.call_count == _RETRY_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_acomplete_raises_503_after_max_retries():
+    """acomplete raises ServiceUnavailableError after exhausting all retries."""
+    mock_call = AsyncMock(side_effect=[_make_service_unavailable_error()] * _RETRY_MAX_ATTEMPTS)
+
+    with (
+        patch("backend.llm.litellm.acompletion", mock_call),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        with pytest.raises(litellm.ServiceUnavailableError):
+            await acomplete(
+                [{"role": "user", "content": "hi"}],
+                "google/gemini-2.5-flash-lite",
+            )
+
+    assert mock_call.call_count == _RETRY_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_acomplete_stream_retries_on_429_then_succeeds():
+    """acomplete_stream retries on 429 rate limit errors and yields chunks on success."""
+    chunks = [_fake_chunk("Hello"), _fake_chunk(" world")]
+
+    async def _fake_stream(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    call_count = 0
+
+    async def _mock_acompletion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 1:
+            raise _make_rate_limit_error()
+        return _fake_stream()
+
+    with (
+        patch("backend.llm.litellm.acompletion", side_effect=_mock_acompletion),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        collected = []
+        async for chunk in acomplete_stream(
+            [{"role": "user", "content": "hi"}],
+            "google/gemini-2.5-flash-lite",
+        ):
+            collected.append(chunk)
+
+    assert len(collected) == 2
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_acomplete_stream_retries_on_503_then_succeeds():
+    """acomplete_stream retries on 503 service unavailable and yields chunks on success."""
+    chunks = [_fake_chunk("Hello"), _fake_chunk(" world")]
+
+    async def _fake_stream(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    call_count = 0
+
+    async def _mock_acompletion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 1:
+            raise _make_service_unavailable_error()
+        return _fake_stream()
+
+    with (
+        patch("backend.llm.litellm.acompletion", side_effect=_mock_acompletion),
+        patch("backend.llm.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        collected = []
+        async for chunk in acomplete_stream(
+            [{"role": "user", "content": "hi"}],
+            "google/gemini-2.5-flash-lite",
+        ):
+            collected.append(chunk)
+
+    assert len(collected) == 2
+    assert call_count == 2


### PR DESCRIPTION
## Summary

- Extend `backend/llm.py` retry logic to handle **429 Rate Limit** (`RateLimitError`) and **503 Service Unavailable** (`ServiceUnavailableError`) errors, in addition to existing 404 retries
- Both `acomplete` and `acomplete_stream` now share a `_RETRYABLE_ERRORS` tuple with exponential backoff (0.5s base, up to 8s max, 4 attempts)
- Added 6 new tests covering 429/503 retry-then-succeed and retry-exhaustion scenarios for both streaming and non-streaming paths

## Test plan

- [x] All 738 existing tests pass (`python -m pytest backend/tests/ -x -q`)
- [x] New tests verify 429 retry + success for `acomplete`
- [x] New tests verify 503 retry + success for `acomplete`
- [x] New tests verify 429/503 raise after max retries exhausted
- [x] New tests verify 429/503 retry + success for `acomplete_stream`

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)