### PR TITLE
Fix token_key PermissionError in read-only containers

### DIFF
--- a/backend/tests/test_token_encryption.py
+++ b/backend/tests/test_token_encryption.py
@@ -21,7 +21,7 @@ def _fresh_key(tmp_path, monkeypatch):
     """Use a fresh encryption key for each test."""
     reset_for_testing()
     key_file = tmp_path / ".token_key"
-    monkeypatch.setattr("backend.token_encryption._KEY_FILE", key_file)
+    monkeypatch.setattr("backend.token_encryption._PRIMARY_KEY_FILE", key_file)
     monkeypatch.delenv("TOKEN_ENCRYPTION_KEY", raising=False)
     yield
     reset_for_testing()
@@ -79,7 +79,7 @@ class TestDecryptOrPlaintext:
 class TestKeyPersistence:
     def test_auto_generates_key_file(self, tmp_path, monkeypatch):
         key_file = tmp_path / "subdir" / ".token_key"
-        monkeypatch.setattr("backend.token_encryption._KEY_FILE", key_file)
+        monkeypatch.setattr("backend.token_encryption._PRIMARY_KEY_FILE", key_file)
         reset_for_testing()
 
         encrypt("test")
@@ -90,7 +90,7 @@ class TestKeyPersistence:
 
     def test_reuses_existing_key(self, tmp_path, monkeypatch):
         key_file = tmp_path / ".token_key"
-        monkeypatch.setattr("backend.token_encryption._KEY_FILE", key_file)
+        monkeypatch.setattr("backend.token_encryption._PRIMARY_KEY_FILE", key_file)
         reset_for_testing()
 
         encrypted = encrypt("test-value")

--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -23,9 +23,25 @@ from .config import settings
 
 logger = logging.getLogger(__name__)
 
-_KEY_FILE = Path(settings.DATA_DIR) / ".token_key"
+_PRIMARY_KEY_FILE = Path(settings.DATA_DIR) / ".token_key"
+_FALLBACK_KEY_DIR = Path("/tmp/.reli")
+_FALLBACK_KEY_FILE = _FALLBACK_KEY_DIR / ".token_key"
 
 _fernet: Fernet | None = None
+
+
+def _key_file_path() -> Path:
+    """Return a writable key-file path, preferring DATA_DIR, falling back to /tmp."""
+    if _PRIMARY_KEY_FILE.exists():
+        return _PRIMARY_KEY_FILE
+    # Check if primary directory is writable
+    try:
+        _PRIMARY_KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        if os.access(_PRIMARY_KEY_FILE.parent, os.W_OK):
+            return _PRIMARY_KEY_FILE
+    except OSError:
+        pass
+    return _FALLBACK_KEY_FILE
 
 
 def _get_fernet() -> Fernet:
@@ -43,15 +59,25 @@ def _get_fernet() -> Fernet:
         return _fernet
 
     # Auto-generate and persist a key file
-    if _KEY_FILE.exists():
-        key = _KEY_FILE.read_text().strip()
+    key_file = _key_file_path()
+    if key_file.exists():
+        key = key_file.read_text().strip()
     else:
         key = Fernet.generate_key().decode()
-        _KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
-        _KEY_FILE.write_text(key)
-        # Restrict permissions to owner-only
-        _KEY_FILE.chmod(0o600)
-        logger.info("Generated new token encryption key at %s", _KEY_FILE)
+        try:
+            key_file.parent.mkdir(parents=True, exist_ok=True)
+            key_file.write_text(key)
+            key_file.chmod(0o600)
+            logger.info("Generated new token encryption key at %s", key_file)
+        except OSError:
+            # Last resort: use /tmp fallback if even the chosen path fails
+            _FALLBACK_KEY_DIR.mkdir(parents=True, exist_ok=True)
+            _FALLBACK_KEY_FILE.write_text(key)
+            _FALLBACK_KEY_FILE.chmod(0o600)
+            logger.warning(
+                "Could not write key to %s, using fallback %s",
+                key_file, _FALLBACK_KEY_FILE,
+            )
 
     _fernet = Fernet(key.encode())
     return _fernet


### PR DESCRIPTION
## Summary
- When `TOKEN_ENCRYPTION_KEY` env var is not set, the auto-generated key file now falls back to `/tmp/.reli/.token_key` if the primary `DATA_DIR` is read-only (e.g., in Docker containers where backend/ is part of the image)
- Wraps the key-file write in try/except so a PermissionError no longer crashes the app at startup
- Fixes 14x PermissionError events in Sentry

## Notes on Bug 2 (user_filter_clause ImportError)
The `user_filter_clause` function exists in `db_engine.py` on master. The 12x Sentry errors reference `/mnt/ext-fast/gc/rigs/reli/backend/db_engine.py` which is a local sweep scheduler path, not Railway production. This is a stale local deployment issue, not a code bug.

## Test plan
- [x] All 10 existing `test_token_encryption.py` tests pass
- [x] Updated test fixtures to reference renamed `_PRIMARY_KEY_FILE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)