### PR TITLE
fix: use git fetch+reset instead of pull --rebase in staging deploy

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -52,6 +52,8 @@ jobs:
             docker pull "$IMAGE:$DEPLOY_SHA"
 
             cd /mnt/ext-fast/gc/rigs/reli
+            # fetch+reset instead of pull --rebase: handles server-side unstaged changes cleanly
+            # Note: resets tracked files only; untracked files (.env, etc.) are preserved
             git fetch origin main
             git reset --hard origin/main
             RELI_IMAGE_TAG="$DEPLOY_SHA" docker compose -f docker-compose.staging.yml up -d

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -52,7 +52,8 @@ jobs:
             docker pull "$IMAGE:$DEPLOY_SHA"
 
             cd /mnt/ext-fast/gc/rigs/reli
-            git pull --rebase
+            git fetch origin main
+            git reset --hard origin/main
             RELI_IMAGE_TAG="$DEPLOY_SHA" docker compose -f docker-compose.staging.yml up -d
 
       - name: Wait for staging health


### PR DESCRIPTION
## Summary

- `git pull --rebase` in the staging SSH deploy step fails silently when the staging server has unstaged local changes, causing Docker to restart with the stale compose file
- The container was being recreated with the old `127.0.0.1:8001:8000` port binding instead of `0.0.0.0:8001:8000`, making the health check endpoint unreachable from GitHub Actions
- Replace `git pull --rebase` with `git fetch origin main && git reset --hard origin/main`, which always brings the working tree to the exact repo state regardless of local changes

## Changes

- `.github/workflows/staging-pipeline.yml`: Replace `git pull --rebase` with `git fetch origin main` + `git reset --hard origin/main` in the "Deploy staging via SSH" step (+2/-1 lines)

## Root Cause

The 5 Whys chain from CI run `24371629782`:

1. Health check at `http://100.120.193.82:8001/healthz` failed all 20 attempts
2. Container was bound to `127.0.0.1:8001:8000` (loopback only), not `0.0.0.0:8001:8000`
3. `git pull --rebase` failed on the staging server — explicit error in CI logs: `error: cannot pull with rebase: You have unstaged changes.`
4. Docker compose ran with the stale `docker-compose.staging.yml` (with `127.0.0.1` binding) because the pull never updated it
5. `appleboy/ssh-action` didn't abort on the git error — docker-compose launched the container "successfully" with the old file

## Validation

- Type check: N/A (YAML-only change; TS baseline confirmed clean)
- Lint: 0 errors (3 pre-existing warnings not introduced by this change)
- Tests: 211 passed, 0 failed across 18 test files
- Build: N/A (no frontend files changed)

Post-merge validation: next staging pipeline run should show no `git pull --rebase` errors and health check should pass within first few attempts.

Fixes #597