### PR TITLE
Fix last json comparison in conflict_detector

### DIFF
--- a/backend/conflict_detector.py
+++ b/backend/conflict_detector.py
@@ -14,6 +14,8 @@ import re
 from dataclasses import dataclass
 from datetime import date
 
+from sqlalchemy import String, cast
+
 from sqlalchemy.orm import aliased
 from sqlmodel import Session, or_, select
 
@@ -236,7 +238,7 @@ def detect_schedule_overlaps(
     stmt = select(ThingRecord).where(
         ThingRecord.active == True,
         ThingRecord.data.is_not(None),  # type: ignore[union-attr]
-        ThingRecord.data != {},  # type: ignore[arg-type]
+        cast(ThingRecord.data, String) != '{}',
     )
     rows = session.exec(stmt).all()
 


### PR DESCRIPTION
## Summary
- Fixes `ProgrammingError: operator does not exist: json <> json` on `/api/conflicts`
- The ORM expression `ThingRecord.data != {}` was missed during the SQLModel conversion (PR #478) — uses `cast(data, String) != '{}'` like the rest of the codebase

## Test plan
- [ ] Verify `/api/conflicts` no longer returns 500
- [ ] Check Sentry for zero new `json <> json` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)