### PR TITLE
fix: add --legacy-peer-deps to staging E2E npm install

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -101,7 +101,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm --prefix frontend ci
+        run: npm --prefix frontend ci --legacy-peer-deps
 
       - name: Install Playwright browsers
         run: npx --prefix frontend playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- `Staging E2E smoke tests` CI job was failing at the \"Install dependencies\" step with `ERESOLVE` because `@tailwindcss/vite@4.2.1` declares a peer dependency on `vite@^5.2.0 || ^6 || ^7`, but the project uses `vite@^8.0.0`
- Root cause: the `npm --prefix frontend ci` command in `staging-pipeline.yml` (line 104) was missing `--legacy-peer-deps`, which is the documented project convention for this known conflict
- Fix: add `--legacy-peer-deps` to the npm install command in the `staging-e2e` job

## Changes

| File | Change |
|------|--------|
| `.github/workflows/staging-pipeline.yml` | Add `--legacy-peer-deps` to `npm ci` in staging E2E install step (+1/-1) |

## Validation

- YAML-only change; no frontend TypeScript was modified
- Frontend build: ✅ Pass (88 modules, tsc + vite build)
- Lint: ✅ 0 errors (3 pre-existing warnings unrelated to this change)
- Tests: ✅ 212/212 passed

The `--legacy-peer-deps` flag is the documented convention per `CLAUDE.md`:
> Frontend has a peer dependency conflict — always use `--legacy-peer-deps` with npm.

Fixes #599