### PR TITLE
Fix #443: Replace leaked error details with generic messages

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -188,9 +188,9 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
 
     try:
         flow.fetch_token(code=code)
-    except Exception as exc:
-        logger.error("OAuth token exchange failed: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Google login failed: {exc}")
+    except Exception:
+        logger.exception("Google OAuth callback failed")
+        raise HTTPException(status_code=502, detail="Authentication failed. Please try again.")
 
     # Verify and extract user info from the id_token
     credentials = flow.credentials

--- a/backend/routers/calendar.py
+++ b/backend/routers/calendar.py
@@ -1,5 +1,6 @@
 """Google Calendar read-only integration endpoints."""
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,6 +15,8 @@ from ..google_calendar import (
     is_configured,
     is_connected,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
 
@@ -47,13 +50,14 @@ def calendar_callback(
 ) -> RedirectResponse:
     """Handle the OAuth2 callback from Google."""
     if error:
-        # Redirect to frontend with error
-        return RedirectResponse(url=f"/?calendar_error={error}")
+        logger.error("Calendar OAuth returned error: %s", error)
+        return RedirectResponse(url="/?calendar_error=oauth_denied")
 
     try:
         exchange_code(code, state=state, user_id=user_id)
-    except Exception as exc:
-        return RedirectResponse(url=f"/?calendar_error={exc}")
+    except Exception:
+        logger.exception("Calendar OAuth callback failed")
+        return RedirectResponse(url="/?calendar_error=connection_failed")
 
     # Redirect back to the app with success indicator
     return RedirectResponse(url="/?calendar_connected=true")

--- a/backend/routers/gmail.py
+++ b/backend/routers/gmail.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import logging
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -16,6 +17,8 @@ from ..auth import require_user
 from ..config import settings
 import backend.db_engine as _engine_mod
 from ..db_models import GoogleTokenRecord
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/gmail", tags=["gmail"])
 
@@ -285,7 +288,8 @@ def gmail_callback(
 ) -> RedirectResponse:
     """Exchange authorization code for tokens and store them."""
     if error:
-        raise HTTPException(status_code=400, detail=f"OAuth error: {error}")
+        logger.error("Gmail OAuth returned error: %s", error)
+        raise HTTPException(status_code=400, detail="Gmail authorization was denied or failed.")
 
     if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
         raise HTTPException(status_code=501, detail="Gmail integration not configured")
@@ -378,8 +382,9 @@ def get_message(message_id: str, user_id: str = Depends(require_user)) -> GmailM
     service = _get_service(user_id=user_id)
     try:
         msg = service.users().messages().get(userId="me", id=message_id, format="full").execute()
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Message not found: {e}")
+    except Exception:
+        logger.exception("Failed to fetch Gmail message %s", message_id)
+        raise HTTPException(status_code=404, detail="Message not found")
     return _parse_message(msg)
 
 
@@ -389,8 +394,9 @@ def get_thread(thread_id: str, user_id: str = Depends(require_user)) -> GmailThr
     service = _get_service(user_id=user_id)
     try:
         thread = service.users().threads().get(userId="me", id=thread_id, format="full").execute()
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Thread not found: {e}")
+    except Exception:
+        logger.exception("Failed to fetch Gmail thread %s", thread_id)
+        raise HTTPException(status_code=404, detail="Thread not found")
 
     thread_messages = [_parse_message(m) for m in thread.get("messages", [])]
     subject = thread_messages[0].subject if thread_messages else "(no subject)"


### PR DESCRIPTION
## Summary
- Replaced raw exception messages in HTTP response details with generic user-facing messages across `auth.py`, `calendar.py`, and `gmail.py` routers
- Added `logger.exception()` / `logger.error()` calls to preserve full error details in server logs
- Fixed calendar OAuth redirect to use a generic error code instead of embedding exception text in the URL query parameter

## Test plan
- [x] All 738 existing backend tests pass
- [ ] Verify OAuth error flows return generic messages (manual test with invalid OAuth state)
- [ ] Confirm server logs still contain detailed error info for debugging

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)