### PR TITLE
fix: bind staging port to all interfaces for external health check

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -7,7 +7,7 @@ services:
     image: ghcr.io/alexsiri7/reli:${RELI_IMAGE_TAG:-latest}
     container_name: reli-staging
     ports:
-      - "127.0.0.1:8001:8000"
+      - "0.0.0.0:8001:8000"
     volumes:
       - ./data-staging:/app/data
     environment:


### PR DESCRIPTION
## Summary

- `docker-compose.staging.yml` was binding port 8001 to `127.0.0.1` only, making the staging container unreachable from the GitHub Actions runner (which connects via Tailscale to `100.120.193.82:8001`)
- The health check has failed on every single staging pipeline run since the staging workflow was introduced in commit `6ea8372` (2026-03-31)
- Fix: change port binding from `"127.0.0.1:8001:8000"` to `"0.0.0.0:8001:8000"` so the container is accessible on all interfaces, including Tailscale

## Changes

| File | Change |
|------|--------|
| `docker-compose.staging.yml` | Port binding `127.0.0.1:8001:8000` → `0.0.0.0:8001:8000` |

## Validation

- Lint: 0 errors (3 pre-existing warnings, unrelated)
- Tests: 212 passed, 0 failed
- Build: compiled successfully
- Full staging validation requires: merge → SSH into staging server to resolve unstaged changes (`git stash && git pull --rebase`) → trigger staging pipeline

## Notes

There is a secondary operational issue: the staging server has local unstaged changes that cause `git pull --rebase` to fail. This is non-fatal (the deploy continues) but must be resolved manually on the server after this PR merges so the updated compose file is picked up. This cannot be fixed via a code change.

Fixes #595