### PR TITLE
Fix #470: Add Alembic migration for weekly_briefings table

### DIFF
--- a/backend/alembic/versions/e5348d5dff40_add_weekly_briefings_table.py
+++ b/backend/alembic/versions/e5348d5dff40_add_weekly_briefings_table.py
@@ -1,0 +1,37 @@
+"""add weekly_briefings table
+
+Revision ID: e5348d5dff40
+Revises: 450defba86b7
+Create Date: 2026-03-30 22:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5348d5dff40'
+down_revision: Union[str, Sequence[str], None] = '450defba86b7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create weekly_briefings table."""
+    op.create_table('weekly_briefings',
+        sa.Column('id', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('user_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('week_start', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('content', sa.JSON(), nullable=False),
+        sa.Column('generated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    """Drop weekly_briefings table."""
+    op.drop_table('weekly_briefings')


### PR DESCRIPTION
## Summary
- Adds Alembic migration `e5348d5dff40` to create the `weekly_briefings` table
- The `WeeklyBriefingRecord` model was added in PR #468 but no migration was generated, causing `UndefinedTable` errors in production (Sentry issue #470)
- Migration creates: id (PK), user_id (FK → users.id), week_start, content (JSON), generated_at

## Test plan
- [ ] Verify migration applies cleanly: `alembic upgrade head`
- [ ] Verify downgrade works: `alembic downgrade -1`
- [ ] Confirm weekly_briefings table exists in Supabase after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)