### PR TITLE
security: fix 7 critical/high vulnerabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ OLLAMA_BASE_URL=http://localhost:11434
 # GOOGLE_CLIENT_SECRET=
 # SECRET_KEY=  # JWT signing key
 
+# Set to "true" to run without authentication (development only)
+# AUTH_DISABLED=true
+
 # Google Calendar OAuth redirect
 # GOOGLE_REDIRECT_URI=http://localhost:8000/api/calendar/callback
 # GOOGLE_AUTH_REDIRECT_URI=http://localhost:8000/api/auth/google/callback

--- a/backend/config.py
+++ b/backend/config.py
@@ -122,9 +122,16 @@ class Settings(BaseSettings):
                 raise ValueError(
                     f"Missing required production env vars: {', '.join(missing)}"
                 )
-        if not self.SECRET_KEY:
+        if not self.SECRET_KEY and not self.RELI_API_TOKEN:
+            auth_disabled = os.getenv("AUTH_DISABLED", "").lower() in ("true", "1", "yes")
+            if not auth_disabled:
+                raise ValueError(
+                    "SECRET_KEY or RELI_API_TOKEN must be set. "
+                    "To intentionally run without auth, set AUTH_DISABLED=true"
+                )
             warnings.warn(
-                "SECRET_KEY is empty — authentication is DISABLED", stacklevel=2
+                "SECRET_KEY is empty — authentication is DISABLED (AUTH_DISABLED=true)",
+                stacklevel=2,
             )
         return self
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -701,8 +701,15 @@ class _TokenAuthMiddleware:
             provided = auth_header[7:]
 
             # 1. Static token match (legacy / backward compat)
-            if static_token and provided == static_token:
+            import secrets as _secrets
+
+            if static_token and _secrets.compare_digest(provided, static_token):
                 authorized = True
+                from .auth import _resolve_api_token_user
+
+                resolved_uid = _resolve_api_token_user()
+                if resolved_uid:
+                    _current_user_id.set(resolved_uid)
 
             # 2. JWT validation (OAuth flow)
             if not authorized and secret_key:

--- a/backend/routers/gmail.py
+++ b/backend/routers/gmail.py
@@ -17,6 +17,7 @@ from ..auth import require_user
 from ..config import settings
 import backend.db_engine as _engine_mod
 from ..db_models import GoogleTokenRecord
+from ..token_encryption import decrypt_or_plaintext, encrypt
 
 logger = logging.getLogger(__name__)
 
@@ -91,11 +92,11 @@ def _save_token(creds: Any, user_id: str = "") -> None:
             ).first()
 
         if existing:
-            existing.access_token = creds.token
-            existing.refresh_token = creds.refresh_token or existing.refresh_token
+            existing.access_token = encrypt(creds.token) if creds.token else existing.access_token
+            existing.refresh_token = encrypt(creds.refresh_token) if creds.refresh_token else existing.refresh_token
             existing.token_uri = creds.token_uri
             existing.client_id = creds.client_id
-            existing.client_secret = creds.client_secret
+            existing.client_secret = encrypt(creds.client_secret) if creds.client_secret else existing.client_secret
             existing.expiry = expiry_str
             existing.scopes = scopes_str
             existing.updated_at = now
@@ -104,11 +105,11 @@ def _save_token(creds: Any, user_id: str = "") -> None:
             record = GoogleTokenRecord(
                 user_id=uid,
                 service="gmail",
-                access_token=creds.token,
-                refresh_token=creds.refresh_token,
+                access_token=encrypt(creds.token) if creds.token else "",
+                refresh_token=encrypt(creds.refresh_token) if creds.refresh_token else "",
                 token_uri=creds.token_uri,
                 client_id=creds.client_id,
-                client_secret=creds.client_secret,
+                client_secret=encrypt(creds.client_secret) if creds.client_secret else "",
                 expiry=expiry_str,
                 scopes=scopes_str,
                 updated_at=now,
@@ -145,12 +146,15 @@ def _load_creds(user_id: str = "") -> Any:
             ).first()
 
     if row:
+        access_token, _ = decrypt_or_plaintext(row.access_token) if row.access_token else ("", False)
+        refresh_token, _ = decrypt_or_plaintext(row.refresh_token) if row.refresh_token else ("", False)
+        client_secret, _ = decrypt_or_plaintext(row.client_secret) if row.client_secret else ("", False)
         creds = Credentials(
-            token=row.access_token,
-            refresh_token=row.refresh_token,
+            token=access_token,
+            refresh_token=refresh_token,
             token_uri=row.token_uri,
             client_id=row.client_id,
-            client_secret=row.client_secret,
+            client_secret=client_secret,
         )
         if row.expiry:
             creds.expiry = datetime.fromisoformat(row.expiry).replace(tzinfo=None)

--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -155,6 +155,11 @@ def oauth_authorize(
         raise HTTPException(status_code=400, detail="Only code_challenge_method=S256 is supported")
     if not redirect_uri:
         raise HTTPException(status_code=400, detail="redirect_uri is required")
+    registered = mcp_registered_clients.get(client_id)
+    if not registered:
+        raise HTTPException(status_code=400, detail="Unknown client_id — register first via POST /oauth/register")
+    if redirect_uri not in registered.get("redirect_uris", []):
+        raise HTTPException(status_code=400, detail="redirect_uri not registered for this client")
     if not code_challenge:
         raise HTTPException(status_code=400, detail="code_challenge is required (PKCE required)")
 

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -751,7 +751,9 @@ def get_orphan_relationships(
     session: Session = Depends(get_session),
 ) -> list[Relationship]:
     """Return relationships where from_thing_id or to_thing_id doesn't exist."""
-    thing_ids = select(ThingRecord.id)
+    thing_ids = select(ThingRecord.id).where(
+        user_filter_clause(ThingRecord.user_id, user_id)
+    )
     stmt = select(ThingRelationshipRecord).where(
         or_(
             ThingRelationshipRecord.from_thing_id.not_in(thing_ids),  # type: ignore[union-attr]
@@ -771,7 +773,9 @@ def cleanup_orphan_relationships(
     import logging as _logging
 
     _logger = _logging.getLogger(__name__)
-    thing_ids_subq = select(ThingRecord.id)
+    thing_ids_subq = select(ThingRecord.id).where(
+        user_filter_clause(ThingRecord.user_id, user_id)
+    )
     orphans = session.exec(
         select(ThingRelationshipRecord).where(
             or_(
@@ -883,11 +887,20 @@ def create_relationship(
 @router.delete("/relationships/{rel_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a relationship")
 def delete_relationship(
     rel_id: str,
+    user_id: str = Depends(require_user),
     session: Session = Depends(get_session),
 ) -> None:
     """Delete a relationship by ID."""
     record = session.get(ThingRelationshipRecord, rel_id)
     if not record:
         raise HTTPException(status_code=404, detail=f"Relationship '{rel_id}' not found")
+    if user_id:
+        from_thing = session.get(ThingRecord, record.from_thing_id)
+        to_thing = session.get(ThingRecord, record.to_thing_id)
+        if not (
+            (from_thing and from_thing.user_id == user_id)
+            or (to_thing and to_thing.user_id == user_id)
+        ):
+            raise HTTPException(status_code=404, detail=f"Relationship '{rel_id}' not found")
     session.delete(record)
     session.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,6 +21,7 @@ os.environ.setdefault("SENTRY_DSN", "")
 # test_auth.py patches backend.auth.SECRET_KEY directly for auth-enabled tests.
 os.environ["SECRET_KEY"] = ""
 os.environ["RELI_API_TOKEN"] = ""
+os.environ.setdefault("AUTH_DISABLED", "true")
 
 # ---------------------------------------------------------------------------
 # Database fixtures

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -504,7 +504,7 @@ function MessageBubble({ msg, speakingId, speak }: { msg: ChatMessage; speakingI
             <>
               <div className="prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-headings:my-2 prose-pre:my-2 prose-blockquote:my-1 prose-pre:bg-surface-container-low prose-pre:border prose-pre:border-on-surface-variant/10 prose-code:text-primary">
                 <ReactMarkdown
-                  urlTransform={(url) => url}
+                  urlTransform={(url) => /^(javascript|data|vbscript):/i.test(url.trim()) ? '' : url}
                   components={{
                     a: ({ href, children }) => {
                       if (href?.startsWith('thing://')) {


### PR DESCRIPTION
## Summary

Fixes all **CRITICAL** and **HIGH** findings from the security audit (22 confirmed findings total):

- **SEC-01 (CRITICAL):** `DELETE /api/things/relationships/{rel_id}` had no `require_user` dependency and no ownership check — any user could delete any relationship. Added auth + ownership verification.
- **SEC-02 (CRITICAL):** Gmail OAuth tokens stored in plaintext despite `token_encryption` module existing. Applied `encrypt()`/`decrypt_or_plaintext()` with transparent migration of existing plaintext tokens.
- **SEC-03 (HIGH):** OAuth `redirect_uri` accepted without validation against registered client URIs. Added check against `registered["redirect_uris"]`.
- **SEC-04 (HIGH):** Orphan relationship endpoints queried all users' data. Scoped `thing_ids` subquery with `user_filter_clause`.
- **SEC-05 (HIGH):** Auth silently disabled when `SECRET_KEY` empty. Now requires `SECRET_KEY`/`RELI_API_TOKEN` or explicit `AUTH_DISABLED=true`.
- **SEC-06 (HIGH):** MCP static token auth left `user_id=""`, granting access to all users' data. Now resolves to actual user + uses timing-safe comparison.
- **SEC-07 (HIGH):** `ReactMarkdown` `urlTransform` disabled sanitization, allowing `javascript:` XSS. Now blocks dangerous protocols.

15 MEDIUM/LOW findings tracked as separate issues.

## Test plan
- [ ] Verify `DELETE /api/things/relationships/{rel_id}` returns 404 for relationships not owned by the requesting user
- [ ] Verify Gmail OAuth flow still works (tokens encrypted on save, decrypted on load, plaintext migrated transparently)
- [ ] Verify MCP OAuth rejects unregistered redirect_uris
- [ ] Verify app refuses to start without `SECRET_KEY` unless `AUTH_DISABLED=true`
- [ ] Verify MCP static token auth resolves to correct user_id
- [ ] Verify markdown links with `javascript:` protocol are sanitized

🤖 Generated with [Claude Code](https://claude.com/claude-code)