### PR TITLE
Fix #485: use DELETE FROM instead of TRUNCATE for SQLite compat

### DIFF
--- a/backend/vector_store.py
+++ b/backend/vector_store.py
@@ -200,7 +200,7 @@ def reindex_all() -> int:
     try:
         with Session(_engine_mod.engine) as session:
             # Clear existing embeddings
-            session.execute(sa_text("TRUNCATE thing_embeddings"))
+            session.execute(sa_text("DELETE FROM thing_embeddings"))
             session.commit()
 
         # Fetch all things from the database


### PR DESCRIPTION
## Summary
- Replace `TRUNCATE thing_embeddings` with `DELETE FROM thing_embeddings` in `vector_store.py:reindex_all()`
- `TRUNCATE` is PostgreSQL-only and causes `sqlite3.OperationalError` when running with SQLite backend
- `DELETE FROM` works on both SQLite and PostgreSQL

Fixes #485

## Test plan
- [x] All 756 backend tests pass
- [x] No other PostgreSQL-only raw SQL found in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)