### PR TITLE
fix: reject unauthenticated requests when RELI_API_TOKEN is set

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -33,6 +33,7 @@ def _resolve_api_token_user() -> str:
     from sqlmodel import Session, select
 
     import backend.db_engine as _engine_mod
+
     from .db_models import UserRecord
 
     try:

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -67,7 +67,10 @@ async def require_user(request: Request) -> str:
         )
 
     if not SECRET_KEY:
-        return ""
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
 
     # --- Cookie-based JWT auth (web UI) ---
     token = request.cookies.get(COOKIE_NAME)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -89,10 +89,53 @@ class TestJWTAuth:
         assert "Not authenticated" in resp.json()["detail"]
 
     def test_api_bypassed_when_no_secret_key(self, patched_db):
-        """When SECRET_KEY is empty, auth is disabled for local dev."""
-        with patch("backend.auth.SECRET_KEY", ""):
+        """When neither SECRET_KEY nor RELI_API_TOKEN is set, auth is disabled for local dev."""
+        with (
+            patch("backend.auth.SECRET_KEY", ""),
+            patch("backend.auth._API_TOKEN", ""),  # explicit: test the fully-disabled path
+        ):
             from backend.main import app
 
             with TestClient(app) as c:
                 resp = c.get("/api/things")
                 assert resp.status_code == 200
+
+
+class TestApiTokenWithoutSecretKey:
+    """Staging scenario: RELI_API_TOKEN set, SECRET_KEY absent."""
+
+    @pytest.fixture()
+    def staging_client(self, patched_db):
+        """TestClient simulating staging: API token set, no SECRET_KEY."""
+        with (
+            patch("backend.auth.SECRET_KEY", ""),
+            patch("backend.auth._API_TOKEN", "staging-token-abc"),
+        ):
+            from backend.main import app
+
+            with TestClient(app) as c:
+                yield c
+
+    def test_unauthenticated_request_rejected_when_api_token_set(self, staging_client):
+        """When RELI_API_TOKEN is configured but no Bearer token is provided, reject with 401."""
+        resp = staging_client.get("/api/things")
+        assert resp.status_code == 401
+        assert "Not authenticated" in resp.json()["detail"]
+
+    def test_valid_bearer_token_accepted_when_secret_key_absent(self, staging_client):
+        """Valid Bearer token must still work even when SECRET_KEY is not set."""
+        resp = staging_client.get(
+            "/api/things",
+            headers={"Authorization": "Bearer staging-token-abc"},
+        )
+        # Auth passes (not 401) — actual status depends on whether a user record exists
+        assert resp.status_code != 401
+
+    def test_invalid_bearer_token_rejected_when_secret_key_absent(self, staging_client):
+        """Invalid Bearer token must receive 401 in staging config."""
+        resp = staging_client.get(
+            "/api/things",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 401
+        assert "Invalid API token" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

- `backend/auth.py:69` had a logic gap: when `RELI_API_TOKEN` is set but `SECRET_KEY` is not (the staging configuration), the `require_user()` dependency would fall through to `return ""`, silently allowing unauthenticated requests instead of raising 401.
- Fixed by replacing `return ""` with `raise HTTPException(status.HTTP_401_UNAUTHORIZED)` at that branch.
- The `if not SECRET_KEY and not _API_TOKEN: return ""` check at line 54 still covers dev environments where auth is fully disabled (neither token configured).

## Changes

| File | Change |
|------|--------|
| `backend/auth.py` | Replace `return ""` with `raise HTTPException(401)` when `SECRET_KEY` is unset but `_API_TOKEN` is set (+4/-1 lines) |

## Validation

| Check | Result |
|-------|--------|
| Backend auth tests (`pytest backend/tests/test_auth.py`) | ✅ 8 passed |
| Frontend lint | ✅ 0 errors |
| Frontend tests | ✅ 212 passed, 0 failed |
| Frontend build | ✅ Compiled successfully |

E2E smoke tests run against the live staging server and require a deploy to validate — expected to pass after merge and deploy.

## Root Cause

Staging sets `RELI_API_TOKEN` (for MCP/API access) but not `SECRET_KEY` (no cookie auth needed). The auth function checked Bearer token first, then fell through to `if not SECRET_KEY: return ""` — allowing any request without a Bearer header through as an anonymous user.

Fixes #601