### PR TITLE
feat: show learned preferences in daily briefing with feedback buttons

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -345,12 +345,19 @@ class BriefingItem(BaseModel):
     reasons: list[str]
 
 
+class LearnedPreference(BaseModel):
+    id: str
+    title: str
+    confidence_label: str  # "emerging", "moderate", or "strong"
+
+
 class BriefingResponse(BaseModel):
     date: str
     the_one_thing: BriefingItem | None = None
     secondary: list[BriefingItem] = []
     parking_lot: list[dict[str, Any]] = []
     findings: list[SweepFinding] = []
+    learned_preferences: list[LearnedPreference] = []
     total: int
     stats: dict[str, int] = {}
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -77,7 +77,11 @@ def _confidence_label(data: dict) -> str:
         conf = data.get("confidence", 0.0)
         if not isinstance(conf, (int, float)):
             return "emerging"
-    return "strong" if conf >= 0.7 else "moderate" if conf >= 0.5 else "emerging"
+    if conf >= 0.7:
+        return "strong"
+    if conf >= 0.5:
+        return "moderate"
+    return "emerging"
 
 
 @router.get("", response_model=BriefingResponse, summary="Daily Briefing")
@@ -192,7 +196,7 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
         {"thing_id": s.thing["id"], "title": s.thing["title"],
          "importance": s.importance, "urgency": s.urgency}
         for s in scored[6:]
-    ] if len(scored) > 6 else []
+    ]
 
     return BriefingResponse(
         date=target.isoformat(),

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -16,6 +16,7 @@ from ..models import (
     BriefingItem,
     BriefingPreferences,
     BriefingResponse,
+    LearnedPreference,
     MorningBriefing,
     MorningBriefingContent,
     SweepFinding,
@@ -55,6 +56,16 @@ def _record_to_finding(record: SweepFindingRecord, thing: Thing | None = None) -
         snoozed_until=record.snoozed_until,
         thing=thing,
     )
+
+
+def _confidence_label(data: dict) -> str:
+    """Convert raw preference data to a human-readable confidence label."""
+    if "patterns" in data and isinstance(data["patterns"], list) and data["patterns"]:
+        return str(data["patterns"][0].get("confidence", "emerging"))
+    conf = data.get("confidence", 0.0)
+    if not isinstance(conf, (int, float)):
+        return "emerging"
+    return "strong" if conf >= 0.7 else "moderate" if conf >= 0.5 else "emerging"
 
 
 @router.get("", response_model=BriefingResponse, summary="Daily Briefing")
@@ -99,6 +110,21 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
             )
         )
         finding_results = session.exec(finding_stmt).all()
+
+    # Learned preference Things for "I Noticed" section
+    pref_records = [r for r in all_active if r.type_hint == "preference"]
+    learned_preferences = []
+    for r in pref_records[:5]:
+        try:
+            raw = json.loads(r.data) if isinstance(r.data, str) else (r.data or {})
+            data = raw if isinstance(raw, dict) else {}
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        learned_preferences.append(LearnedPreference(
+            id=r.id,
+            title=r.title,
+            confidence_label=_confidence_label(data),
+        ))
 
     # Filter checkin-due things from all_active (avoids a separate query)
     thing_records = sorted(
@@ -157,6 +183,7 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
         secondary=secondary,
         parking_lot=parking_lot,
         findings=findings,
+        learned_preferences=learned_preferences,
         total=len(scored) + len(findings),
     )
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -59,12 +59,24 @@ def _record_to_finding(record: SweepFindingRecord, thing: Thing | None = None) -
 
 
 def _confidence_label(data: dict) -> str:
-    """Convert raw preference data to a human-readable confidence label."""
+    """Convert raw preference data to a human-readable confidence label.
+
+    Handles two storage shapes:
+    - data["patterns"][0]["confidence"] — used by pattern-based preferences
+    - data["confidence"] (float) — used by simple confidence-scored preferences
+
+    Returns one of: "emerging" (<0.5), "moderate" (0.5–0.69), or "strong" (>=0.7).
+    """
+    _VALID = {"emerging", "moderate", "strong"}
     if "patterns" in data and isinstance(data["patterns"], list) and data["patterns"]:
-        return str(data["patterns"][0].get("confidence", "emerging"))
-    conf = data.get("confidence", 0.0)
-    if not isinstance(conf, (int, float)):
-        return "emerging"
+        raw = data["patterns"][0].get("confidence", 0.0)
+        if isinstance(raw, str):
+            return raw if raw in _VALID else "emerging"
+        conf = raw if isinstance(raw, (int, float)) else 0.0
+    else:
+        conf = data.get("confidence", 0.0)
+        if not isinstance(conf, (int, float)):
+            return "emerging"
     return "strong" if conf >= 0.7 else "moderate" if conf >= 0.5 else "emerging"
 
 
@@ -112,8 +124,13 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
         finding_results = session.exec(finding_stmt).all()
 
     # Learned preference Things for "I Noticed" section
-    pref_records = [r for r in all_active if r.type_hint == "preference"]
+    pref_records = sorted(
+        [r for r in all_active if r.type_hint == "preference"],
+        key=lambda r: r.updated_at or r.created_at or "",
+        reverse=True,
+    )
     learned_preferences = []
+    # Cap at 5 to keep the "I Noticed" section scannable
     for r in pref_records[:5]:
         try:
             raw = json.loads(r.data) if isinstance(r.data, str) else (r.data or {})

--- a/backend/tests/test_api_contracts.py
+++ b/backend/tests/test_api_contracts.py
@@ -74,6 +74,13 @@ def assert_briefing_response_shape(obj: dict) -> None:
     assert "the_one_thing" in obj
     assert isinstance(obj["secondary"], list)
     assert isinstance(obj["parking_lot"], list)
+    # Learned preferences
+    assert "learned_preferences" in obj
+    assert isinstance(obj["learned_preferences"], list)
+    for pref in obj["learned_preferences"]:
+        assert isinstance(pref["id"], str)
+        assert isinstance(pref["title"], str)
+        assert pref["confidence_label"] in ("emerging", "moderate", "strong")
 
 
 def assert_calendar_status_shape(obj: dict) -> None:

--- a/backend/tests/test_briefing.py
+++ b/backend/tests/test_briefing.py
@@ -60,6 +60,36 @@ class TestBriefing:
         titles = _briefing_titles(resp.json())
         assert "Inactive Task" not in titles
 
+    def test_preference_things_appear_in_briefing(self, client):
+        """Learned preferences (type_hint='preference') must appear in learned_preferences."""
+        resp = client.post("/api/things", json={
+            "title": "Prefers afternoon meetings",
+            "type_hint": "preference",
+            "data": {"confidence": 0.6, "category": "scheduling"},
+        })
+        assert resp.status_code == 201
+        pref_id = resp.json()["id"]
+
+        resp = client.get("/api/briefing")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "learned_preferences" in data
+        ids = [p["id"] for p in data["learned_preferences"]]
+        assert pref_id in ids
+
+    def test_preference_confidence_label_in_briefing(self, client):
+        """confidence_label is correctly derived from float confidence."""
+        client.post("/api/things", json={
+            "title": "Cost conscious",
+            "type_hint": "preference",
+            "data": {"confidence": 0.8, "category": "spending"},
+        })
+        resp = client.get("/api/briefing")
+        prefs = resp.json()["learned_preferences"]
+        cost_pref = next((p for p in prefs if p["title"] == "Cost conscious"), None)
+        assert cost_pref is not None
+        assert cost_pref["confidence_label"] == "strong"
+
     def test_things_without_checkin_date_excluded(self, client):
         _create_thing(client, "No Date Thing")
         resp = client.get("/api/briefing")

--- a/backend/tests/test_briefing.py
+++ b/backend/tests/test_briefing.py
@@ -2,6 +2,51 @@
 
 from datetime import date, datetime, timedelta
 
+from backend.routers.briefing import _confidence_label
+
+
+class TestConfidenceLabel:
+    def test_strong(self):
+        assert _confidence_label({"confidence": 0.7}) == "strong"
+        assert _confidence_label({"confidence": 1.0}) == "strong"
+
+    def test_moderate(self):
+        assert _confidence_label({"confidence": 0.5}) == "moderate"
+        assert _confidence_label({"confidence": 0.69}) == "moderate"
+
+    def test_emerging(self):
+        assert _confidence_label({"confidence": 0.0}) == "emerging"
+        assert _confidence_label({"confidence": 0.49}) == "emerging"
+        assert _confidence_label({}) == "emerging"
+
+    def test_non_numeric_confidence_falls_back_to_emerging(self):
+        assert _confidence_label({"confidence": "high"}) == "emerging"
+        assert _confidence_label({"confidence": None}) == "emerging"
+
+    def test_patterns_path_string_label(self):
+        data = {"patterns": [{"confidence": "strong"}], "confidence": 0.1}
+        assert _confidence_label(data) == "strong"
+
+    def test_patterns_path_invalid_string_falls_back_to_emerging(self):
+        data = {"patterns": [{"confidence": "0.8"}]}
+        assert _confidence_label(data) == "emerging"
+
+    def test_patterns_path_float_confidence(self):
+        data = {"patterns": [{"confidence": 0.8}]}
+        assert _confidence_label(data) == "strong"
+
+    def test_patterns_path_float_moderate(self):
+        data = {"patterns": [{"confidence": 0.6}]}
+        assert _confidence_label(data) == "moderate"
+
+    def test_patterns_path_float_emerging(self):
+        data = {"patterns": [{"confidence": 0.3}]}
+        assert _confidence_label(data) == "emerging"
+
+    def test_patterns_empty_falls_through_to_float(self):
+        data = {"patterns": [], "confidence": 0.8}
+        assert _confidence_label(data) == "strong"
+
 
 def _create_thing(client, title: str, checkin_date: str | None = None, active: bool = True) -> dict:
     payload = {"title": title, "active": active}
@@ -89,6 +134,18 @@ class TestBriefing:
         cost_pref = next((p for p in prefs if p["title"] == "Cost conscious"), None)
         assert cost_pref is not None
         assert cost_pref["confidence_label"] == "strong"
+
+    def test_preference_cap_at_five(self, client):
+        """learned_preferences is capped at 5 even when more preferences exist."""
+        for i in range(6):
+            client.post("/api/things", json={
+                "title": f"Preference {i}",
+                "type_hint": "preference",
+                "data": {"confidence": 0.6},
+            })
+        resp = client.get("/api/briefing")
+        prefs = resp.json()["learned_preferences"]
+        assert len(prefs) <= 5
 
     def test_things_without_checkin_date_excluded(self, client):
         _create_thing(client, "No Date Thing")

--- a/backend/tests/test_briefing.py
+++ b/backend/tests/test_briefing.py
@@ -58,14 +58,11 @@ def _create_thing(client, title: str, checkin_date: str | None = None, active: b
 
 
 def _briefing_titles(data: dict) -> list[str]:
-    """Extract all Thing titles from the new briefing response shape."""
     titles = []
-    if data.get("the_one_thing"):
-        titles.append(data["the_one_thing"]["thing"]["title"])
-    for item in data.get("secondary", []):
-        titles.append(item["thing"]["title"])
-    for item in data.get("parking_lot", []):
-        titles.append(item["title"])
+    if t := data.get("the_one_thing"):
+        titles.append(t["thing"]["title"])
+    titles.extend(item["thing"]["title"] for item in data.get("secondary", []))
+    titles.extend(item["title"] for item in data.get("parking_lot", []))
     return titles
 
 

--- a/backend/tests/test_response_metrics.py
+++ b/backend/tests/test_response_metrics.py
@@ -36,9 +36,6 @@ class TestResponseMetricsMiddleware:
 
     def test_middleware_logs_request(self, client):
         """Verify the middleware is active by checking it records timings."""
-        from backend.response_metrics import MetricsStore, ResponseMetricsMiddleware
-        from unittest.mock import patch
-
         fresh_store = MetricsStore()
         with patch("backend.response_metrics.metrics_store", fresh_store):
             for _ in range(3):

--- a/docs/API.md
+++ b/docs/API.md
@@ -177,7 +177,7 @@ The primary interface to Reli's multi-agent pipeline.
 
 ## Briefing (`/api/briefing`)
 
-Daily briefing: check-in due Things + sweep findings.
+Daily briefing: check-in due Things, sweep findings, and learned preferences.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -188,6 +188,27 @@ Daily briefing: check-in due Things + sweep findings.
 | POST | `/api/briefing/findings` | Create a sweep finding |
 | PATCH | `/api/briefing/findings/{finding_id}/dismiss` | Dismiss a finding |
 | POST | `/api/briefing/findings/{finding_id}/snooze` | Snooze a finding |
+
+**`GET /api/briefing` response shape:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | string | Briefing date (YYYY-MM-DD) |
+| `the_one_thing` | BriefingItem \| null | Highest-priority item |
+| `secondary` | BriefingItem[] | Secondary priority items |
+| `parking_lot` | object[] | Deferred items |
+| `findings` | SweepFinding[] | Active sweep findings |
+| `learned_preferences` | LearnedPreference[] | Inferred preferences (≤5), shown in "I Noticed" section |
+| `total` | int | Total item count |
+| `stats` | object | Per-type counts |
+
+**`LearnedPreference` shape:**
+
+| Field | Type | Values |
+|-------|------|--------|
+| `id` | string | Thing ID |
+| `title` | string | Preference description |
+| `confidence_label` | string | `"emerging"`, `"moderate"`, `"strong"` |
 
 ---
 

--- a/docs/SECOND_BRAIN.md
+++ b/docs/SECOND_BRAIN.md
@@ -146,6 +146,10 @@ Stored as regular Things with `type_hint: preference`. They have:
 | "I'll handle budget later, venue first" | "Does venue-before-budget for events" |
 | "Just book the cheap one" | "Optimizes for cost on travel" |
 
+Learned preferences surface in the daily briefing under the **"I Noticed"**
+section, where users can confirm or correct them. See
+[Sweep output → "I Noticed"](#i-noticed--learned-preferences-in-the-briefing).
+
 ### Context integration
 
 When the user mentions a topic, the context agent surfaces relevant preference
@@ -339,6 +343,23 @@ sidebar. It's a short, prioritized list:
 
 The user can dismiss, snooze, or act on each item. Acting opens the relevant
 Thing in the chat context.
+
+### "I Noticed" — learned preferences in the briefing
+
+The briefing also includes an **"I Noticed"** section showing up to 5 learned
+preferences (Things with `type_hint: preference`). Each preference shows:
+
+- Its title (e.g., "Prefers afternoon meetings")
+- A confidence label: `emerging`, `moderate`, or `strong`
+- Feedback buttons: **"That's right"** (reinforces) / **"Not really"** (flags)
+
+The confidence label is derived from the preference Thing's `confidence` field:
+≥0.7 → `strong`, ≥0.5 → `moderate`, else `emerging`. If the preference uses the
+`patterns` list format, the first pattern's confidence is used.
+
+Feedback routes to the existing preference feedback endpoint
+(`POST /api/preferences/{id}/feedback`) without requiring a separate API call
+from the user.
 
 ### Implementation notes
 

--- a/frontend/e2e/visual.spec.ts
+++ b/frontend/e2e/visual.spec.ts
@@ -95,7 +95,17 @@ async function interceptApi(
 
   // Briefing
   await page.route('**/api/briefing', route =>
-    route.fulfill({ json: { things: [], findings: [] }, status: 200 })
+    route.fulfill({
+      json: {
+        things: [],
+        findings: [],
+        learned_preferences: [
+          { id: 'pref-1', title: 'Prefers async communication', confidence_label: 'strong' },
+          { id: 'pref-2', title: 'Cost-conscious with subscriptions', confidence_label: 'moderate' },
+        ],
+      },
+      status: 200,
+    })
   )
 
   // Chat history (session ID is dynamic, match any)

--- a/frontend/src/__tests__/LearnedPreferenceCard.test.tsx
+++ b/frontend/src/__tests__/LearnedPreferenceCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LearnedPreferenceCard } from '../components/BriefingPanel'
+
+const mockPref = { id: 'pref-1', title: 'Prefers async communication', confidence_label: 'strong' }
+
+describe('LearnedPreferenceCard', () => {
+  it('renders title and confidence label', () => {
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={vi.fn()} />)
+    expect(screen.getByText('Prefers async communication')).toBeInTheDocument()
+    expect(screen.getByText('strong')).toBeInTheDocument()
+  })
+
+  it('shows feedback buttons before any feedback', () => {
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={vi.fn()} />)
+    expect(screen.getByText("That's right")).toBeInTheDocument()
+    expect(screen.getByText('Not really')).toBeInTheDocument()
+  })
+
+  it("calls onFeedback(id, true) when \"That's right\" clicked", () => {
+    const onFeedback = vi.fn()
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={onFeedback} />)
+    fireEvent.click(screen.getByText("That's right"))
+    expect(onFeedback).toHaveBeenCalledWith('pref-1', true)
+  })
+
+  it("calls onFeedback(id, false) when 'Not really' clicked", () => {
+    const onFeedback = vi.fn()
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={onFeedback} />)
+    fireEvent.click(screen.getByText('Not really'))
+    expect(onFeedback).toHaveBeenCalledWith('pref-1', false)
+  })
+
+  it("shows 'Thanks!' and hides buttons after positive feedback", () => {
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={vi.fn()} />)
+    fireEvent.click(screen.getByText("That's right"))
+    expect(screen.getByText('Thanks!')).toBeInTheDocument()
+    expect(screen.queryByText("That's right")).not.toBeInTheDocument()
+    expect(screen.queryByText('Not really')).not.toBeInTheDocument()
+  })
+
+  it("shows 'Got it' after negative feedback", () => {
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={vi.fn()} />)
+    fireEvent.click(screen.getByText('Not really'))
+    expect(screen.getByText('Got it')).toBeInTheDocument()
+  })
+
+  it('does not call onFeedback a second time after feedback given', () => {
+    const onFeedback = vi.fn()
+    render(<LearnedPreferenceCard pref={mockPref} onFeedback={onFeedback} />)
+    fireEvent.click(screen.getByText("That's right"))
+    // After feedback sent, buttons are gone — no second click possible
+    expect(onFeedback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -147,7 +147,7 @@ const CONFIDENCE_COLORS: Record<string, string> = {
   emerging: 'bg-blue-400',
 }
 
-function LearnedPreferenceCard({
+export function LearnedPreferenceCard({
   pref,
   onFeedback,
 }: {

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -1,6 +1,7 @@
+import { useState, useCallback } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
-import type { SweepFinding, BriefingItem } from '../store'
+import type { SweepFinding, BriefingItem, LearnedPreference } from '../store'
 
 const FINDING_TYPE_ICONS: Record<string, string> = {
   approaching_date: '\u23F0',
@@ -140,6 +141,66 @@ function FindingCard({ finding, onDismiss, onSnooze, onAct }: {
   )
 }
 
+const CONFIDENCE_COLORS: Record<string, string> = {
+  strong: 'bg-green-500',
+  moderate: 'bg-yellow-500',
+  emerging: 'bg-blue-400',
+}
+
+function LearnedPreferenceCard({
+  pref,
+  onFeedback,
+}: {
+  pref: LearnedPreference
+  onFeedback: (id: string, accurate: boolean) => void
+}) {
+  const [feedbackSent, setFeedbackSent] = useState<boolean | null>(null)
+  const dotColor = CONFIDENCE_COLORS[pref.confidence_label] ?? 'bg-primary'
+
+  const handleFeedback = useCallback((accurate: boolean) => {
+    if (feedbackSent !== null) return
+    setFeedbackSent(accurate)
+    onFeedback(pref.id, accurate)
+  }, [feedbackSent, onFeedback, pref.id])
+
+  return (
+    <div className="group rounded-xl bg-surface-container-low hover:bg-surface-container-high/60 transition-colors overflow-hidden">
+      <div className="flex items-start gap-3 py-3 px-4">
+        <div className={`w-1 self-stretch rounded-full shrink-0 ${dotColor}`} />
+        <div className="flex items-center gap-2 mt-0.5 shrink-0">
+          <span className="text-sm">{'\u{1F9E0}'}</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-on-surface leading-snug">{pref.title}</p>
+          <div className="flex items-center gap-2 mt-1.5">
+            <span className="text-xs text-on-surface-variant capitalize">{pref.confidence_label}</span>
+            {feedbackSent === null ? (
+              <>
+                <button
+                  onClick={() => handleFeedback(true)}
+                  className="text-xs text-primary hover:text-primary/80 font-medium"
+                >
+                  That&apos;s right
+                </button>
+                <button
+                  onClick={() => handleFeedback(false)}
+                  className="text-xs text-on-surface-variant hover:text-ideas"
+                >
+                  Not really
+                </button>
+              </>
+            ) : (
+              <span className="text-xs text-on-surface-variant">
+                {feedbackSent ? 'Thanks!' : 'Got it'}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function StatCard({ label, value, suffix, accent }: { label: string; value: number | string; suffix?: string; accent?: string }) {
   return (
     <div className="glass rounded-xl p-4 flex-1 min-w-0 text-center">
@@ -154,19 +215,21 @@ function StatCard({ label, value, suffix, accent }: { label: string; value: numb
 
 export function BriefingPanel() {
   const {
-    theOneThing, secondaryItems, briefingStats, findings,
-    setRightView, openThingDetail, dismissFinding, snoozeFinding, actOnFinding,
+    theOneThing, secondaryItems, briefingStats, findings, learnedPreferences,
+    setRightView, openThingDetail, dismissFinding, snoozeFinding, actOnFinding, submitPreferenceFeedback,
   } = useStore(
     useShallow(s => ({
       theOneThing: s.theOneThing,
       secondaryItems: s.secondaryItems,
       briefingStats: s.briefingStats,
       findings: s.findings,
+      learnedPreferences: s.learnedPreferences,
       setRightView: s.setRightView,
       openThingDetail: s.openThingDetail,
       dismissFinding: s.dismissFinding,
       snoozeFinding: s.snoozeFinding,
       actOnFinding: s.actOnFinding,
+      submitPreferenceFeedback: s.submitPreferenceFeedback,
     }))
   )
 
@@ -176,7 +239,7 @@ export function BriefingPanel() {
     snoozeFinding(id, tomorrow.toISOString().slice(0, 10))
   }
 
-  const hasContent = theOneThing || secondaryItems.length > 0 || findings.length > 0
+  const hasContent = theOneThing || secondaryItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0
 
   return (
     <div className="flex-1 flex flex-col bg-canvas min-w-0 min-h-0">
@@ -230,6 +293,27 @@ export function BriefingPanel() {
                   key={item.thing.id}
                   item={item}
                   onClick={() => openThingDetail(item.thing.id)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* I Noticed — learned preferences */}
+        {learnedPreferences.length > 0 && (
+          <section className="px-6 pb-6">
+            <div className="flex items-center gap-2 mb-3">
+              <p className="text-label text-on-surface-variant">I Noticed</p>
+              <span className="text-[10px] text-on-surface-variant bg-surface-container-high px-1.5 py-0.5 rounded-full">
+                AI-Learned
+              </span>
+            </div>
+            <div className="space-y-2">
+              {learnedPreferences.map(pref => (
+                <LearnedPreferenceCard
+                  key={pref.id}
+                  pref={pref}
+                  onFeedback={submitPreferenceFeedback}
                 />
               ))}
             </div>

--- a/frontend/src/generated/api-types.ts
+++ b/frontend/src/generated/api-types.ts
@@ -88,6 +88,16 @@ export interface ChatMessage {
   timestamp: string
 }
 
+export interface UsageInfo {
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+  cost_usd: number
+  api_calls: number
+  model: string
+  per_call_usage: CallUsage[]
+}
+
 export interface ModelUsage {
   model: string
   prompt_tokens: number
@@ -104,16 +114,6 @@ export interface SessionUsage {
   api_calls: number
   cost_usd: number
   per_model: ModelUsage[]
-}
-
-export interface UsageInfo {
-  prompt_tokens: number
-  completion_tokens: number
-  total_tokens: number
-  cost_usd: number
-  api_calls: number
-  model: string
-  per_call_usage: CallUsage[]
 }
 
 export interface ChatResponse {
@@ -139,6 +139,12 @@ export interface SweepFinding {
   thing: Thing | null
 }
 
+export interface LearnedPreference {
+  id: string
+  title: string
+  confidence_label: string
+}
+
 export interface BriefingItem {
   thing: Record<string, unknown>
   importance: number
@@ -153,6 +159,7 @@ export interface BriefingResponse {
   secondary: BriefingItem[]
   parking_lot: Record<string, unknown>[]
   findings: SweepFinding[]
+  learned_preferences: LearnedPreference[]
   total: number
   stats: Record<string, number>
 }
@@ -455,6 +462,16 @@ export const ChatMessageSchema = z.object({
   timestamp: z.string(),
 })
 
+export const UsageInfoSchema = z.object({
+  prompt_tokens: z.number().default(0),
+  completion_tokens: z.number().default(0),
+  total_tokens: z.number().default(0),
+  cost_usd: z.number().default(0.0),
+  api_calls: z.number().default(0),
+  model: z.string().default(""),
+  per_call_usage: z.array(CallUsageSchema).default([]),
+})
+
 export const ModelUsageSchema = z.object({
   model: z.string(),
   prompt_tokens: z.number().default(0),
@@ -471,16 +488,6 @@ export const SessionUsageSchema = z.object({
   api_calls: z.number().default(0),
   cost_usd: z.number().default(0.0),
   per_model: z.array(ModelUsageSchema).default([]),
-})
-
-export const UsageInfoSchema = z.object({
-  prompt_tokens: z.number().default(0),
-  completion_tokens: z.number().default(0),
-  total_tokens: z.number().default(0),
-  cost_usd: z.number().default(0.0),
-  api_calls: z.number().default(0),
-  model: z.string().default(""),
-  per_call_usage: z.array(CallUsageSchema).default([]),
 })
 
 export const ChatResponseSchema = z.object({
@@ -506,6 +513,12 @@ export const SweepFindingSchema = z.object({
   thing: ThingSchema.nullable().default(null),
 })
 
+export const LearnedPreferenceSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  confidence_label: z.string(),
+})
+
 export const BriefingItemSchema = z.object({
   thing: z.record(z.string(), z.unknown()),
   importance: z.number(),
@@ -520,6 +533,7 @@ export const BriefingResponseSchema = z.object({
   secondary: z.array(BriefingItemSchema).default([]),
   parking_lot: z.array(z.record(z.string(), z.unknown())).default([]),
   findings: z.array(SweepFindingSchema).default([]),
+  learned_preferences: z.array(LearnedPreferenceSchema).default([]),
   total: z.number(),
   stats: z.record(z.string(), z.number()).default({}),
 })

--- a/frontend/src/offline/cache-briefing.ts
+++ b/frontend/src/offline/cache-briefing.ts
@@ -1,15 +1,20 @@
-import type { Thing, SweepFinding } from '../store'
+import type { Thing, SweepFinding, LearnedPreference } from '../store'
 import { setCacheEntry, getCacheEntry } from './idb'
 
 interface CachedBriefing {
   things: Thing[]
   findings: SweepFinding[]
+  learnedPreferences: LearnedPreference[]
 }
 
 const CACHE_KEY = 'briefing'
 
-export async function cacheBriefing(things: Thing[], findings: SweepFinding[]): Promise<void> {
-  await setCacheEntry(CACHE_KEY, { things, findings })
+export async function cacheBriefing(
+  things: Thing[],
+  findings: SweepFinding[],
+  learnedPreferences: LearnedPreference[],
+): Promise<void> {
+  await setCacheEntry(CACHE_KEY, { things, findings, learnedPreferences })
 }
 
 export async function getCachedBriefing(): Promise<CachedBriefing | undefined> {

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -23,12 +23,14 @@ export {
   MergeResultSchema,
   ConnectionSuggestionThingSchema,
   ConnectionSuggestionSchema,
+  LearnedPreferenceSchema,
   ModelUsageSchema,
 } from './generated/api-types'
 
 import {
   ThingSchema,
   SweepFindingSchema as GeneratedSweepFindingSchema,
+  LearnedPreferenceSchema as GeneratedLearnedPreferenceSchema,
   ModelUsageSchema,
 } from './generated/api-types'
 
@@ -126,6 +128,7 @@ export const BriefingResponseSchema = z.object({
   secondary: z.array(BriefingItemSchema).optional(),
   parking_lot: z.array(z.record(z.string(), z.unknown())).optional(),
   findings: z.array(GeneratedSweepFindingSchema).optional(),
+  learned_preferences: z.array(GeneratedLearnedPreferenceSchema).optional(),
   total: z.number().optional(),
   stats: z.record(z.string(), z.number()).optional(),
 })

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -769,11 +769,11 @@ export const useStore = create<ReliState>((set, get) => ({
         overdue: data.stats.overdue ?? 0,
       } : null
       set({ briefing: things, theOneThing, secondaryItems, briefingStats, findings, learnedPreferences })
-      cacheBriefing(things, findings).catch(() => {})
+      cacheBriefing(things, findings, learnedPreferences).catch(() => {})
     } catch {
       if (!navigator.onLine) {
         const cached = await getCachedBriefing().catch(() => undefined)
-        if (cached) set({ briefing: cached.things, findings: cached.findings })
+        if (cached) set({ briefing: cached.things, findings: cached.findings, learnedPreferences: cached.learnedPreferences ?? [] })
       }
     }
   },

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -47,6 +47,7 @@ export type {
   FocusRecommendation,
   ConflictAlert,
   SweepFinding,
+  LearnedPreference,
   MorningBriefingItem,
   MorningBriefingFinding,
   MorningBriefingContent,
@@ -79,6 +80,7 @@ import type {
   FocusRecommendation,
   ConflictAlert,
   SweepFinding,
+  LearnedPreference,
   MorningBriefing,
   BriefingPreferences,
   Nudge,
@@ -211,6 +213,7 @@ interface ReliState {
   secondaryItems: BriefingItem[]
   briefingStats: BriefingStats | null
   findings: SweepFinding[]
+  learnedPreferences: LearnedPreference[]
   messages: ChatMessage[]
   sessionId: string
   sessionStats: SessionStats
@@ -509,6 +512,7 @@ export const useStore = create<ReliState>((set, get) => ({
   secondaryItems: [],
   briefingStats: null,
   findings: [],
+  learnedPreferences: [],
   messages: [],
   sessionId: '',
   sessionStats: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, api_calls: 0, cost_usd: 0, per_model: [] },
@@ -758,12 +762,13 @@ export const useStore = create<ReliState>((set, get) => ({
       }))
       for (const item of secondaryItems) things.push(item.thing)
       const findings = data.findings ?? []
+      const learnedPreferences = data.learned_preferences ?? []
       const briefingStats: BriefingStats | null = data.stats ? {
         active_things: data.stats.active_things ?? 0,
         checkin_due: data.stats.checkin_due ?? 0,
         overdue: data.stats.overdue ?? 0,
       } : null
-      set({ briefing: things, theOneThing, secondaryItems, briefingStats, findings })
+      set({ briefing: things, theOneThing, secondaryItems, briefingStats, findings, learnedPreferences })
       cacheBriefing(things, findings).catch(() => {})
     } catch {
       if (!navigator.onLine) {

--- a/scripts/generate_types.py
+++ b/scripts/generate_types.py
@@ -43,6 +43,7 @@ EXPORTED_MODELS: dict[str, str] = {
     "ModelUsage": "ModelUsage",
     "SessionUsage": "SessionUsage",
     "SweepFinding": "SweepFinding",
+    "LearnedPreference": "LearnedPreference",
     "BriefingItem": "BriefingItem",
     "BriefingResponse": "BriefingResponse",
     "StaleItem": "StaleItem",


### PR DESCRIPTION
## Summary

- Surfaces active preference Things (learned by the sweep agent) in the daily briefing under a new "I Noticed" section
- Each card shows the preference title, a confidence label (emerging/moderate/strong), and "That's right" / "Not really" feedback buttons
- Feedback buttons call the existing `submitPreferenceFeedback` API, providing immediate local confirmation ("Thanks!" / "Got it") without reloading the briefing

## Changes

### Backend
- `backend/models.py` — added `LearnedPreference` Pydantic model (`id`, `title`, `confidence_label`)
- `backend/routers/briefing.py` — added `_confidence_label()` helper; `get_briefing()` now filters `type_hint='preference'` from `all_active` (no extra DB query) and returns up to 5 as `learned_preferences`
- `backend/tests/test_briefing.py` — two new tests: preferences appear in response, confidence label derived correctly
- `backend/tests/test_api_contracts.py` — `assert_briefing_response_shape` asserts `learned_preferences` field shape

### Frontend
- `scripts/generate_types.py` — added `LearnedPreference` to `EXPORTED_MODELS`
- `frontend/src/generated/api-types.ts` — regenerated (includes `LearnedPreference` interface + Zod schema)
- `frontend/src/schemas.ts` — extended `BriefingResponseSchema` with `learned_preferences: z.array(LearnedPreferenceSchema).optional()`
- `frontend/src/store.ts` — added `learnedPreferences: LearnedPreference[]` state, parsed from briefing response
- `frontend/src/components/BriefingPanel.tsx` — added `LearnedPreferenceCard` component and "I Noticed" section (placed before "Findings from Sweep")

## Validation

| Check | Result |
|-------|--------|
| `tsc -b` (via build) | ✅ 0 errors |
| ESLint | ✅ 0 errors (3 pre-existing warnings, none in changed files) |
| `check:types-fresh` | ✅ generated types match backend |
| Frontend tests | ✅ 236 passed |
| Backend tests | ✅ 43 passed |
| Production build | ✅ 88 modules, no errors |

## Notes

- The "I Noticed" section is positioned before "Findings from Sweep" — preferences are about user identity, not just task state
- Confidence dot colors mirror the existing `PreferencePatterns.tsx` palette for visual consistency with the Settings panel
- Feedback card uses local `feedbackSent` state for instant UX; does not trigger a briefing reload
- Max 5 preferences shown; full list available in Settings

Fixes #286