### PR TITLE
Fix: align vector dimensions to 1536 for text-embedding-3-small

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ REQUESTY_API_KEY=your_requesty_api_key_here
 # REQUESTY_REASONING_MODEL=
 # REQUESTY_RESPONSE_MODEL=
 
-# Embedding model for ChromaDB vector search
+# Embedding model for pgvector semantic search
 EMBEDDING_MODEL=text-embedding-3-small
 
 # Ollama — optional local LLM for context agent (reduces API costs)

--- a/backend/config.py
+++ b/backend/config.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
     REQUESTY_RESPONSE_MODEL: str = ""
 
     # --- Embedding ---
-    EMBEDDING_MODEL: str = "text-embedding-3-large"
+    EMBEDDING_MODEL: str = "text-embedding-3-small"
 
     # --- Ollama (optional local LLM) ---
     OLLAMA_BASE_URL: str = "http://localhost:11434"

--- a/supabase/migrations/20260321000000_initial_schema.sql
+++ b/supabase/migrations/20260321000000_initial_schema.sql
@@ -48,7 +48,7 @@ create table if not exists things (
     last_referenced timestamptz,
     open_questions jsonb,
     user_id text not null references users(id),
-    embedding vector(3072)
+    embedding vector(1536)
 );
 
 create index if not exists idx_things_checkin on things(checkin_date);


### PR DESCRIPTION
## Summary
- **config.py**: Change `EMBEDDING_MODEL` default from `text-embedding-3-large` (3072 dims) to `text-embedding-3-small` (1536 dims) to match production `.env` and `.env.example`
- **Supabase migration**: Fix `things.embedding` column from `vector(3072)` to `vector(1536)`
- **.env.example**: Update comment from "ChromaDB" to "pgvector" (the vector backend was migrated in #480)

The Alembic migration `b2c3d4e5f6a7` already corrected `thing_embeddings` to `Vector(1536)`, and `db_models.py` already had `Vector(1536)`. The remaining mismatches were in the config default and the Supabase initial schema.

Fixes #484

## Test plan
- [x] All 651 backend tests pass (1 pre-existing failure from disk space, unrelated)
- [x] Config tests pass
- [ ] Deploy and verify `/reindex` produces embeddings without DataError

🤖 Generated with [Claude Code](https://claude.com/claude-code)