### PR TITLE
Remove legacy database.py imports from production code

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,7 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 from starlette.responses import Response as StarletteResponse  # noqa: E402
 
 from .auth import COOKIE_NAME, JWT_ALGORITHM, SECRET_KEY, require_user  # noqa: E402
-from .database import clean_orphan_relationships, init_db  # noqa: E402
+from .db_engine import engine as _db_engine  # noqa: E402
 from .mcp_server import create_mcp_asgi_app  # noqa: E402
 from .metrics import MetricsMiddleware, metrics_response  # noqa: E402
 from .rate_limit import RateLimitMiddleware, get_rate_limit_config  # noqa: E402
@@ -88,8 +88,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     from .config import settings as _settings
 
     if not _settings.DATABASE_URL:
-        init_db()
-        clean_orphan_relationships()
+        from sqlmodel import SQLModel as _SQLModel
+        _SQLModel.metadata.create_all(_db_engine)
     await start_scheduler()
 
     # Start MCP session manager (required for streamable HTTP transport).

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -15,8 +15,7 @@ from sqlmodel import Session, select
 from ..auth import require_user
 import backend.db_engine as _engine_mod
 from ..db_engine import user_filter_clause, user_filter_text
-from ..db_models import ChatHistoryRecord, ChatMessageUsageRecord, UsageLogRecord
-from ..database import get_latest_summary
+from ..db_models import ChatHistoryRecord, ChatMessageUsageRecord, ConversationSummaryRecord, UsageLogRecord
 from ..models import (
     CallUsage,
     ChatMessage,
@@ -308,7 +307,23 @@ def _fetch_history(session_id: str, context_window: int, user_id: str = "") -> l
 
     # Try summary-based history if we have a user_id
     if user_id:
-        latest_summary = get_latest_summary(user_id)
+        with Session(_engine_mod.engine) as _sum_sess:
+            _sum_record = _sum_sess.exec(
+                select(ConversationSummaryRecord)
+                .where(ConversationSummaryRecord.user_id == user_id)
+                .order_by(ConversationSummaryRecord.messages_summarized_up_to.desc())  # type: ignore[union-attr]
+            ).first()
+        latest_summary: dict[str, Any] | None = (
+            {
+                "id": _sum_record.id,
+                "summary_text": _sum_record.summary_text,
+                "messages_summarized_up_to": _sum_record.messages_summarized_up_to,
+                "token_count": _sum_record.token_count,
+                "created_at": _sum_record.created_at,
+            }
+            if _sum_record
+            else None
+        )
         if latest_summary:
             with Session(_engine_mod.engine) as session:
                 records = session.exec(

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -16,7 +16,6 @@ from ..db_models import ThingRecord, ThingRelationshipRecord, ThingTypeRecord
 from ..db_models import MergeHistoryRecord as MergeHistoryDBRecord
 
 from ..auth import require_user
-from ..database import clean_orphan_relationships
 from ..models import (
     GraphEdge,
     GraphNode,
@@ -724,10 +723,30 @@ def get_orphan_relationships(
 
 
 @router.post("/relationships/cleanup", response_model=OrphanCleanupResult, summary="Delete orphan relationships")
-def cleanup_orphan_relationships(user_id: str = Depends(require_user)) -> OrphanCleanupResult:
-    """Delete all orphan relationships."""
-    deleted_count, deleted_ids = clean_orphan_relationships()
-    return OrphanCleanupResult(deleted_count=deleted_count, deleted_ids=deleted_ids)
+def cleanup_orphan_relationships(
+    session: Session = Depends(get_session),
+    user_id: str = Depends(require_user),
+) -> OrphanCleanupResult:
+    """Delete all orphan relationships where from/to thing no longer exists."""
+    import logging as _logging
+
+    _logger = _logging.getLogger(__name__)
+    thing_ids_subq = select(ThingRecord.id)
+    orphans = session.exec(
+        select(ThingRelationshipRecord).where(
+            or_(
+                ThingRelationshipRecord.from_thing_id.notin_(thing_ids_subq),  # type: ignore[union-attr]
+                ThingRelationshipRecord.to_thing_id.notin_(thing_ids_subq),  # type: ignore[union-attr]
+            )
+        )
+    ).all()
+    orphan_ids = [r.id for r in orphans]
+    for r in orphans:
+        session.delete(r)
+    if orphan_ids:
+        session.commit()
+        _logger.info("Cleaned %d orphan relationship(s): %s", len(orphan_ids), orphan_ids)
+    return OrphanCleanupResult(deleted_count=len(orphan_ids), deleted_ids=orphan_ids)
 
 
 # -- Relationships --

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,7 +35,12 @@ def tmp_db_path(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def patched_db(tmp_db_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Patch the database module to use a temp SQLite file."""
+    """Patch the database module to use a temp SQLite file.
+
+    Uses legacy ``init_db()`` to create tables and seed data (many test files
+    still import ``db()`` from ``database.py``), then patches the ORM
+    ``db_engine`` module so SQLModel code-paths hit the same temp DB.
+    """
     import backend.database as db_module
     import backend.db_engine as engine_module
     from sqlmodel import Session, create_engine


### PR DESCRIPTION
## Summary
- Migrated `main.py`, `routers/chat.py`, and `routers/things.py` off `database.py` to use SQLModel/ORM equivalents
- `main.py`: replaced `init_db()` with `SQLModel.metadata.create_all(engine)` and removed startup `clean_orphan_relationships()` call
- `chat.py`: replaced `get_latest_summary()` with inline ORM query using `ConversationSummaryRecord`
- `things.py`: replaced `clean_orphan_relationships()` with an ORM-based subquery using `Session` dependency injection
- `database.py` is **not deleted yet** — 17 test files still import `db()` from it; those will be migrated in a follow-up

### Test files still using `database.py`
`test_things.py`, `test_chat_pipeline.py`, `test_morning_briefing.py`, `test_conflict_detector.py`, `test_sweep.py`, `test_merge.py`, `test_summarization.py`, `test_chat_summarization_pipeline.py`, `test_reasoning_agent.py`, `test_staleness.py`, `test_auth.py`, `test_sweep_reflection.py`, `test_possessive_dedup.py`, `test_preference_sweep.py`, `test_sweep_scheduler.py`, `test_mcp_server.py`, `test_personality_preferences.py`, `test_database_supabase.py`, `test_sweep_patterns.py`

## Test plan
- [x] `pytest backend/tests/test_things.py` — 36 passed
- [x] `pytest backend/tests/test_summarization.py` — passed
- [x] `pytest backend/tests/test_sweep.py backend/tests/test_merge.py` — passed
- [x] Combined run of 158 tests — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)