### PR TITLE
fix: handle race condition in _upsert_user causing UniqueViolationError

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,5 @@
 """Google OAuth2 login + JWT session authentication."""
 
-import json
 import logging
 import secrets
 import threading
@@ -12,14 +11,13 @@ from fastapi.responses import RedirectResponse
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from google_auth_oauthlib.flow import Flow
-
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 import backend.db_engine as _engine_mod
-from ..db_models import UserRecord, ThingRecord
 
 from ..config import settings
+from ..db_models import ThingRecord, UserRecord
 from ..oauth_state import (
     cleanup_and_get,
     cleanup_and_pop,
@@ -90,9 +88,7 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
     now = datetime.now(timezone.utc)
     user_id: str
     with Session(_engine_mod.engine) as session:
-        existing = session.exec(
-            select(UserRecord).where(UserRecord.google_id == google_id)
-        ).first()
+        existing = session.exec(select(UserRecord).where(UserRecord.google_id == google_id)).first()
         if existing:
             user_id = existing.id
             existing.email = email
@@ -118,9 +114,7 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
             except IntegrityError:
                 session.rollback()
                 # Concurrent request created the same user — fetch the winner
-                existing = session.exec(
-                    select(UserRecord).where(UserRecord.google_id == google_id)
-                ).first()
+                existing = session.exec(select(UserRecord).where(UserRecord.google_id == google_id)).first()
                 if existing is None:
                     raise  # unexpected: re-raise if still not found
                 user_id = existing.id
@@ -239,14 +233,18 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
     if mcp_session:
         # Issue a short-lived auth code for the MCP client to exchange
         auth_code = secrets.token_urlsafe(32)
-        cleanup_and_store(mcp_auth_codes, auth_code, {
-            "user_id": user_id,
-            "email": email,
-            "code_challenge": mcp_session["code_challenge"],
-            "code_challenge_method": mcp_session["code_challenge_method"],
-            "redirect_uri": mcp_session["redirect_uri"],
-            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=MCP_AUTH_CODE_TTL_SECONDS),
-        })
+        cleanup_and_store(
+            mcp_auth_codes,
+            auth_code,
+            {
+                "user_id": user_id,
+                "email": email,
+                "code_challenge": mcp_session["code_challenge"],
+                "code_challenge_method": mcp_session["code_challenge_method"],
+                "redirect_uri": mcp_session["redirect_uri"],
+                "expires_at": datetime.now(timezone.utc) + timedelta(seconds=MCP_AUTH_CODE_TTL_SECONDS),
+            },
+        )
         client_redirect = mcp_session["redirect_uri"]
         client_state = mcp_session.get("client_state", "")
         sep = "&" if "?" in client_redirect else "?"

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -13,7 +13,8 @@ from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from google_auth_oauthlib.flow import Flow
 
-from sqlmodel import Session
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
 
 import backend.db_engine as _engine_mod
 from ..db_models import UserRecord, ThingRecord
@@ -89,7 +90,6 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
     now = datetime.now(timezone.utc)
     user_id: str
     with Session(_engine_mod.engine) as session:
-        from sqlmodel import select
         existing = session.exec(
             select(UserRecord).where(UserRecord.google_id == google_id)
         ).first()
@@ -113,7 +113,24 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                 updated_at=now,
             )
             session.add(user_record)
-            session.commit()
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                # Concurrent request created the same user — fetch the winner
+                existing = session.exec(
+                    select(UserRecord).where(UserRecord.google_id == google_id)
+                ).first()
+                if existing is None:
+                    raise  # unexpected: re-raise if still not found
+                user_id = existing.id
+                existing.email = email
+                existing.name = name
+                existing.picture = picture
+                existing.updated_at = now
+                session.add(existing)
+                session.commit()
+                return user_id
             _create_user_thing_sqlmodel(session, user_id, name, email, google_id, now)
     return user_id
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -113,6 +113,12 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                 session.commit()
             except IntegrityError:
                 session.rollback()
+                # Assumes the only unique constraint on UserRecord that can fire here is
+                # google_id — if the schema gains additional unique indexes, revisit.
+                logger.warning(
+                    "_upsert_user: IntegrityError on INSERT for google_id=%s — concurrent winner, retrying",
+                    google_id,
+                )
                 # Concurrent request created the same user — fetch the winner
                 existing = session.exec(select(UserRecord).where(UserRecord.google_id == google_id)).first()
                 if existing is None:
@@ -123,7 +129,11 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                 existing.picture = picture
                 existing.updated_at = now
                 session.add(existing)
-                session.commit()
+                try:
+                    session.commit()
+                except Exception:
+                    logger.exception("_upsert_user: failed to update winner row for google_id=%s", google_id)
+                    raise
                 return user_id
             _create_user_thing_sqlmodel(session, user_id, name, email, google_id, now)
     return user_id

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -129,11 +129,7 @@ def _upsert_user(google_id: str, email: str, name: str, picture: str | None) -> 
                 existing.picture = picture
                 existing.updated_at = now
                 session.add(existing)
-                try:
-                    session.commit()
-                except Exception:
-                    logger.exception("_upsert_user: failed to update winner row for google_id=%s", google_id)
-                    raise
+                session.commit()
                 return user_id
             _create_user_thing_sqlmodel(session, user_id, name, email, google_id, now)
     return user_id

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -17,6 +17,41 @@ def authed_client(patched_db):
             yield c
 
 
+class TestUpsertUserConcurrency:
+    """Test that concurrent OAuth callbacks don't crash on duplicate insert."""
+
+    def test_upsert_user_handles_integrity_error(self, patched_db):
+        """Simulated race: INSERT fails with IntegrityError, retry finds winner."""
+        from sqlalchemy.exc import IntegrityError
+        from sqlmodel import Session
+
+        from backend.routers.auth import _upsert_user
+
+        original_commit = Session.commit
+        call_count = 0
+
+        def commit_that_races(self):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Simulate the concurrent winner by inserting the row first
+                original_commit(self)
+                # Now raise as if a second concurrent request hit a conflict
+                raise IntegrityError("mock", {}, Exception("unique violation"))
+            return original_commit(self)
+
+        from unittest.mock import patch as _patch
+
+        with _patch.object(Session, "commit", commit_that_races):
+            # _upsert_user will: try INSERT -> commit_that_races commits it
+            # then raises IntegrityError -> rollback -> re-SELECT finds the
+            # row (it was committed) -> updates it -> second commit succeeds
+            user_id = _upsert_user("google-race", "racer@example.com", "Racer", None)
+
+        assert user_id is not None
+        assert user_id.startswith("u-")
+
+
 class TestUserThingCreation:
     """Test that a Thing is auto-created for new OAuth users."""
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,6 +5,10 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session
+
+from backend.routers.auth import _upsert_user
 
 
 @pytest.fixture()
@@ -21,12 +25,7 @@ class TestUpsertUserConcurrency:
     """Test that concurrent OAuth callbacks don't crash on duplicate insert."""
 
     def test_upsert_user_handles_integrity_error(self, patched_db):
-        """Simulated race: INSERT fails with IntegrityError, retry finds winner."""
-        from sqlalchemy.exc import IntegrityError
-        from sqlmodel import Session
-
-        from backend.routers.auth import _upsert_user
-
+        """Simulated race: commit succeeds then IntegrityError is raised; retry finds the winner row."""
         original_commit = Session.commit
         call_count = 0
 
@@ -40,9 +39,7 @@ class TestUpsertUserConcurrency:
                 raise IntegrityError("mock", {}, Exception("unique violation"))
             return original_commit(self)
 
-        from unittest.mock import patch as _patch
-
-        with _patch.object(Session, "commit", commit_that_races):
+        with patch.object(Session, "commit", commit_that_races):
             # _upsert_user will: try INSERT -> commit_that_races commits it
             # then raises IntegrityError -> rollback -> re-SELECT finds the
             # row (it was committed) -> updates it -> second commit succeeds
@@ -50,6 +47,18 @@ class TestUpsertUserConcurrency:
 
         assert user_id is not None
         assert user_id.startswith("u-")
+        assert call_count == 2  # initial commit + retry commit both ran
+
+    def test_upsert_user_reraises_unexpected_integrity_error(self, patched_db):
+        """IntegrityError with no concurrent winner should propagate."""
+
+        def commit_that_fails_cold(self):
+            # Do NOT insert first — simulates a non-race IntegrityError (no winner row)
+            raise IntegrityError("mock", {}, Exception("unexpected constraint"))
+
+        with patch.object(Session, "commit", commit_that_fails_cold):
+            with pytest.raises(IntegrityError):
+                _upsert_user("google-unexpected", "err@example.com", "Err", None)
 
 
 class TestUserThingCreation:
@@ -57,7 +66,6 @@ class TestUserThingCreation:
 
     def test_upsert_user_creates_thing_for_new_user(self, patched_db):
         from backend.database import db
-        from backend.routers.auth import _upsert_user
 
         user_id = _upsert_user("google-123", "alice@example.com", "Alice", None)
 
@@ -76,7 +84,6 @@ class TestUserThingCreation:
 
     def test_upsert_user_no_duplicate_thing_on_repeat_login(self, patched_db):
         from backend.database import db
-        from backend.routers.auth import _upsert_user
 
         user_id = _upsert_user("google-123", "alice@example.com", "Alice", None)
         _upsert_user("google-123", "alice@example.com", "Alice", None)


### PR DESCRIPTION
## Summary

- Fixes a race condition in `_upsert_user()` (`backend/routers/auth.py`) where two concurrent OAuth callbacks for the same Google user both pass the `SELECT` check with `existing = None`, then both attempt an `INSERT`, causing an `IntegrityError` on the `google_id` unique constraint
- Added `IntegrityError` catch around the `session.commit()` in the INSERT path: on conflict, rolls back and re-fetches the row created by the winning concurrent request, then updates it
- Moved `from sqlalchemy.exc import IntegrityError` and `from sqlmodel import Session, select` to module level (were previously inline or missing)
- Added a test (`test_upsert_user_concurrent_race`) that simulates the concurrent INSERT scenario and verifies the retry path returns a valid user ID without raising

## Changes

| File | Action | Description |
|------|--------|-------------|
| `backend/routers/auth.py` | UPDATE | Add `IntegrityError` catch + rollback + retry SELECT in `_upsert_user`; fix imports |
| `backend/tests/test_auth.py` | UPDATE | Add concurrent upsert race condition test |

## Validation

- **mypy**: ✅ No errors in changed files (1 pre-existing unrelated error in `oauth_state.py`)
- **ruff lint**: ✅ Pass (fixed unused `import json`, fixed import sort order)
- **ruff format**: ✅ Pass
- **Backend tests**: ✅ 782 passed, 12 skipped (794 total)
- **Frontend tests**: ✅ 213 passed across 18 test files
- **Frontend build**: ✅ Compiled successfully (88 modules)

## Root Cause

The SELECT-then-INSERT pattern in `_upsert_user` has a race window: two concurrent requests can both see `existing = None` and both attempt an `INSERT`, with the second failing on the `google_id` unique constraint. Triggered in practice by double-click login or simultaneous MCP + web tab OAuth callbacks.

Fixes #612