### PR TITLE
feat: redesign BriefingPanel with card layout, inline actions, and NLP summary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,13 +86,12 @@ function App() {
 
     // Handle OAuth callback redirect
     const params = new URLSearchParams(window.location.search)
-    if (params.has('calendar_connected') || params.has('calendar_error')) {
+    const calendarRedirected = params.has('calendar_connected') || params.has('calendar_error')
+    const gmailRedirected = params.has('gmail_connected') || params.has('gmail_error')
+    if (calendarRedirected || gmailRedirected) {
       window.history.replaceState({}, '', '/')
-      fetchCalendarStatus()
-    }
-    if (params.has('gmail_connected') || params.has('gmail_error')) {
-      window.history.replaceState({}, '', '/')
-      fetchGmailStatus()
+      if (calendarRedirected) fetchCalendarStatus()
+      if (gmailRedirected) fetchGmailStatus()
     }
 
     return () => clearInterval(interval)

--- a/frontend/src/__tests__/BriefingPanel.test.tsx
+++ b/frontend/src/__tests__/BriefingPanel.test.tsx
@@ -1,46 +1,85 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { DueTodayRow } from '../components/BriefingPanel'
+import { DueTodayRow, TodayEventRow } from '../components/BriefingPanel'
+import type { BriefingItem, CalendarEvent } from '../store'
 
-const mockItem = {
-  thing: { id: 'thing-1', title: 'Write proposal', active: true },
+const mockItem: BriefingItem = {
+  thing: { id: 'thing-1', title: 'Write proposal', active: true } as BriefingItem['thing'],
   importance: 1,
   urgency: 0.8,
   score: 0.9,
   reasons: ['Due today'],
 }
 
+const makeEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  id: 'e1',
+  summary: 'Team standup',
+  start: '2026-04-18T09:30:00Z',
+  end: '2026-04-18T10:00:00Z',
+  all_day: false,
+  location: null,
+  status: 'confirmed',
+  ...overrides,
+})
+
 describe('DueTodayRow', () => {
   it('renders thing title and reason', () => {
-    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    render(<DueTodayRow item={mockItem} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
     expect(screen.getByText('Write proposal')).toBeInTheDocument()
     expect(screen.getByText('Due today')).toBeInTheDocument()
   })
 
   it('calls onDone with thing id when Done clicked', () => {
     const onDone = vi.fn()
-    render(<DueTodayRow item={mockItem as never} onDone={onDone} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    render(<DueTodayRow item={mockItem} onDone={onDone} onSnooze={vi.fn()} onChat={vi.fn()} />)
     fireEvent.click(screen.getByText('Done'))
     expect(onDone).toHaveBeenCalledWith('thing-1')
   })
 
   it('calls onSnooze with thing id when Snooze clicked', () => {
     const onSnooze = vi.fn()
-    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={onSnooze} onChat={vi.fn()} />)
+    render(<DueTodayRow item={mockItem} onDone={vi.fn()} onSnooze={onSnooze} onChat={vi.fn()} />)
     fireEvent.click(screen.getByText('Snooze'))
     expect(onSnooze).toHaveBeenCalledWith('thing-1')
   })
 
   it('calls onChat with thing id and title when Chat clicked', () => {
     const onChat = vi.fn()
-    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={onChat} />)
+    render(<DueTodayRow item={mockItem} onDone={vi.fn()} onSnooze={vi.fn()} onChat={onChat} />)
     fireEvent.click(screen.getByText('Chat'))
     expect(onChat).toHaveBeenCalledWith('thing-1', 'Write proposal')
   })
 
   it('renders without reason when reasons array is empty', () => {
-    const itemNoReasons = { ...mockItem, reasons: [] }
-    render(<DueTodayRow item={itemNoReasons as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    const itemNoReasons: BriefingItem = { ...mockItem, reasons: [] }
+    render(<DueTodayRow item={itemNoReasons} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
     expect(screen.getByText('Write proposal')).toBeInTheDocument()
+  })
+})
+
+describe('TodayEventRow', () => {
+  it('renders event summary', () => {
+    render(<TodayEventRow event={makeEvent()} />)
+    expect(screen.getByText('Team standup')).toBeInTheDocument()
+  })
+
+  it('shows "All day" for all-day events', () => {
+    render(<TodayEventRow event={makeEvent({ all_day: true })} />)
+    expect(screen.getByText('All day')).toBeInTheDocument()
+  })
+
+  it('renders location when present', () => {
+    render(<TodayEventRow event={makeEvent({ location: 'Room 3B' })} />)
+    expect(screen.getByText('Room 3B')).toBeInTheDocument()
+  })
+
+  it('omits location when null', () => {
+    render(<TodayEventRow event={makeEvent({ location: null })} />)
+    expect(screen.queryByText('Room 3B')).not.toBeInTheDocument()
+  })
+
+  it('falls back to raw string for malformed date', () => {
+    render(<TodayEventRow event={makeEvent({ start: 'not-a-date', all_day: false })} />)
+    expect(screen.getByText('not-a-date')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/BriefingPanel.test.tsx
+++ b/frontend/src/__tests__/BriefingPanel.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DueTodayRow } from '../components/BriefingPanel'
+
+const mockItem = {
+  thing: { id: 'thing-1', title: 'Write proposal', active: true },
+  importance: 1,
+  urgency: 0.8,
+  score: 0.9,
+  reasons: ['Due today'],
+}
+
+describe('DueTodayRow', () => {
+  it('renders thing title and reason', () => {
+    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    expect(screen.getByText('Write proposal')).toBeInTheDocument()
+    expect(screen.getByText('Due today')).toBeInTheDocument()
+  })
+
+  it('calls onDone with thing id when Done clicked', () => {
+    const onDone = vi.fn()
+    render(<DueTodayRow item={mockItem as never} onDone={onDone} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    fireEvent.click(screen.getByText('Done'))
+    expect(onDone).toHaveBeenCalledWith('thing-1')
+  })
+
+  it('calls onSnooze with thing id when Snooze clicked', () => {
+    const onSnooze = vi.fn()
+    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={onSnooze} onChat={vi.fn()} />)
+    fireEvent.click(screen.getByText('Snooze'))
+    expect(onSnooze).toHaveBeenCalledWith('thing-1')
+  })
+
+  it('calls onChat with thing id and title when Chat clicked', () => {
+    const onChat = vi.fn()
+    render(<DueTodayRow item={mockItem as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={onChat} />)
+    fireEvent.click(screen.getByText('Chat'))
+    expect(onChat).toHaveBeenCalledWith('thing-1', 'Write proposal')
+  })
+
+  it('renders without reason when reasons array is empty', () => {
+    const itemNoReasons = { ...mockItem, reasons: [] }
+    render(<DueTodayRow item={itemNoReasons as never} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} />)
+    expect(screen.getByText('Write proposal')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/__tests__/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import type { Nudge } from '../generated/api-types'
 
 type Msg = {
@@ -17,6 +17,8 @@ type Msg = {
   model?: string | null
 }
 
+const mockClearChatPrefill = vi.fn()
+
 const mockStore = {
   messages: [] as Msg[],
   things: [] as unknown[],
@@ -31,6 +33,8 @@ const mockStore = {
   googleSeedLoading: false,
   calendarStatus: { configured: false, connected: false },
   nudges: [] as Nudge[],
+  chatPrefill: null as string | null,
+  clearChatPrefill: mockClearChatPrefill,
 }
 
 const mockDismissNudge = vi.fn()
@@ -72,6 +76,7 @@ beforeEach(() => {
   mockStore.chatLoading = false
   mockStore.historyLoading = false
   mockStore.hasMoreHistory = false
+  mockClearChatPrefill.mockReset()
 })
 
 describe('ChatPanel', () => {
@@ -182,5 +187,16 @@ describe('ChatPanel', () => {
     expect(screen.getByText('Context Active')).toBeInTheDocument()
     expect(screen.getAllByText('Auth Refactor').length).toBeGreaterThan(0)
     mockStore.messages = []
+  })
+
+  it('populates textarea from chatPrefill and clears it', async () => {
+    mockStore.chatPrefill = 'Let\'s talk about "Write proposal"'
+    render(<ChatPanel />)
+    const textarea = screen.getByPlaceholderText('Message Reli…')
+    await waitFor(() => {
+      expect(textarea).toHaveValue('Let\'s talk about "Write proposal"')
+    })
+    expect(mockClearChatPrefill).toHaveBeenCalledTimes(1)
+    mockStore.chatPrefill = null
   })
 })

--- a/frontend/src/__tests__/store.test.ts
+++ b/frontend/src/__tests__/store.test.ts
@@ -120,3 +120,21 @@ describe('store: clearError', () => {
     expect(useStore.getState().error).toBeNull()
   })
 })
+
+describe('store: openChatWithContext', () => {
+  it('sets chatPrefill, rightView, mobileView', () => {
+    useStore.getState().openChatWithContext('thing-1', 'Write proposal')
+    const state = useStore.getState()
+    expect(state.chatPrefill).toBe('Let\'s talk about "Write proposal"')
+    expect(state.rightView).toBe('chat')
+    expect(state.mobileView).toBe('chat')
+  })
+})
+
+describe('store: clearChatPrefill', () => {
+  it('nulls chatPrefill', () => {
+    useStore.setState({ chatPrefill: 'something' })
+    useStore.getState().clearChatPrefill()
+    expect(useStore.getState().chatPrefill).toBeNull()
+  })
+})

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -43,10 +43,13 @@ function SectionCard({ title, accent, children }: {
   )
 }
 
-function TodayEventRow({ event }: { event: CalendarEvent }) {
-  const startTime = event.all_day ? 'All day' : new Date(event.start).toLocaleTimeString('en-US', {
-    hour: 'numeric', minute: '2-digit',
-  })
+export function TodayEventRow({ event }: { event: CalendarEvent }) {
+  const parsed = new Date(event.start)
+  const startTime = event.all_day
+    ? 'All day'
+    : isNaN(parsed.getTime())
+      ? event.start
+      : parsed.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
   return (
     <div className="flex items-start gap-3 py-2 px-4">
       <span className="text-xs text-on-surface-variant tabular-nums shrink-0 pt-0.5 w-16">{startTime}</span>
@@ -226,7 +229,7 @@ function StatCard({ label, value, suffix, accent }: { label: string; value: numb
 export function BriefingPanel() {
   const {
     theOneThing, secondaryItems, briefingStats, findings, learnedPreferences, nudges,
-    morningBriefing, calendarEvents,
+    morningBriefing, calendarEvents, error,
     setRightView, dismissFinding, snoozeFinding, actOnFinding,
     submitPreferenceFeedback, updateThing, snoozeThing, openChatWithContext,
   } = useStore(
@@ -239,6 +242,7 @@ export function BriefingPanel() {
       nudges: s.nudges,
       morningBriefing: s.morningBriefing,
       calendarEvents: s.calendarEvents,
+      error: s.error,
       setRightView: s.setRightView,
       dismissFinding: s.dismissFinding,
       snoozeFinding: s.snoozeFinding,
@@ -266,7 +270,7 @@ export function BriefingPanel() {
     snoozeThing(id, tomorrow.toISOString().slice(0, 10))
   }
 
-  const todayISO = new Date().toISOString().slice(0, 10)
+  const todayISO = new Date().toLocaleDateString('en-CA')  // YYYY-MM-DD in local TZ
   const todayEvents = calendarEvents.filter(e => e.start.slice(0, 10) === todayISO)
 
   const dueTodayItems = [
@@ -308,6 +312,11 @@ export function BriefingPanel() {
               <NudgeBanner key={nudge.id} nudge={nudge} />
             ))}
           </section>
+        )}
+        {error && (
+          <div className="mx-6 mt-3 px-4 py-2 rounded-xl bg-error/10 text-error text-sm">
+            {error}
+          </div>
         )}
         {/* Greeting */}
         <section className="px-6 pt-8 pb-4">

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
-import type { SweepFinding, BriefingItem, LearnedPreference } from '../store'
+import type { SweepFinding, BriefingItem, LearnedPreference, CalendarEvent } from '../store'
 import { NudgeBanner } from './NudgeBanner'
 
 const FINDING_TYPE_CONFIG: Record<string, { icon: string; color: string }> = {
@@ -30,71 +30,73 @@ function getGreeting(): string {
   return 'Good Evening'
 }
 
-function urgencyLabel(urgency: number): { text: string; className: string } {
-  if (urgency >= 0.8) return { text: 'Urgent', className: 'text-ideas' }
-  if (urgency >= 0.5) return { text: 'Soon', className: 'text-events' }
-  return { text: 'Upcoming', className: 'text-on-surface-variant' }
-}
-
-function OneThingCard({ item, onClick }: { item: BriefingItem; onClick: () => void }) {
-  const urg = urgencyLabel(item.urgency)
+function SectionCard({ title, accent, children }: {
+  title: string
+  accent: string
+  children: React.ReactNode
+}) {
   return (
-    <>
-      {/* Mobile card — border-l-4 with decorative star */}
-      <button
-        onClick={onClick}
-        className="md:hidden w-full text-left relative overflow-hidden rounded-2xl p-6 bg-surface-container-high shadow-2xl border-l-4 border-primary hover:bg-surface-container-high/90 transition-colors cursor-pointer"
-      >
-        <div className="absolute top-0 right-0 p-4 opacity-10 pointer-events-none" aria-hidden>
-          <svg className="w-16 h-16 text-primary" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-          </svg>
-        </div>
-        <p className="text-[10px] font-bold uppercase tracking-widest text-primary mb-3 block">The One Thing</p>
-        <h3 className="text-2xl font-bold leading-tight text-on-surface mb-3">{item.thing.title}</h3>
-        {item.reasons.length > 0 && (
-          <p className="text-sm text-on-surface-variant">{item.reasons[0]}</p>
-        )}
-        <div className="flex items-center gap-2 mt-3">
-          <span className={`text-label font-medium ${urg.className}`}>{urg.text}</span>
-          <span className="text-label text-on-surface-variant">· Score {item.score.toFixed(1)}</span>
-        </div>
-      </button>
-      {/* Desktop card — existing glass style */}
-      <button
-        onClick={onClick}
-        className="hidden md:block w-full text-left glass rounded-2xl p-6 hover:bg-surface-container-high/80 transition-colors cursor-pointer"
-      >
-        <p className="text-label text-on-surface-variant mb-2">The One Thing</p>
-        <h3 className="text-headline text-on-surface font-semibold mb-3 leading-tight">{item.thing.title}</h3>
-        {item.reasons.length > 0 && (
-          <p className="text-body text-on-surface-variant mb-3">{item.reasons[0]}</p>
-        )}
-        <div className="flex items-center gap-3">
-          <span className={`text-label font-medium ${urg.className}`}>{urg.text}</span>
-          <span className="text-label text-on-surface-variant">Score {item.score.toFixed(1)}</span>
-        </div>
-      </button>
-    </>
+    <section className="px-6 pb-6">
+      <p className={`text-label font-semibold mb-2 ${accent}`}>{title}</p>
+      <div className="space-y-2">{children}</div>
+    </section>
   )
 }
 
-function PriorityFocusCard({ item, onClick }: { item: BriefingItem; onClick: () => void }) {
+function TodayEventRow({ event }: { event: CalendarEvent }) {
+  const startTime = event.all_day ? 'All day' : new Date(event.start).toLocaleTimeString('en-US', {
+    hour: 'numeric', minute: '2-digit',
+  })
   return (
-    <button
-      onClick={onClick}
-      className="w-full text-left rounded-xl p-4 bg-surface-container-low hover:bg-surface-container-high transition-colors cursor-pointer flex items-center gap-4"
-    >
+    <div className="flex items-start gap-3 py-2 px-4">
+      <span className="text-xs text-on-surface-variant tabular-nums shrink-0 pt-0.5 w-16">{startTime}</span>
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-on-surface font-medium truncate">{item.thing.title}</p>
-        {item.reasons.length > 0 && (
-          <p className="text-xs text-on-surface-variant mt-0.5 truncate">{item.reasons[0]}</p>
+        <p className="text-sm text-on-surface leading-snug">{event.summary}</p>
+        {event.location && (
+          <p className="text-xs text-on-surface-variant mt-0.5 truncate">{event.location}</p>
         )}
       </div>
-      <span className="gradient-cta text-xs font-medium px-3 py-1.5 rounded-lg shrink-0">
-        Focus
-      </span>
-    </button>
+    </div>
+  )
+}
+
+export function DueTodayRow({ item, onDone, onSnooze, onChat }: {
+  item: BriefingItem
+  onDone: (id: string) => void
+  onSnooze: (id: string) => void
+  onChat: (id: string, title: string) => void
+}) {
+  return (
+    <div className="group rounded-xl bg-surface-container-low hover:bg-surface-container-high/60 transition-colors overflow-hidden">
+      <div className="flex items-start gap-3 py-3 px-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-on-surface font-medium leading-snug">{item.thing.title}</p>
+          {item.reasons.length > 0 && (
+            <p className="text-xs text-on-surface-variant mt-0.5 truncate">{item.reasons[0]}</p>
+          )}
+          <div className="flex items-center gap-2 mt-1.5 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+            <button
+              onClick={() => onDone(item.thing.id)}
+              className="text-xs text-primary hover:text-primary/80 font-medium"
+            >
+              Done
+            </button>
+            <button
+              onClick={() => onSnooze(item.thing.id)}
+              className="text-xs text-on-surface-variant hover:text-on-surface"
+            >
+              Snooze
+            </button>
+            <button
+              onClick={() => onChat(item.thing.id, item.thing.title)}
+              className="text-xs text-on-surface-variant hover:text-on-surface"
+            >
+              Chat
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -224,7 +226,9 @@ function StatCard({ label, value, suffix, accent }: { label: string; value: numb
 export function BriefingPanel() {
   const {
     theOneThing, secondaryItems, briefingStats, findings, learnedPreferences, nudges,
-    setRightView, openThingDetail, dismissFinding, snoozeFinding, actOnFinding, submitPreferenceFeedback,
+    morningBriefing, calendarEvents,
+    setRightView, dismissFinding, snoozeFinding, actOnFinding,
+    submitPreferenceFeedback, updateThing, snoozeThing, openChatWithContext,
   } = useStore(
     useShallow(s => ({
       theOneThing: s.theOneThing,
@@ -233,12 +237,16 @@ export function BriefingPanel() {
       findings: s.findings,
       learnedPreferences: s.learnedPreferences,
       nudges: s.nudges,
+      morningBriefing: s.morningBriefing,
+      calendarEvents: s.calendarEvents,
       setRightView: s.setRightView,
-      openThingDetail: s.openThingDetail,
       dismissFinding: s.dismissFinding,
       snoozeFinding: s.snoozeFinding,
       actOnFinding: s.actOnFinding,
       submitPreferenceFeedback: s.submitPreferenceFeedback,
+      updateThing: s.updateThing,
+      snoozeThing: s.snoozeThing,
+      openChatWithContext: s.openChatWithContext,
     }))
   )
 
@@ -248,7 +256,25 @@ export function BriefingPanel() {
     snoozeFinding(id, tomorrow.toISOString().slice(0, 10))
   }
 
-  const hasContent = theOneThing || secondaryItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0
+  const handleDoneThing = (id: string) => {
+    updateThing(id, { active: false })
+  }
+
+  const handleSnoozeThing = (id: string) => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    snoozeThing(id, tomorrow.toISOString().slice(0, 10))
+  }
+
+  const todayISO = new Date().toISOString().slice(0, 10)
+  const todayEvents = calendarEvents.filter(e => e.start.slice(0, 10) === todayISO)
+
+  const dueTodayItems = [
+    ...(theOneThing ? [theOneThing] : []),
+    ...secondaryItems,
+  ]
+
+  const hasContent = dueTodayItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0 || todayEvents.length > 0
 
   return (
     <div className="flex-1 flex flex-col bg-canvas min-w-0 min-h-0">
@@ -292,74 +318,65 @@ export function BriefingPanel() {
           <p className="hidden md:block text-body text-on-surface-variant mt-1">{formatGreetingDate()}</p>
         </section>
 
-        {/* The One Thing hero card */}
-        {theOneThing && (
-          <section className="px-6 pb-6">
-            <OneThingCard
-              item={theOneThing}
-              onClick={() => openThingDetail(theOneThing.thing.id)}
-            />
+        {/* NLP Summary */}
+        {morningBriefing?.content.summary && (
+          <section className="px-6 pb-4">
+            <p className="text-body text-on-surface-variant italic leading-relaxed">
+              {morningBriefing.content.summary}
+            </p>
           </section>
         )}
 
-        {/* Priority Focus — first secondary item */}
-        {secondaryItems.length > 0 && (
-          <section className="px-6 pb-6">
-            <p className="text-label text-on-surface-variant mb-2">Priority Focus</p>
-            <div className="space-y-2">
-              {secondaryItems.slice(0, 3).map(item => (
-                <PriorityFocusCard
-                  key={item.thing.id}
-                  item={item}
-                  onClick={() => openThingDetail(item.thing.id)}
-                />
-              ))}
+        {/* Today's Schedule — only when calendar events exist for today */}
+        {todayEvents.length > 0 && (
+          <SectionCard title="Today's Schedule" accent="text-green-500">
+            <div className="rounded-xl bg-surface-container-low overflow-hidden">
+              {todayEvents.map(e => <TodayEventRow key={e.id} event={e} />)}
             </div>
-          </section>
+          </SectionCard>
         )}
 
-        {/* I Noticed — learned preferences */}
-        {learnedPreferences.length > 0 && (
-          <section className="px-6 pb-6">
-            <div className="flex items-center gap-2 mb-3">
-              <p className="text-label text-on-surface-variant">I Noticed</p>
-              <span className="text-[10px] text-on-surface-variant bg-surface-container-high px-1.5 py-0.5 rounded-full">
-                AI-Learned
-              </span>
-            </div>
-            <div className="space-y-2">
-              {learnedPreferences.map(pref => (
-                <LearnedPreferenceCard
-                  key={pref.id}
-                  pref={pref}
-                  onFeedback={submitPreferenceFeedback}
-                />
-              ))}
-            </div>
-          </section>
+        {/* Due Today */}
+        {dueTodayItems.length > 0 && (
+          <SectionCard title="Due Today" accent="text-indigo-400">
+            {dueTodayItems.map(item => (
+              <DueTodayRow
+                key={item.thing.id}
+                item={item}
+                onDone={handleDoneThing}
+                onSnooze={handleSnoozeThing}
+                onChat={openChatWithContext}
+              />
+            ))}
+          </SectionCard>
         )}
 
-        {/* Findings from Sweep */}
+        {/* Needs Attention */}
         {findings.length > 0 && (
-          <section className="px-6 pb-6">
-            <div className="flex items-center gap-2 mb-3">
-              <p className="text-label text-on-surface-variant">Findings from Sweep</p>
-              <span className="text-[10px] text-on-surface-variant bg-surface-container-high px-1.5 py-0.5 rounded-full">
-                AI-Generated Insights
-              </span>
-            </div>
-            <div className="space-y-2">
-              {findings.slice(0, 6).map(f => (
-                <FindingCard
-                  key={f.id}
-                  finding={f}
-                  onDismiss={dismissFinding}
-                  onSnooze={handleSnooze}
-                  onAct={actOnFinding}
-                />
-              ))}
-            </div>
-          </section>
+          <SectionCard title="Needs Attention" accent="text-amber-500">
+            {findings.slice(0, 6).map(f => (
+              <FindingCard
+                key={f.id}
+                finding={f}
+                onDismiss={dismissFinding}
+                onSnooze={handleSnooze}
+                onAct={actOnFinding}
+              />
+            ))}
+          </SectionCard>
+        )}
+
+        {/* I Noticed */}
+        {learnedPreferences.length > 0 && (
+          <SectionCard title="I Noticed" accent="text-purple-400">
+            {learnedPreferences.map(pref => (
+              <LearnedPreferenceCard
+                key={pref.id}
+                pref={pref}
+                onFeedback={submitPreferenceFeedback}
+              />
+            ))}
+          </SectionCard>
         )}
 
         {/* Stats footer */}

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -254,21 +254,19 @@ export function BriefingPanel() {
     }))
   )
 
-  const handleSnooze = (id: string) => {
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    snoozeFinding(id, tomorrow.toISOString().slice(0, 10))
+  const getTomorrowISO = () => {
+    const d = new Date()
+    d.setDate(d.getDate() + 1)
+    return d.toISOString().slice(0, 10)
   }
+
+  const handleSnooze = (id: string) => snoozeFinding(id, getTomorrowISO())
 
   const handleDoneThing = (id: string) => {
     updateThing(id, { active: false })
   }
 
-  const handleSnoozeThing = (id: string) => {
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    snoozeThing(id, tomorrow.toISOString().slice(0, 10))
-  }
+  const handleSnoozeThing = (id: string) => snoozeThing(id, getTomorrowISO())
 
   const todayISO = new Date().toLocaleDateString('en-CA')  // YYYY-MM-DD in local TZ
   const todayEvents = calendarEvents.filter(e => e.start.slice(0, 10) === todayISO)

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -752,7 +752,7 @@ function InteractionStyleSelector({ style, onChange }: { style: InteractionStyle
 }
 
 export function ChatPanel() {
-  const { messages, chatLoading, historyLoading, hasMoreHistory, sendMessage, fetchOlderMessages, sessionStats, chatMode, setChatMode, interactionStyle, setInteractionStyle, seedFromGoogle, googleSeedLoading, calendarStatus, gmailStatus, nudges } = useStore(
+  const { messages, chatLoading, historyLoading, hasMoreHistory, sendMessage, fetchOlderMessages, sessionStats, chatMode, setChatMode, interactionStyle, setInteractionStyle, seedFromGoogle, googleSeedLoading, calendarStatus, gmailStatus, nudges, chatPrefill, clearChatPrefill } = useStore(
     useShallow(s => ({
       messages: s.messages,
       chatLoading: s.chatLoading,
@@ -770,6 +770,8 @@ export function ChatPanel() {
       calendarStatus: s.calendarStatus,
       gmailStatus: s.gmailStatus,
       nudges: s.nudges,
+      chatPrefill: s.chatPrefill,
+      clearChatPrefill: s.clearChatPrefill,
     }))
   )
   const { isOnline } = useNetworkStatus()
@@ -815,6 +817,17 @@ export function ChatPanel() {
   useEffect(() => {
     registerChatInputFocus(() => inputRef.current?.focus())
   }, [registerChatInputFocus])
+
+  // Consume chatPrefill from store (e.g. briefing "Chat" action)
+  useEffect(() => {
+    if (!chatPrefill) return
+    const prefill = chatPrefill
+    clearChatPrefill()
+    queueMicrotask(() => {
+      setInput(prefill)
+      inputRef.current?.focus()
+    })
+  }, [chatPrefill, clearChatPrefill])
 
   // Scroll to bottom instantly on initial mount
   const hasMountScrolled = useRef(false)

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -281,6 +281,9 @@ interface ReliState {
   actOnFinding: (finding: SweepFinding) => void
   snoozeThing: (id: string, checkinDate: string | null) => Promise<void>
   updateThing: (id: string, updates: Record<string, unknown>) => Promise<void>
+  chatPrefill: string | null
+  openChatWithContext: (thingId: string, title: string) => void
+  clearChatPrefill: () => void
   fetchHistory: () => Promise<void>
   fetchOlderMessages: () => Promise<void>
   sendMessage: (text: string) => Promise<void>
@@ -538,6 +541,7 @@ export const useStore = create<ReliState>((set, get) => ({
   gmailStatus: { connected: false, email: null },
   morningBriefing: null,
   morningBriefingLoading: false,
+  chatPrefill: null,
   briefingPreferences: null,
 
   nudges: [],
@@ -851,6 +855,15 @@ export const useStore = create<ReliState>((set, get) => ({
       get().openThingDetail(finding.thing_id)
     }
   },
+
+  openChatWithContext: (_thingId: string, title: string) => {
+    set({
+      chatPrefill: `Let's talk about "${title}"`,
+      rightView: 'chat',
+      mobileView: 'chat',
+    })
+  },
+  clearChatPrefill: () => set({ chatPrefill: null }),
 
   snoozeThing: async (id: string, checkinDate: string | null) => {
     try {


### PR DESCRIPTION
## Summary

Redesigns `BriefingPanel` from a flat priority list into a four-section color-coded card layout that lets users process their entire day without leaving the briefing screen.

**Changes:**
- **Today's Schedule** (green) — surfaces today's calendar events from the store
- **Due Today** (indigo) — replaces "The One Thing" + "Priority Focus"; adds **Done / Snooze / Chat** inline actions on every item
- **Needs Attention** (amber) — renames "Findings from Sweep" with same Open/Snooze/Dismiss actions
- **I Noticed** (purple) — learned preference cards unchanged
- **NLP summary** — displays `morningBriefing.content.summary` below the greeting (hidden when empty)
- **Chat prefill** — new `chatPrefill` + `openChatWithContext` store action; ChatPanel consumes prefill on mount so Chat buttons open a pre-loaded conversation

All data was already in the store — no backend changes required.

## Files Changed

| File | Action |
|------|--------|
| `frontend/src/store.ts` | Add `chatPrefill`, `openChatWithContext`, `clearChatPrefill` |
| `frontend/src/components/BriefingPanel.tsx` | Full section restructure + new `DueTodayRow`, `TodayEventRow`, `SectionCard` components |
| `frontend/src/components/ChatPanel.tsx` | Consume `chatPrefill` via `useEffect` on mount |
| `frontend/src/__tests__/BriefingPanel.test.tsx` | New tests for `DueTodayRow` Done/Snooze/Chat callbacks |

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc -b`) | ✅ No errors |
| Lint (`eslint .`) | ✅ 0 errors, 3 pre-existing warnings (unrelated files) |
| Tests (`vitest run`) | ✅ 284 passed, 0 failed (26 test files) |
| Build (`vite build`) | ✅ Compiled successfully |

## Notable Implementation Details

- Sections are conditionally rendered — hidden when their data is empty (no empty cards shown)
- Done/Snooze/Chat actions are hover-only on desktop (`md:opacity-0 md:group-hover:opacity-100`) and always visible on mobile
- `openChatWithContext` sets both `rightView: 'chat'` and `mobileView: 'chat'` — safe since desktop ignores `mobileView` and mobile ignores `rightView`
- `DueTodayRow` is exported for direct unit test import

Part of #292