### PR TITLE
Fix eval CI: add missing api_base for Requesty routing

### DIFF
--- a/eval/_eval_model.py
+++ b/eval/_eval_model.py
@@ -10,6 +10,7 @@ from google.adk.models.lite_llm import LiteLlm
 
 from backend.agents import (
     REQUESTY_API_KEY,
+    REQUESTY_BASE_URL,
     REQUESTY_MODEL,
     REQUESTY_REASONING_MODEL,
     REQUESTY_RESPONSE_MODEL,
@@ -42,9 +43,12 @@ def make_eval_model(stage: str = "reasoning") -> LiteLlm:
             api_key=google_api_key,
         )
     else:
-        # Fall back to Requesty
+        # Fall back to Requesty — openai/ prefix tells LiteLLM to use the
+        # OpenAI-compatible provider, and api_base routes to Requesty which
+        # handles the google/ provider routing in the model name.
         effective = model_name if model_name.startswith("openai/") else f"openai/{model_name}"
         return LiteLlm(
             model=effective,
             api_key=REQUESTY_API_KEY,
+            api_base=REQUESTY_BASE_URL,
         )


### PR DESCRIPTION
## Summary
- Fixes #432 — eval CI was failing because `REQUESTY_API_KEY` wasn't routing to OpenAI properly
- **Root cause:** `eval/_eval_model.py` was missing `api_base=REQUESTY_BASE_URL` when creating `LiteLlm` instances for the Requesty fallback path. Without `api_base`, LiteLLM sees the `openai/` prefix and sends requests to OpenAI's API directly (not Requesty), where the Requesty API key is invalid and the `google/` model names don't exist
- Added the missing `api_base` parameter and imported `REQUESTY_BASE_URL` from `backend.agents`

## Test plan
- [ ] Eval CI workflow triggers on this PR (paths include `eval/**`) and passes
- [ ] Verify eval results are posted as PR comment with passing scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)