### PR TITLE
Fix Alembic startup crash and connection pool exhaustion

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -50,6 +50,7 @@ def run_migrations_online() -> None:
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        connect_args={"connect_timeout": 10},
     )
 
     with connectable.connect() as connection:

--- a/backend/db_engine.py
+++ b/backend/db_engine.py
@@ -24,7 +24,12 @@ _url = settings.database_url
 # SQLite needs check_same_thread=False for FastAPI's threaded request handling.
 _connect_args: dict = {"check_same_thread": False} if _url.startswith("sqlite") else {}
 
-engine = create_engine(_url, connect_args=_connect_args, echo=False)
+_pool_args: dict = {}
+if not _url.startswith("sqlite"):
+    # Limit pool size to stay within Supabase free-tier connection limits.
+    _pool_args = {"pool_size": 3, "max_overflow": 2, "pool_pre_ping": True}
+
+engine = create_engine(_url, connect_args=_connect_args, echo=False, **_pool_args)
 
 # SQLite-specific PRAGMAs (WAL mode, foreign keys).
 if _url.startswith("sqlite"):

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,9 +75,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     _alembic_ini = _pathlib.Path(__file__).resolve().parent.parent / "alembic.ini"
     if _alembic_ini.exists():
-        _alembic_cfg = AlembicConfig(str(_alembic_ini))
-        alembic_command.upgrade(_alembic_cfg, "head")
-        logger.info("Alembic migrations applied successfully.")
+        try:
+            _alembic_cfg = AlembicConfig(str(_alembic_ini))
+            alembic_command.upgrade(_alembic_cfg, "head")
+            logger.info("Alembic migrations applied successfully.")
+        except Exception:
+            logger.exception("Alembic migration failed — starting with existing schema.")
     else:
         logger.warning("alembic.ini not found at %s — skipping migrations.", _alembic_ini)
 


### PR DESCRIPTION
## Summary
- Limit Postgres connection pool to 3+2 with `pool_pre_ping` (stays within Supabase free-tier limits)
- Wrap Alembic `upgrade head` in try/except so app still starts if migration can't connect
- Add `connect_timeout=10` to Alembic's connection to prevent indefinite hangs

Fixes #430, #431, #462, #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)