### PR TITLE
fix: provide non-empty RELI_API_TOKEN default in staging

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -102,5 +102,3 @@ async def require_user(request: Request) -> str:
         )
 
     return user_id
-
-

--- a/backend/config.py
+++ b/backend/config.py
@@ -119,9 +119,7 @@ class Settings(BaseSettings):
             }
             missing = [k for k, v in required.items() if not v]
             if missing:
-                raise ValueError(
-                    f"Missing required production env vars: {', '.join(missing)}"
-                )
+                raise ValueError(f"Missing required production env vars: {', '.join(missing)}")
         if not self.SECRET_KEY and not self.RELI_API_TOKEN:
             warnings.warn(
                 "SECRET_KEY and RELI_API_TOKEN are both empty — authentication is DISABLED",

--- a/backend/config.py
+++ b/backend/config.py
@@ -122,9 +122,15 @@ class Settings(BaseSettings):
                 raise ValueError(
                     f"Missing required production env vars: {', '.join(missing)}"
                 )
-        if not self.SECRET_KEY:
+        if not self.SECRET_KEY and not self.RELI_API_TOKEN:
             warnings.warn(
-                "SECRET_KEY is empty — authentication is DISABLED", stacklevel=2
+                "SECRET_KEY and RELI_API_TOKEN are both empty — authentication is DISABLED",
+                stacklevel=2,
+            )
+        elif not self.SECRET_KEY:
+            warnings.warn(
+                "SECRET_KEY is empty — cookie-based auth (Google OAuth) is DISABLED",
+                stacklevel=2,
             )
         return self
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -173,9 +173,7 @@ def test_settings_production_with_secrets_passes():
     """Settings should not raise when required secrets are provided in production."""
     from backend.config import Settings
 
-    with patch.dict(
-        "os.environ", {"RAILWAY_ENVIRONMENT_NAME": "production"}, clear=False
-    ):
+    with patch.dict("os.environ", {"RAILWAY_ENVIRONMENT_NAME": "production"}, clear=False):
         s = Settings(SECRET_KEY="supersecret", REQUESTY_API_KEY="key123")
         assert s.SECRET_KEY == "supersecret"
         assert s.REQUESTY_API_KEY == "key123"
@@ -231,9 +229,9 @@ def test_settings_partial_auth_warns_about_cookie_only():
             messages = [str(x.message) for x in w]
 
             # Should warn about cookie auth being disabled
-            assert any("cookie-based auth" in m for m in messages), \
-                f"Expected cookie-auth warning, got: {messages}"
+            assert any("cookie-based auth" in m for m in messages), f"Expected cookie-auth warning, got: {messages}"
 
             # Must NOT say authentication is fully disabled
-            assert not any("authentication is DISABLED" in m for m in messages), \
+            assert not any("authentication is DISABLED" in m for m in messages), (
                 "Should not claim auth fully disabled when API token is set"
+            )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -214,3 +214,26 @@ def test_settings_empty_secret_key_warns():
             Settings(SECRET_KEY="", REQUESTY_API_KEY="somekey")
             secret_warnings = [x for x in w if "authentication is DISABLED" in str(x.message)]
             assert len(secret_warnings) >= 1
+
+
+def test_settings_partial_auth_warns_about_cookie_only():
+    """When SECRET_KEY is empty but RELI_API_TOKEN is set, warn only about cookie auth."""
+    from backend.config import Settings
+
+    env_overrides = {
+        "RAILWAY_ENVIRONMENT_NAME": "",
+        "PRODUCTION": "",
+    }
+    with patch.dict("os.environ", env_overrides, clear=False):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Settings(SECRET_KEY="", RELI_API_TOKEN="staging-token", REQUESTY_API_KEY="key")
+            messages = [str(x.message) for x in w]
+
+            # Should warn about cookie auth being disabled
+            assert any("cookie-based auth" in m for m in messages), \
+                f"Expected cookie-auth warning, got: {messages}"
+
+            # Must NOT say authentication is fully disabled
+            assert not any("authentication is DISABLED" in m for m in messages), \
+                "Should not claim auth fully disabled when API token is set"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,7 +25,7 @@ services:
       - GOOGLE_AUTH_REDIRECT_URI=${GOOGLE_AUTH_REDIRECT_URI:-}
       - RELI_BASE_URL=${RELI_BASE_URL:-}
       - SECRET_KEY=${SECRET_KEY:-}
-      - RELI_API_TOKEN=${RELI_API_TOKEN:-reli-staging-placeholder}
+      - RELI_API_TOKEN=${RELI_API_TOKEN:-reli-staging-placeholder}  # Override at deploy time with a real secret
       - SENTRY_DSN=${SENTRY_DSN:-}
       - SENTRY_ENVIRONMENT=staging
       - DATABASE_URL=${DATABASE_URL:-}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -25,7 +25,7 @@ services:
       - GOOGLE_AUTH_REDIRECT_URI=${GOOGLE_AUTH_REDIRECT_URI:-}
       - RELI_BASE_URL=${RELI_BASE_URL:-}
       - SECRET_KEY=${SECRET_KEY:-}
-      - RELI_API_TOKEN=${RELI_API_TOKEN:-}
+      - RELI_API_TOKEN=${RELI_API_TOKEN:-reli-staging-placeholder}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - SENTRY_ENVIRONMENT=staging
       - DATABASE_URL=${DATABASE_URL:-}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -171,6 +171,7 @@ Both data stores contain production data. Handle with care.
 | `GOOGLE_CLIENT_ID` | Yes | — | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Yes | — | Google OAuth client secret |
 | `SECRET_KEY` | Yes | — | JWT signing secret |
+| `RELI_API_TOKEN` | No | — | Static bearer token for API auth; enables token-based access without Google OAuth |
 | `DATA_DIR` | No | `backend/` | Directory for `reli.db` |
 | `LOG_LEVEL` | No | `INFO` | Log verbosity: DEBUG, INFO, WARNING |
 | `OLLAMA_MODEL` | No | — | Local model for context agent |


### PR DESCRIPTION
## Summary

Staging E2E smoke tests `GET /api/things rejects unauthenticated request` and `GET /api/briefing rejects unauthenticated request` were failing because both `SECRET_KEY` and `RELI_API_TOKEN` were empty in the staging container. When both are empty, `require_user()` silently disables auth, causing endpoints to return 200 instead of 401.

Two prior fixes (`d3fd255`, `461248c`) added the auth logic and env passthrough, but the staging server's `.env` has no `RELI_API_TOKEN` value — so the passthrough delivered an empty string. This PR gives the default a non-empty placeholder so auth is always enforced in staging.

## Changes

- **`docker-compose.staging.yml`**: Change `RELI_API_TOKEN=${RELI_API_TOKEN:-}` → `RELI_API_TOKEN=${RELI_API_TOKEN:-reli-staging-placeholder}`. The placeholder is only the fallback; if the server's `.env` has a real value, that takes precedence.
- **`backend/config.py`**: Fix misleading auth-disabled warning. Previously warned "auth is DISABLED" whenever `SECRET_KEY` was empty, but auth is only disabled when *both* keys are empty. Now warns accurately: separate messages for (a) both empty → fully disabled, (b) only `SECRET_KEY` empty → cookie auth disabled but API token auth still active.

## Root Cause

```
GET /api/things returns 200 (not 401)
  ← require_user() returns "" (auth disabled)
    ← both SECRET_KEY and RELI_API_TOKEN are empty in staging container
      ← RELI_API_TOKEN=${RELI_API_TOKEN:-} defaults to "" when server .env has no value
```

## Validation

- All 775 backend tests pass (12 skipped), 82% coverage
- All 212 frontend tests pass across 18 test files
- mypy: no errors in `backend/config.py`
- ruff check + format: clean
- Frontend build: success

After merging and deploying, the next CI run should show both previously-failing smoke tests passing (staging container will have `RELI_API_TOKEN=reli-staging-placeholder`, causing `require_user()` to enforce auth and return 401 for unauthenticated requests).

Fixes #605