### PR TITLE
Fix #447: Make CORS origins configurable for production

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -140,6 +140,9 @@ class Settings(BaseSettings):
                 raise ValueError(f"STORAGE_BACKEND=supabase requires: {', '.join(missing)}")
         return self
 
+    # --- CORS ---
+    CORS_ORIGINS: str = ""  # Comma-separated extra origins (e.g. https://reli.interstellarai.net)
+
     # --- Sentry ---
     SENTRY_DSN: str = ""
     SENTRY_ENVIRONMENT: str = "production"

--- a/backend/main.py
+++ b/backend/main.py
@@ -233,9 +233,13 @@ app = FastAPI(
     openapi_tags=_TAG_METADATA,
 )
 
+_default_origins = ["http://localhost:5173", "http://localhost:3000"]
+_extra_origins = [o.strip() for o in _app_settings.CORS_ORIGINS.split(",") if o.strip()] if _app_settings.CORS_ORIGINS else []
+_all_origins = _default_origins + _extra_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=_all_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Add `CORS_ORIGINS` env var to `Settings` in `config.py` (comma-separated extra origins)
- Build combined origins list in `main.py`: localhost defaults + any extra origins from env
- Production deploys set `CORS_ORIGINS=https://reli.interstellarai.net` without code changes

## Test plan
- [x] All 756 existing backend tests pass
- [ ] Verify local dev works without setting `CORS_ORIGINS` (localhost origins still included)
- [ ] Verify production works with `CORS_ORIGINS=https://reli.interstellarai.net`

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)