### PR TITLE
fix: allow CORS on /mcp/ for Claude.ai MCP integration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -247,10 +247,10 @@ _default_origins = ["http://localhost:5173", "http://localhost:3000"]
 _extra_origins = [o.strip() for o in _app_settings.CORS_ORIGINS.split(",") if o.strip()] if _app_settings.CORS_ORIGINS else []
 _all_origins = _default_origins + _extra_origins
 
-# MCP OAuth endpoints must accept cross-origin requests from any MCP client.
+# MCP endpoints must accept cross-origin requests from any MCP client.
 # Use a separate permissive CORS middleware for those paths, and the
 # restrictive one for everything else.
-_MCP_CORS_PREFIXES = ("/oauth/", "/.well-known/")
+_MCP_CORS_PREFIXES = ("/oauth/", "/.well-known/", "/mcp")
 
 
 class _MCPCorsMiddleware(BaseHTTPMiddleware):

--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -57,7 +57,7 @@ def _base_url() -> str:
 def protected_resource_metadata() -> JSONResponse:
     base = _base_url()
     return JSONResponse({
-        "resource": f"{base}/mcp",
+        "resource": f"{base}/mcp/",
         "authorization_servers": [base],
         "scopes_supported": ["mcp"],
     })


### PR DESCRIPTION
## Summary
- Add `/mcp` to the permissive CORS prefixes so Claude.ai's browser-side MCP client can reach the endpoint
- Fix OAuth protected resource metadata to advertise `/mcp/` (with trailing slash) to avoid unnecessary 307 redirect

**Root cause:** Claude.ai's MCP client makes browser-side requests to the MCP endpoint. CORS preflight on `/mcp/` was returning 400 "Disallowed CORS origin" because the permissive CORS middleware only covered `/oauth/` and `/.well-known/` paths.

## Test plan
- [x] All 89 MCP tests pass
- [ ] Verify CORS preflight returns 204 with `Access-Control-Allow-Origin` for claude.ai
- [ ] Try adding MCP server in Claude.ai after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)