### PR TITLE
Feat #386: Implement Cognitive Atelier design system tokens

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,8 +3,47 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* ─── Cognitive Atelier Design System Tokens ──────────────────────────
+   Issue #386 — Foundation tokens for the obsidian dark-mode-first UI.
+   Component restyling happens in #387-#393; this file only defines
+   colors, typography, glassmorphism, and gradient utilities.
+   ──────────────────────────────────────────────────────────────────── */
+
+@theme {
+  /* ── Surface / Background palette ─────────────────────────────── */
+  --color-canvas: #0b1326;
+  --color-surface: #0b1326;
+  --color-surface-container-low: #131b2e;
+  --color-surface-container-high: #222a3d;
+
+  /* ── Semantic accent colors ───────────────────────────────────── */
+  --color-primary: #4F46E5;
+  --color-primary-container: #3730A3;
+  --color-projects: #10B981;
+  --color-events: #F59E0B;
+  --color-people: #14B8A6;
+  --color-ideas: #F43F5E;
+
+  /* ── On-surface text (no pure white) ──────────────────────────── */
+  --color-on-surface: #E2E8F0;
+  --color-on-surface-variant: #94A3B8;
+
+  /* ── Typography scale ─────────────────────────────────────────── */
+  --font-size-display: 3.5rem;
+  --font-size-headline: 1.75rem;
+  --font-size-title: 1.125rem;
+  --font-size-body: 0.875rem;
+  --font-size-label: 0.75rem;
+}
+
 :root {
   color-scheme: light dark;
+
+  /* ── Typography tokens as CSS custom properties ─────────────── */
+  --tracking-display: -0.02em;
+  --tracking-label: 0.05em;
+  --leading-body: 1.6;
+  --font-weight-title: 600;
 }
 
 body {
@@ -12,6 +51,59 @@ body {
   font-family: system-ui, 'Segoe UI', Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Dark mode base styles ───────────────────────────────────────── */
+.dark body,
+:where(.dark) body {
+  background-color: var(--color-canvas);
+  color: var(--color-on-surface);
+}
+
+/* ─── Typography utility classes ─────────────────────────────────── */
+
+.text-display {
+  font-size: var(--font-size-display);
+  letter-spacing: var(--tracking-display);
+  line-height: 1.1;
+}
+
+.text-headline {
+  font-size: var(--font-size-headline);
+  line-height: 1.3;
+}
+
+.text-title {
+  font-size: var(--font-size-title);
+  font-weight: var(--font-weight-title);
+  line-height: 1.4;
+}
+
+.text-body {
+  font-size: var(--font-size-body);
+  line-height: var(--leading-body);
+}
+
+.text-label {
+  font-size: var(--font-size-label);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+}
+
+/* ─── Glassmorphism utility ──────────────────────────────────────── */
+
+.glass {
+  background: color-mix(in srgb, var(--color-surface-container-high) 60%, transparent);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* ─── Gradient CTA utility ───────────────────────────────────────── */
+
+.gradient-cta {
+  background: linear-gradient(135deg, var(--color-primary-container), var(--color-primary));
+  color: #fff;
 }
 
 #root {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
         short_name: 'Reli',
         description: 'Reli — your personal relationship manager',
         theme_color: '#4F46E5',
-        background_color: '#ffffff',
+        background_color: '#0b1326',
         display: 'standalone',
         icons: [
           {


### PR DESCRIPTION
## Summary

- Adds all Cognitive Atelier design tokens as Tailwind v4 `@theme` colors: canvas, surface layers, primary/accent palette (projects, events, people, ideas), and on-surface text colors (no pure white)
- Adds typography utility classes (display, headline, title, body, label) with correct sizing, tracking, and line-height
- Adds `.glass` glassmorphism utility (60% opacity surface + 20px backdrop-blur + subtle white border) and `.gradient-cta` gradient button utility
- Updates dark mode body base styles and PWA `background_color` to canvas `#0b1326`

No components are restyled — this is the foundation for #387-#393.

Closes #386

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `pytest backend/tests/` — 756 passed
- [ ] Visual spot-check: dark mode body background should now be `#0b1326`
- [ ] Verify Tailwind classes like `bg-canvas`, `text-on-surface`, `bg-primary` etc. are available in components

🤖 Generated with [Claude Code](https://claude.com/claude-code)