### PR TITLE
Fix #441: Add locks to OAuth PKCE state dicts

### DIFF
--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -28,6 +29,7 @@ GOOGLE_REDIRECT_URI = settings.GOOGLE_REDIRECT_URI
 
 # PKCE state storage: state -> code_verifier (single-process, in-memory)
 _pending_flows: dict[str, str] = {}
+_pending_flows_lock = threading.Lock()
 
 
 def _client_config() -> dict:
@@ -58,7 +60,8 @@ def get_auth_url() -> str:
         prompt="consent",
     )
     # Store PKCE code_verifier for the callback
-    _pending_flows[state] = flow.code_verifier or ""
+    with _pending_flows_lock:
+        _pending_flows[state] = flow.code_verifier or ""
     return str(auth_url)
 
 
@@ -68,7 +71,11 @@ def exchange_code(code: str, state: str = "", user_id: str = "") -> Credentials:
     flow.redirect_uri = GOOGLE_REDIRECT_URI
 
     # Restore PKCE code_verifier from the auth request
-    code_verifier = _pending_flows.pop(state, None) if state else None
+    if state:
+        with _pending_flows_lock:
+            code_verifier = _pending_flows.pop(state, None)
+    else:
+        code_verifier = None
     if code_verifier:
         flow.code_verifier = code_verifier
 

--- a/backend/oauth_state.py
+++ b/backend/oauth_state.py
@@ -11,12 +11,17 @@ store/retrieve, and each dict is hard-capped at MAX_ENTRIES_PER_DICT.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
 MAX_ENTRIES_PER_DICT = 10_000
+
+# Lock protecting all mutable state dicts below against concurrent access
+# from threadpool-dispatched sync endpoints.
+_state_lock = threading.Lock()
 
 # server_state -> {
 #   client_state, redirect_uri, code_challenge, code_challenge_method,
@@ -81,21 +86,24 @@ def cleanup_and_store(store: dict[str, dict], key: str, value: dict) -> None:
     Raises :class:`StoreFullError` if the store is still at capacity after
     purging expired entries.
     """
-    _cleanup_expired(store)
-    if len(store) >= MAX_ENTRIES_PER_DICT:
-        raise StoreFullError(
-            f"OAuth state store is full ({MAX_ENTRIES_PER_DICT} entries)"
-        )
-    store[key] = value
+    with _state_lock:
+        _cleanup_expired(store)
+        if len(store) >= MAX_ENTRIES_PER_DICT:
+            raise StoreFullError(
+                f"OAuth state store is full ({MAX_ENTRIES_PER_DICT} entries)"
+            )
+        store[key] = value
 
 
 def cleanup_and_get(store: dict[str, dict], key: str) -> dict | None:
     """Purge expired entries, then return the entry for *key* (or ``None``)."""
-    _cleanup_expired(store)
-    return store.get(key)
+    with _state_lock:
+        _cleanup_expired(store)
+        return store.get(key)
 
 
 def cleanup_and_pop(store: dict[str, dict], key: str) -> dict | None:
     """Purge expired entries, then pop and return the entry for *key* (or ``None``)."""
-    _cleanup_expired(store)
-    return store.pop(key, None)
+    with _state_lock:
+        _cleanup_expired(store)
+        return store.pop(key, None)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import secrets
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -44,6 +45,7 @@ COOKIE_NAME = "reli_session"
 
 # PKCE state storage: state -> code_verifier (single-process, in-memory)
 _pending_flows: dict[str, str] = {}
+_pending_flows_lock = threading.Lock()
 
 MCP_AUTH_CODE_TTL_SECONDS = 60 * 10  # 10 minutes
 
@@ -156,7 +158,8 @@ def google_login() -> dict:
         prompt="consent",
     )
     # Store PKCE code_verifier for the callback
-    _pending_flows[state] = flow.code_verifier or ""
+    with _pending_flows_lock:
+        _pending_flows[state] = flow.code_verifier or ""
     return {"auth_url": str(auth_url)}
 
 
@@ -173,7 +176,8 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
 
     # Restore PKCE code_verifier from the auth request.
     # For MCP OAuth flows the verifier is stored in mcp_oauth_sessions instead.
-    code_verifier = _pending_flows.pop(state, None)
+    with _pending_flows_lock:
+        code_verifier = _pending_flows.pop(state, None)
     if not code_verifier:
         mcp_session = cleanup_and_get(mcp_oauth_sessions, state)
         if mcp_session:


### PR DESCRIPTION
## Summary
- Added `threading.Lock` around `_pending_flows` dict mutations in `backend/routers/auth.py` and `backend/google_calendar.py` to prevent race conditions when concurrent OAuth callbacks hit threadpool-dispatched sync endpoints.
- Added `threading.Lock` around `cleanup_and_store`, `cleanup_and_get`, and `cleanup_and_pop` in `backend/oauth_state.py` to protect shared MCP OAuth state dicts from TOCTOU races.

## Test plan
- [x] All 738 existing tests pass (0 failures)
- [x] Lock scope is minimal — only around dict mutations, not around network calls

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)