### PR TITLE
Fix chat: keep provider prefix for Requesty routing

### DIFF
--- a/backend/context_agent.py
+++ b/backend/context_agent.py
@@ -92,13 +92,12 @@ def _make_litellm_model(
             "like google/gemini-2.5-flash. See GH #176.",
             effective_model,
         )
-    # LiteLlm expects the openai/ prefix for OpenAI-compatible providers.
-    # Models from config.yaml may already have a provider prefix like
-    # "google/model-name" — strip it before adding "openai/" so we don't
-    # end up with "openai/google/model-name".
+    # LiteLlm needs the "openai/" prefix to use the OpenAI-compatible client.
+    # Requesty expects "provider/model" (e.g. "google/gemini-3-flash-preview")
+    # as the model name, so the full LiteLLM model string becomes
+    # "openai/google/gemini-3-flash-preview" — openai/ for the client,
+    # google/gemini-3-flash-preview for Requesty's router.
     if not effective_model.startswith("openai/"):
-        if "/" in effective_model:
-            effective_model = effective_model.split("/", 1)[1]
         effective_model = f"openai/{effective_model}"
     return LiteLlm(
         model=effective_model,

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -49,10 +49,6 @@ def _litellm_model(model: str) -> str:
     """
     if model.startswith("openai/"):
         return model
-    # Strip any existing provider prefix (e.g. "google/model-name") before
-    # adding "openai/" so we don't produce "openai/google/model-name".
-    if "/" in model:
-        model = model.split("/", 1)[1]
     return f"openai/{model}"
 
 

--- a/backend/tests/test_context_agent.py
+++ b/backend/tests/test_context_agent.py
@@ -291,11 +291,11 @@ async def test_context_refinement_invalid_json_returns_done():
 
 
 def test_make_litellm_model_adds_prefix():
-    """_make_litellm_model strips provider prefix and adds openai/."""
+    """_make_litellm_model prepends openai/ for LiteLLM's OpenAI client."""
     from backend.context_agent import _make_litellm_model
 
     m = _make_litellm_model(model="google/gemini-2.5-flash-lite", api_key="k")
-    assert m.model == "openai/gemini-2.5-flash-lite"
+    assert m.model == "openai/google/gemini-2.5-flash-lite"
 
 
 def test_make_litellm_model_no_double_prefix():

--- a/backend/tests/test_litellm_connector.py
+++ b/backend/tests/test_litellm_connector.py
@@ -75,7 +75,7 @@ async def test_acomplete_routes_through_requesty():
 
     mock_call.assert_called_once()
     call_kwargs = mock_call.call_args
-    assert call_kwargs.kwargs["model"] == "openai/gemini-2.5-flash-lite"
+    assert call_kwargs.kwargs["model"] == "openai/google/gemini-2.5-flash-lite"
     assert call_kwargs.kwargs["api_base"] == REQUESTY_BASE_URL
     assert call_kwargs.kwargs["api_key"] == "test-key"
     assert result.choices[0].message.content == "test reply"
@@ -99,9 +99,7 @@ async def test_acomplete_all_model_configs(model: str):
             model,
         )
 
-    # Provider prefix is stripped: "google/model" -> "openai/model"
-    base_model = model.split("/", 1)[-1] if "/" in model else model
-    assert mock_call.call_args.kwargs["model"] == f"openai/{base_model}"
+    assert mock_call.call_args.kwargs["model"] == f"openai/{model}"
     assert result.choices[0].message.content == "ok"
 
 
@@ -173,7 +171,7 @@ async def test_per_user_model_override():
         )
 
     call_kwargs = mock_call.call_args.kwargs
-    assert call_kwargs["model"] == "openai/user-model"
+    assert call_kwargs["model"] == "openai/custom/user-model"
     assert call_kwargs["api_key"] == "user-personal-key"
     assert result.choices[0].message.content == "custom model reply"
 


### PR DESCRIPTION
## Summary
- Reverts the provider prefix stripping from #486 which broke Requesty routing
- Requesty expects `provider/model` (e.g. `google/gemini-3-flash-preview`) to route to the correct backend
- The `openai/` prefix is for LiteLLM's client selection only
- Correct format: `openai/google/gemini-3-flash-preview` where `openai/` = LiteLLM client, `google/gemini-3-flash-preview` = Requesty routes to Google

The previous fix incorrectly stripped `google/` producing `openai/gemini-3-flash-preview`, which Requesty rejected because `gemini-3-flash-preview` doesn't exist on OpenAI.

## Test plan
- [ ] Send a chat message — should get a response without "Invalid model" error
- [ ] Sentry: no new `BadRequestError` events on `/api/chat/stream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)