### PR TITLE
fix: ensure chroma_db dir writable for non-root container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,19 @@ COPY prompts/ ./prompts/
 # Copy frontend build from stage 1
 COPY --from=frontend-build /app/frontend/dist/ ./frontend/dist/
 
-# Create data directory with correct ownership
-RUN mkdir -p /app/data && chown reli:reli /app/data
+# Create data & chroma_db directories with correct ownership
+# chroma_db: defensive — chromadb was removed in the pgvector migration but
+# cached Docker layers or transitive deps could still try to initialise it.
+RUN mkdir -p /app/data /app/backend/chroma_db && \
+    chown reli:reli /app/data /app/backend/chroma_db
 
 # Entrypoint fixes bind-mount permissions then drops to non-root
 COPY --chmod=755 <<'ENTRY' /app/entrypoint.sh
 #!/bin/sh
 # Fix ownership of bind-mounted data dir (runs as root initially)
 chown -R reli:reli /app/data 2>/dev/null || true
+# Ensure chroma_db dir is writable (defensive — chromadb removed in pgvector migration)
+mkdir -p /app/backend/chroma_db && chown reli:reli /app/backend/chroma_db 2>/dev/null || true
 exec gosu reli "$@"
 ENTRY
 

--- a/backend/connection_sweep.py
+++ b/backend/connection_sweep.py
@@ -30,7 +30,7 @@ from .db_models import (
 logger = logging.getLogger(__name__)
 
 # Minimum similarity score (cosine distance) to consider a pair
-# ChromaDB returns distances where lower = more similar (cosine)
+# pgvector returns distances where lower = more similar (cosine)
 # We filter by distance < threshold
 MAX_DISTANCE = 0.35
 


### PR DESCRIPTION
## Summary
- Creates `/app/backend/chroma_db` with `reli:reli` ownership in the Dockerfile build stage
- Adds `mkdir -p` + `chown` in the entrypoint script as a runtime safety net for existing deployments
- Fixes a stale "ChromaDB" comment in `connection_sweep.py` (should reference pgvector)

The root cause: chromadb was removed during the pgvector migration but cached Docker layers could still contain it. When chromadb tried to initialize its `PersistentClient`, it attempted to create `/app/backend/chroma_db` which failed because the directory's parent is owned by root and the container runs as `reli` (UID 1000).

Closes #427

## Test plan
- [x] All 756 backend tests pass
- [ ] CI passes
- [ ] Rebuild Docker image and verify no permission errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)