### PR TITLE
Fix Postgres type compatibility: boolean=integer and json comparison errors

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -342,7 +342,7 @@ def apply_storage_changes(
         # Deduplicate: if an active Thing with the same title already exists (case-insensitive),
         # convert the create into an update on the existing Thing instead of silently skipping.
         existing = conn.execute(
-            "SELECT * FROM things WHERE LOWER(title) = LOWER(?) AND active = 1 LIMIT 1", (title,)
+            "SELECT * FROM things WHERE LOWER(title) = LOWER(?) AND active = true LIMIT 1", (title,)
         ).fetchone()
 
         # Possessive dedup: if no exact title match, check whether the user already
@@ -375,7 +375,7 @@ def apply_storage_changes(
                         "SELECT t.* FROM things t"
                         " JOIN thing_relationships r ON r.to_thing_id = t.id"
                         " WHERE r.from_thing_id = ? AND r.relationship_type = ?"
-                        " AND t.active = 1 LIMIT 1",
+                        " AND t.active = true LIMIT 1",
                         (from_id, rel_type),
                     ).fetchone()
                     if match:
@@ -786,7 +786,7 @@ def load_personality_preferences(user_id: str) -> list[dict[str, Any]]:
             bind_params["uid"] = user_id
         result = session.execute(
             sa_text(
-                f"SELECT data FROM things WHERE type_hint = 'preference' AND active = 1{uf_clause}"
+                f"SELECT data FROM things WHERE type_hint = 'preference' AND active = true{uf_clause}"
             ),
             bind_params,
         )

--- a/backend/conflict_detector.py
+++ b/backend/conflict_detector.py
@@ -123,8 +123,8 @@ def detect_blocking_chains(
            JOIN things bf ON bf.id = r.from_thing_id
            JOIN things bt ON bt.id = r.to_thing_id
            WHERE r.relationship_type IN ('blocks', 'depends-on')
-             AND bf.active = 1
-             AND bt.active = 1"""
+             AND bf.active = true
+             AND bt.active = true"""
         )
     ).fetchall()
 
@@ -213,8 +213,8 @@ def detect_schedule_overlaps(
     rows = session.execute(
         text(
             """SELECT id, title, data, checkin_date FROM things
-           WHERE active = 1
-             AND (data IS NOT NULL AND data != '{}' AND data != 'null')"""
+           WHERE active = true
+             AND (data IS NOT NULL AND CAST(data AS TEXT) != '{}' AND CAST(data AS TEXT) != 'null')"""
         )
     ).fetchall()
 
@@ -308,8 +308,8 @@ def detect_deadline_conflicts(
            JOIN things df ON df.id = r.from_thing_id
            JOIN things dt ON dt.id = r.to_thing_id
            WHERE r.relationship_type IN ('depends-on', 'blocks')
-             AND df.active = 1
-             AND dt.active = 1"""
+             AND df.active = true
+             AND dt.active = true"""
         )
     ).fetchall()
 

--- a/backend/routers/nudges.py
+++ b/backend/routers/nudges.py
@@ -110,7 +110,7 @@ def get_nudges(user_id: str = Depends(require_user)) -> list[Nudge]:
 
         # Fetch things with upcoming dates (window: 7 days)
         rows = conn.execute(
-            f"SELECT * FROM things WHERE data IS NOT NULL AND data != '{{}}' AND data != 'null' AND active = 1{uf_sql}",
+            f"SELECT * FROM things WHERE data IS NOT NULL AND CAST(data AS TEXT) != '{{}}' AND CAST(data AS TEXT) != 'null' AND active = true{uf_sql}",
             uf_params,
         ).fetchall()
 

--- a/backend/routers/proactive.py
+++ b/backend/routers/proactive.py
@@ -4,6 +4,7 @@ import re
 from datetime import date
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import String, cast
 from sqlmodel import Session, select
 
 from ..auth import require_user
@@ -121,7 +122,7 @@ def get_proactive_surfaces(
         # Fetch all Things that have a non-null data field (entities live here).
         stmt = select(ThingRecord).where(
             ThingRecord.data.is_not(None),  # type: ignore[union-attr]
-            ThingRecord.data != {},
+            cast(ThingRecord.data, String) != '{}',
             user_filter_clause(ThingRecord.user_id, user_id),
         )
         rows = session.exec(stmt).all()

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -41,7 +41,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import func, text
+from sqlalchemy import String, cast, func, text
 from sqlmodel import Session, select
 
 import backend.db_engine as _engine_mod
@@ -195,7 +195,7 @@ def find_approaching_dates(
         .where(
             ThingRecord.active == True,  # noqa: E712
             ThingRecord.data.is_not(None),  # type: ignore[union-attr]
-            ThingRecord.data != {},
+            cast(ThingRecord.data, String) != '{}',
             user_filter_clause(ThingRecord.user_id, user_id),
         )
     )
@@ -672,7 +672,7 @@ def find_information_gaps(
              AND p.type_hint = 'project'
              AND p.checkin_date IS NULL
              AND {_NO_OQ.replace('open_questions', 'p.open_questions')}{uf_sql_p}
-           GROUP BY p.id, p.title, p.data
+           GROUP BY p.id, p.title, CAST(p.data AS TEXT)
            HAVING COUNT(c.id) > 0"""
         ),
         uf_params_p,


### PR DESCRIPTION
## Summary
- Replace `active = 1` with `active = true` in all raw SQL across 5 files (works in both SQLite and Postgres)
- Replace `data != '{}'` / `data != 'null'` with `CAST(data AS TEXT) != '{}'` in raw SQL to avoid Postgres `json` type comparison errors
- Replace `ThingRecord.data != {}` with `cast(ThingRecord.data, String) != '{}'` in SQLModel expressions for Postgres json column compatibility
- Replace `GROUP BY p.data` with `GROUP BY CAST(p.data AS TEXT)` to avoid Postgres json type in GROUP BY

Fixes ~1600 500-errors from `boolean = integer` and `json <> json` / `json != {}` type mismatches in production.

## Test plan
- [x] All 756 existing tests pass (SQLite backend)
- [ ] Verify 500 errors stop in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)