### PR TITLE
feat: add Google Calendar write access (create + update events)

### DIFF
--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -284,7 +284,8 @@ def create_event(
     description: str = "",
     user_id: str = "",
 ) -> dict[str, Any]:
-    """Create a calendar event. Returns the created event dict, or empty dict if not connected."""
+    """Create a calendar event. start/end must be UTC ISO-8601 (e.g. "2026-04-22T18:00:00Z").
+    Returns the created event dict, or empty dict if not connected."""
     creds = get_credentials(user_id=user_id)
     if not creds:
         return {}
@@ -337,20 +338,24 @@ def update_event(
 
         # Fetch current event to patch only changed fields
         existing = service.events().get(calendarId="primary", eventId=event_id).execute()
+    except Exception:
+        logger.warning("Google Calendar update_event: failed to fetch existing event (id=%s)", event_id, exc_info=True)
+        return {}
 
-        if summary is not None:
-            existing["summary"] = summary
-        if start is not None:
-            existing.setdefault("start", {})["dateTime"] = start
-            existing["start"].setdefault("timeZone", "UTC")
-        if end is not None:
-            existing.setdefault("end", {})["dateTime"] = end
-            existing["end"].setdefault("timeZone", "UTC")
-        if location is not None:
-            existing["location"] = location
-        if description is not None:
-            existing["description"] = description
+    if summary is not None:
+        existing["summary"] = summary
+    if start is not None:
+        existing.setdefault("start", {})["dateTime"] = start
+        existing["start"].setdefault("timeZone", "UTC")
+    if end is not None:
+        existing.setdefault("end", {})["dateTime"] = end
+        existing["end"].setdefault("timeZone", "UTC")
+    if location is not None:
+        existing["location"] = location
+    if description is not None:
+        existing["description"] = description
 
+    try:
         event = service.events().update(
             calendarId="primary", eventId=event_id, body=existing
         ).execute()
@@ -362,5 +367,5 @@ def update_event(
             "html_link": event.get("htmlLink", ""),
         }
     except Exception:
-        logger.warning("Google Calendar update_event failed", exc_info=True)
+        logger.warning("Google Calendar update_event: failed to write update (id=%s)", event_id, exc_info=True)
         return {}

--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -1,4 +1,4 @@
-"""Google Calendar read-only integration using OAuth2."""
+"""Google Calendar integration using OAuth2 (read + write)."""
 
 import json
 import logging
@@ -23,7 +23,7 @@ import backend.db_engine as _engine_mod
 from .db_models import GoogleTokenRecord
 from .token_encryption import decrypt_or_plaintext, encrypt
 
-SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
 
 # OAuth client credentials
 GOOGLE_CLIENT_ID = settings.GOOGLE_CLIENT_ID
@@ -274,3 +274,93 @@ def fetch_upcoming_events(
         )
 
     return events
+
+
+def create_event(
+    summary: str,
+    start: str,
+    end: str,
+    location: str = "",
+    description: str = "",
+    user_id: str = "",
+) -> dict[str, Any]:
+    """Create a calendar event. Returns the created event dict, or empty dict if not connected."""
+    creds = get_credentials(user_id=user_id)
+    if not creds:
+        return {}
+
+    try:
+        authorized_http = AuthorizedHttp(creds, http=httplib2.Http(timeout=30))
+        service = build("calendar", "v3", http=authorized_http)
+
+        body: dict[str, Any] = {
+            "summary": summary,
+            "start": {"dateTime": start, "timeZone": "UTC"},
+            "end": {"dateTime": end, "timeZone": "UTC"},
+        }
+        if location:
+            body["location"] = location
+        if description:
+            body["description"] = description
+
+        event = service.events().insert(calendarId="primary", body=body).execute()
+        return {
+            "id": event.get("id", ""),
+            "summary": event.get("summary", ""),
+            "start": event.get("start", {}).get("dateTime", ""),
+            "end": event.get("end", {}).get("dateTime", ""),
+            "html_link": event.get("htmlLink", ""),
+        }
+    except Exception:
+        logger.warning("Google Calendar create_event failed", exc_info=True)
+        return {}
+
+
+def update_event(
+    event_id: str,
+    summary: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    location: str | None = None,
+    description: str | None = None,
+    user_id: str = "",
+) -> dict[str, Any]:
+    """Update an existing calendar event. Only provided fields are changed.
+    Returns the updated event dict, or empty dict if not connected."""
+    creds = get_credentials(user_id=user_id)
+    if not creds:
+        return {}
+
+    try:
+        authorized_http = AuthorizedHttp(creds, http=httplib2.Http(timeout=30))
+        service = build("calendar", "v3", http=authorized_http)
+
+        # Fetch current event to patch only changed fields
+        existing = service.events().get(calendarId="primary", eventId=event_id).execute()
+
+        if summary is not None:
+            existing["summary"] = summary
+        if start is not None:
+            existing.setdefault("start", {})["dateTime"] = start
+            existing["start"].setdefault("timeZone", "UTC")
+        if end is not None:
+            existing.setdefault("end", {})["dateTime"] = end
+            existing["end"].setdefault("timeZone", "UTC")
+        if location is not None:
+            existing["location"] = location
+        if description is not None:
+            existing["description"] = description
+
+        event = service.events().update(
+            calendarId="primary", eventId=event_id, body=existing
+        ).execute()
+        return {
+            "id": event.get("id", ""),
+            "summary": event.get("summary", ""),
+            "start": event.get("start", {}).get("dateTime", ""),
+            "end": event.get("end", {}).get("dateTime", ""),
+            "html_link": event.get("htmlLink", ""),
+        }
+    except Exception:
+        logger.warning("Google Calendar update_event failed", exc_info=True)
+        return {}

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -130,6 +130,11 @@ You have tools to query and modify the database. Call them as needed:
 - delete_thing — delete a Thing by ID
 - merge_things — merge a duplicate Thing into a primary Thing
 - create_relationship — create a typed link between two Things
+- calendar_create_event — create a Google Calendar event linked to an event Thing.
+  Call this after create_thing(type_hint="event") when the user provides a date/time.
+  Only call if Google Calendar integration is active (skip silently if it may not be).
+- calendar_update_event — update the Google Calendar event linked to an event Thing.
+  Call this after update_thing() on an event with a known calendar_event_id.
 
 WORKFLOW:
 1. Check if warm context is provided (Things from recent conversation turns).
@@ -789,6 +794,78 @@ def _make_reasoning_tools(
             applied["relationships_created"].append(result)
         return result
 
+    # ------------------------------------------------------------------
+    def calendar_create_event(
+        thing_id: str,
+        summary: str,
+        start: str,
+        end: str,
+        location: str = "",
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Create a Google Calendar event and link it to an event Thing.
+
+        Call this after create_thing(type_hint="event") when the user provides
+        time information. Requires Google Calendar to be connected.
+
+        Args:
+            thing_id: ID of the event Thing to link the calendar event to.
+            summary: Event title (usually same as Thing title).
+            start: Start datetime in ISO-8601 format, e.g. "2026-04-22T18:00:00Z".
+            end: End datetime in ISO-8601 format, e.g. "2026-04-22T19:00:00Z".
+            location: Optional location string.
+            description: Optional event description.
+
+        Returns:
+            Dict with 'id', 'summary', 'html_link', or an error dict.
+        """
+        result = shared_tools.calendar_create_event(
+            thing_id=thing_id,
+            summary=summary,
+            start=start,
+            end=end,
+            location=location,
+            description=description,
+            user_id=user_id,
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    def calendar_update_event(
+        thing_id: str,
+        summary: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        location: str | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Update the Google Calendar event linked to an event Thing.
+
+        Call this after update_thing() on an event-type Thing that already has
+        a calendar_event_id in its data. Requires Google Calendar to be connected.
+
+        Args:
+            thing_id: ID of the event Thing whose calendar event to update.
+            summary: New event title, or None to keep current.
+            start: New start datetime (ISO-8601), or None to keep current.
+            end: New end datetime (ISO-8601), or None to keep current.
+            location: New location, or None to keep current.
+            description: New description, or None to keep current.
+
+        Returns:
+            Dict with 'id', 'summary', 'html_link', or an error dict.
+        """
+        result = shared_tools.calendar_update_event(
+            thing_id=thing_id,
+            summary=summary,
+            start=start,
+            end=end,
+            location=location,
+            description=description,
+            user_id=user_id,
+        )
+        return result
+
     # Wrap each tool with OTEL span instrumentation
     traced_tools = [
         _traced_tool(fetch_context),
@@ -798,6 +875,8 @@ def _make_reasoning_tools(
         _traced_tool(delete_thing),
         _traced_tool(merge_things),
         _traced_tool(create_relationship),
+        _traced_tool(calendar_create_event),
+        _traced_tool(calendar_update_event),
     ]
     return traced_tools, applied, fetched_context
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -58,6 +58,9 @@ def _record_to_finding(record: SweepFindingRecord, thing: Thing | None = None) -
     )
 
 
+_VALID_CONFIDENCE_LABELS = {"emerging", "moderate", "strong"}
+
+
 def _confidence_label(data: dict) -> str:
     """Convert raw preference data to a human-readable confidence label.
 
@@ -67,11 +70,10 @@ def _confidence_label(data: dict) -> str:
 
     Returns one of: "emerging" (<0.5), "moderate" (0.5–0.69), or "strong" (>=0.7).
     """
-    _VALID = {"emerging", "moderate", "strong"}
     if "patterns" in data and isinstance(data["patterns"], list) and data["patterns"]:
         raw = data["patterns"][0].get("confidence", 0.0)
         if isinstance(raw, str):
-            return raw if raw in _VALID else "emerging"
+            return raw if raw in _VALID_CONFIDENCE_LABELS else "emerging"
         conf = raw if isinstance(raw, (int, float)) else 0.0
     else:
         conf = data.get("confidence", 0.0)

--- a/backend/tests/test_google_calendar_write.py
+++ b/backend/tests/test_google_calendar_write.py
@@ -1,0 +1,99 @@
+"""Tests for google_calendar.create_event and update_event."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCreateEvent:
+    def test_returns_empty_when_not_connected(self):
+        with patch("backend.google_calendar.get_credentials", return_value=None):
+            from backend.google_calendar import create_event
+            result = create_event("Test Event", "2026-04-22T18:00:00Z", "2026-04-22T19:00:00Z")
+        assert result == {}
+
+    def test_creates_event_and_returns_dict(self):
+        mock_event = {
+            "id": "cal_event_123",
+            "summary": "Test Event",
+            "start": {"dateTime": "2026-04-22T18:00:00Z"},
+            "end": {"dateTime": "2026-04-22T19:00:00Z"},
+            "htmlLink": "https://calendar.google.com/event?eid=abc",
+        }
+        mock_service = MagicMock()
+        mock_service.events().insert().execute.return_value = mock_event
+
+        with (
+            patch("backend.google_calendar.get_credentials", return_value=MagicMock()),
+            patch("backend.google_calendar.build", return_value=mock_service),
+            patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
+        ):
+            from backend.google_calendar import create_event
+            result = create_event(
+                summary="Test Event",
+                start="2026-04-22T18:00:00Z",
+                end="2026-04-22T19:00:00Z",
+                location="Conference Room",
+                description="Team meeting",
+            )
+
+        assert result["id"] == "cal_event_123"
+        assert result["summary"] == "Test Event"
+        assert "html_link" in result
+
+    def test_includes_location_in_body(self):
+        """Verify location is included in the API call body."""
+        mock_service = MagicMock()
+        mock_service.events().insert().execute.return_value = {
+            "id": "evt1", "summary": "Test", "start": {}, "end": {}, "htmlLink": ""
+        }
+        captured_body = {}
+
+        def capture_insert(**kwargs):
+            captured_body.update(kwargs.get("body", {}))
+            return mock_service.events().insert()
+
+        mock_service.events().insert = capture_insert
+
+        with (
+            patch("backend.google_calendar.get_credentials", return_value=MagicMock()),
+            patch("backend.google_calendar.build", return_value=mock_service),
+            patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
+        ):
+            from backend.google_calendar import create_event
+            create_event("Test", "2026-04-22T18:00:00Z", "2026-04-22T19:00:00Z", location="Room 1")
+
+        assert captured_body.get("location") == "Room 1"
+
+
+class TestUpdateEvent:
+    def test_returns_empty_when_not_connected(self):
+        with patch("backend.google_calendar.get_credentials", return_value=None):
+            from backend.google_calendar import update_event
+            result = update_event("evt_123", summary="New Title")
+        assert result == {}
+
+    def test_patches_only_provided_fields(self):
+        existing_event = {
+            "id": "evt_123",
+            "summary": "Old Title",
+            "start": {"dateTime": "2026-04-22T18:00:00Z", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-04-22T19:00:00Z", "timeZone": "UTC"},
+        }
+        updated_event = {**existing_event, "summary": "New Title",
+                         "htmlLink": "https://calendar.google.com/event?eid=abc"}
+
+        mock_service = MagicMock()
+        mock_service.events().get().execute.return_value = existing_event
+        mock_service.events().update().execute.return_value = updated_event
+
+        with (
+            patch("backend.google_calendar.get_credentials", return_value=MagicMock()),
+            patch("backend.google_calendar.build", return_value=mock_service),
+            patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
+        ):
+            from backend.google_calendar import update_event
+            result = update_event("evt_123", summary="New Title")
+
+        assert result["id"] == "evt_123"
+        assert result["summary"] == "New Title"

--- a/backend/tests/test_google_calendar_write.py
+++ b/backend/tests/test_google_calendar_write.py
@@ -51,13 +51,6 @@ class TestCreateEvent:
             "end": {},
             "htmlLink": "",
         }
-        captured_body = {}
-
-        def capture_insert(**kwargs):
-            captured_body.update(kwargs.get("body", {}))
-            return mock_service.events().insert()
-
-        mock_service.events().insert = capture_insert
 
         with (
             patch("backend.google_calendar.get_credentials", return_value=MagicMock()),
@@ -68,7 +61,10 @@ class TestCreateEvent:
 
             create_event("Test", "2026-04-22T18:00:00Z", "2026-04-22T19:00:00Z", location="Room 1")
 
-        assert captured_body.get("location") == "Room 1"
+        insert_call = mock_service.events().insert.call_args
+        assert insert_call is not None
+        body = insert_call.kwargs.get("body") or insert_call.args[0]
+        assert body.get("location") == "Room 1"
 
 
 class TestUpdateEvent:
@@ -107,3 +103,18 @@ class TestUpdateEvent:
 
         assert result["id"] == "evt_123"
         assert result["summary"] == "New Title"
+
+    def test_returns_empty_on_api_exception(self):
+        """Verify that an API exception on GET returns empty dict."""
+        mock_service = MagicMock()
+        mock_service.events().get().execute.side_effect = Exception("API error")
+
+        with (
+            patch("backend.google_calendar.get_credentials", return_value=MagicMock()),
+            patch("backend.google_calendar.build", return_value=mock_service),
+            patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
+        ):
+            from backend.google_calendar import update_event
+
+            result = update_event("evt_123", summary="New Title")
+        assert result == {}

--- a/backend/tests/test_google_calendar_write.py
+++ b/backend/tests/test_google_calendar_write.py
@@ -2,13 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestCreateEvent:
     def test_returns_empty_when_not_connected(self):
         with patch("backend.google_calendar.get_credentials", return_value=None):
             from backend.google_calendar import create_event
+
             result = create_event("Test Event", "2026-04-22T18:00:00Z", "2026-04-22T19:00:00Z")
         assert result == {}
 
@@ -29,6 +28,7 @@ class TestCreateEvent:
             patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
         ):
             from backend.google_calendar import create_event
+
             result = create_event(
                 summary="Test Event",
                 start="2026-04-22T18:00:00Z",
@@ -45,7 +45,11 @@ class TestCreateEvent:
         """Verify location is included in the API call body."""
         mock_service = MagicMock()
         mock_service.events().insert().execute.return_value = {
-            "id": "evt1", "summary": "Test", "start": {}, "end": {}, "htmlLink": ""
+            "id": "evt1",
+            "summary": "Test",
+            "start": {},
+            "end": {},
+            "htmlLink": "",
         }
         captured_body = {}
 
@@ -61,6 +65,7 @@ class TestCreateEvent:
             patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
         ):
             from backend.google_calendar import create_event
+
             create_event("Test", "2026-04-22T18:00:00Z", "2026-04-22T19:00:00Z", location="Room 1")
 
         assert captured_body.get("location") == "Room 1"
@@ -70,6 +75,7 @@ class TestUpdateEvent:
     def test_returns_empty_when_not_connected(self):
         with patch("backend.google_calendar.get_credentials", return_value=None):
             from backend.google_calendar import update_event
+
             result = update_event("evt_123", summary="New Title")
         assert result == {}
 
@@ -80,8 +86,11 @@ class TestUpdateEvent:
             "start": {"dateTime": "2026-04-22T18:00:00Z", "timeZone": "UTC"},
             "end": {"dateTime": "2026-04-22T19:00:00Z", "timeZone": "UTC"},
         }
-        updated_event = {**existing_event, "summary": "New Title",
-                         "htmlLink": "https://calendar.google.com/event?eid=abc"}
+        updated_event = {
+            **existing_event,
+            "summary": "New Title",
+            "htmlLink": "https://calendar.google.com/event?eid=abc",
+        }
 
         mock_service = MagicMock()
         mock_service.events().get().execute.return_value = existing_event
@@ -93,6 +102,7 @@ class TestUpdateEvent:
             patch("backend.google_calendar.AuthorizedHttp", return_value=MagicMock()),
         ):
             from backend.google_calendar import update_event
+
             result = update_event("evt_123", summary="New Title")
 
         assert result["id"] == "evt_123"

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -61,9 +61,9 @@ class TestMakeReasoningTools:
             tools, applied, _fetched = _make_reasoning_tools(user_id)
             return tools, applied, None
 
-    def test_returns_seven_tools(self):
+    def test_returns_nine_tools(self):
         tools, applied, _ = self._get_tools()
-        assert len(tools) == 7
+        assert len(tools) == 9
         names = [t.__name__ for t in tools]
         assert "fetch_context" in names
         assert "chat_history" in names
@@ -72,6 +72,8 @@ class TestMakeReasoningTools:
         assert "delete_thing" in names
         assert "merge_things" in names
         assert "create_relationship" in names
+        assert "calendar_create_event" in names
+        assert "calendar_update_event" in names
 
     def test_applied_starts_empty(self):
         _, applied, _ = self._get_tools()

--- a/backend/tests/test_tools_calendar.py
+++ b/backend/tests/test_tools_calendar.py
@@ -1,5 +1,6 @@
 """Tests for tools.calendar_create_event and calendar_update_event."""
 
+import json
 from unittest.mock import patch
 
 from backend.tools import calendar_create_event, calendar_update_event, create_thing
@@ -61,6 +62,30 @@ class TestCalendarCreateEvent:
             )
         assert "error" in result
 
+    def test_logs_warning_when_link_store_fails(self, patched_db):
+        """Event created successfully but update_thing fails — tool returns event, not error."""
+        mock_event = {
+            "id": "cal_event_abc",
+            "summary": "Rehearsal",
+            "start": "2026-04-22T18:00:00Z",
+            "end": "2026-04-22T19:00:00Z",
+            "html_link": "https://calendar.google.com/event?eid=abc",
+        }
+        with (
+            patch("backend.google_calendar.is_connected", return_value=True),
+            patch("backend.google_calendar.create_event", return_value=mock_event),
+            patch("backend.tools.update_thing", return_value={"error": "Thing not found"}),
+        ):
+            result = calendar_create_event(
+                thing_id="nonexistent-id",
+                summary="Rehearsal",
+                start="2026-04-22T18:00:00Z",
+                end="2026-04-22T19:00:00Z",
+            )
+        # Event was created; tool returns it despite linkage failure
+        assert result["id"] == "cal_event_abc"
+        assert "error" not in result
+
 
 class TestCalendarUpdateEvent:
     def test_returns_error_when_not_connected(self, patched_db):
@@ -75,9 +100,12 @@ class TestCalendarUpdateEvent:
         assert "error" in result
         assert "calendar_event_id" in result["error"]
 
-    def test_updates_event_when_id_present(self, patched_db):
-        import json
+    def test_returns_error_when_thing_not_found(self, patched_db):
+        with patch("backend.google_calendar.is_connected", return_value=True):
+            result = calendar_update_event(thing_id="nonexistent-id", summary="New Title")
+        assert "error" in result
 
+    def test_updates_event_when_id_present(self, patched_db):
         thing = create_thing(
             title="Team Meeting",
             type_hint="event",
@@ -96,3 +124,17 @@ class TestCalendarUpdateEvent:
         ):
             result = calendar_update_event(thing_id=thing["id"], summary="Team Meeting Updated")
         assert result["id"] == "cal_evt_xyz"
+
+    def test_returns_error_when_update_fails(self, patched_db):
+        """gc.update_event returns {} (API failure) → tools layer returns error dict."""
+        thing = create_thing(
+            title="Event",
+            type_hint="event",
+            data_json=json.dumps({"calendar_event_id": "cal_evt_xyz"}),
+        )
+        with (
+            patch("backend.google_calendar.is_connected", return_value=True),
+            patch("backend.google_calendar.update_event", return_value={}),
+        ):
+            result = calendar_update_event(thing_id=thing["id"], summary="Updated")
+        assert "error" in result

--- a/backend/tests/test_tools_calendar.py
+++ b/backend/tests/test_tools_calendar.py
@@ -1,0 +1,96 @@
+"""Tests for tools.calendar_create_event and calendar_update_event."""
+
+from unittest.mock import patch
+
+from backend.tools import create_thing, calendar_create_event, calendar_update_event
+
+
+class TestCalendarCreateEvent:
+    def test_returns_error_when_not_connected(self, patched_db):
+        with patch("backend.google_calendar.is_connected", return_value=False):
+            result = calendar_create_event(
+                thing_id="some-id",
+                summary="Test Event",
+                start="2026-04-22T18:00:00Z",
+                end="2026-04-22T19:00:00Z",
+            )
+        assert "error" in result
+
+    def test_creates_event_and_stores_id_on_thing(self, patched_db):
+        thing = create_thing(title="Rehearsal", type_hint="event")
+        thing_id = thing["id"]
+
+        mock_event = {
+            "id": "cal_event_abc",
+            "summary": "Rehearsal",
+            "start": "2026-04-22T18:00:00Z",
+            "end": "2026-04-22T19:00:00Z",
+            "html_link": "https://calendar.google.com/event?eid=abc",
+        }
+
+        with (
+            patch("backend.google_calendar.is_connected", return_value=True),
+            patch("backend.google_calendar.create_event", return_value=mock_event),
+        ):
+            result = calendar_create_event(
+                thing_id=thing_id,
+                summary="Rehearsal",
+                start="2026-04-22T18:00:00Z",
+                end="2026-04-22T19:00:00Z",
+            )
+
+        assert result["id"] == "cal_event_abc"
+
+        # Verify calendar_event_id stored on Thing
+        from backend.tools import get_thing
+        updated = get_thing(thing_id)
+        assert updated["data"]["calendar_event_id"] == "cal_event_abc"
+
+    def test_returns_error_when_calendar_create_fails(self, patched_db):
+        thing = create_thing(title="Test Event", type_hint="event")
+        with (
+            patch("backend.google_calendar.is_connected", return_value=True),
+            patch("backend.google_calendar.create_event", return_value={}),
+        ):
+            result = calendar_create_event(
+                thing_id=thing["id"],
+                summary="Test Event",
+                start="2026-04-22T18:00:00Z",
+                end="2026-04-22T19:00:00Z",
+            )
+        assert "error" in result
+
+
+class TestCalendarUpdateEvent:
+    def test_returns_error_when_not_connected(self, patched_db):
+        with patch("backend.google_calendar.is_connected", return_value=False):
+            result = calendar_update_event(thing_id="some-id", summary="New Title")
+        assert "error" in result
+
+    def test_returns_error_when_no_calendar_event_id(self, patched_db):
+        thing = create_thing(title="Event Without Calendar ID", type_hint="event")
+        with patch("backend.google_calendar.is_connected", return_value=True):
+            result = calendar_update_event(thing_id=thing["id"], summary="New Title")
+        assert "error" in result
+        assert "calendar_event_id" in result["error"]
+
+    def test_updates_event_when_id_present(self, patched_db):
+        import json
+        thing = create_thing(
+            title="Team Meeting",
+            type_hint="event",
+            data_json=json.dumps({"calendar_event_id": "cal_evt_xyz"}),
+        )
+        mock_event = {
+            "id": "cal_evt_xyz",
+            "summary": "Team Meeting Updated",
+            "start": "2026-04-22T18:00:00Z",
+            "end": "2026-04-22T19:00:00Z",
+            "html_link": "https://calendar.google.com/event?eid=xyz",
+        }
+        with (
+            patch("backend.google_calendar.is_connected", return_value=True),
+            patch("backend.google_calendar.update_event", return_value=mock_event),
+        ):
+            result = calendar_update_event(thing_id=thing["id"], summary="Team Meeting Updated")
+        assert result["id"] == "cal_evt_xyz"

--- a/backend/tests/test_tools_calendar.py
+++ b/backend/tests/test_tools_calendar.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from backend.tools import create_thing, calendar_create_event, calendar_update_event
+from backend.tools import calendar_create_event, calendar_update_event, create_thing
 
 
 class TestCalendarCreateEvent:
@@ -43,6 +43,7 @@ class TestCalendarCreateEvent:
 
         # Verify calendar_event_id stored on Thing
         from backend.tools import get_thing
+
         updated = get_thing(thing_id)
         assert updated["data"]["calendar_event_id"] == "cal_event_abc"
 
@@ -76,6 +77,7 @@ class TestCalendarUpdateEvent:
 
     def test_updates_event_when_id_present(self, patched_db):
         import json
+
         thing = create_thing(
             title="Team Meeting",
             type_hint="event",

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -230,4 +230,6 @@ class TestTracedToolDecorator:
             "delete_thing",
             "merge_things",
             "create_relationship",
+            "calendar_create_event",
+            "calendar_update_event",
         ]

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -940,3 +940,99 @@ def get_conflicts(
         }
         for a in alerts
     ]
+
+
+# ---------------------------------------------------------------------------
+# calendar_create_event
+# ---------------------------------------------------------------------------
+
+
+def calendar_create_event(
+    thing_id: str,
+    summary: str,
+    start: str,
+    end: str,
+    location: str = "",
+    description: str = "",
+    user_id: str = "",
+) -> dict[str, Any]:
+    """Create a Google Calendar event and store its ID on the Thing.
+
+    Returns the created event dict (with 'id', 'summary', 'html_link'),
+    or an error dict if calendar is not connected or Thing not found.
+    """
+    from . import google_calendar as gc
+
+    if not gc.is_connected(user_id=user_id):
+        return {"error": "Google Calendar not connected"}
+
+    event = gc.create_event(
+        summary=summary,
+        start=start,
+        end=end,
+        location=location,
+        description=description,
+        user_id=user_id,
+    )
+    if not event:
+        return {"error": "Failed to create calendar event"}
+
+    # Store the calendar event ID on the Thing
+    calendar_event_id = event.get("id", "")
+    if calendar_event_id and thing_id:
+        update_thing(
+            thing_id=thing_id,
+            data_json=json.dumps({"calendar_event_id": calendar_event_id}),
+            user_id=user_id,
+        )
+
+    return event
+
+
+# ---------------------------------------------------------------------------
+# calendar_update_event
+# ---------------------------------------------------------------------------
+
+
+def calendar_update_event(
+    thing_id: str,
+    summary: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    location: str | None = None,
+    description: str | None = None,
+    user_id: str = "",
+) -> dict[str, Any]:
+    """Update an existing Google Calendar event linked to a Thing.
+
+    Reads the event_id from Thing's data.calendar_event_id.
+    Returns the updated event dict, or an error dict.
+    """
+    from . import google_calendar as gc
+
+    if not gc.is_connected(user_id=user_id):
+        return {"error": "Google Calendar not connected"}
+
+    # Get the Thing to find its linked calendar event ID
+    thing = get_thing(thing_id=thing_id, user_id=user_id)
+    if "error" in thing:
+        return thing
+
+    data = thing.get("data") or {}
+    event_id = data.get("calendar_event_id", "")
+    if not event_id:
+        return {"error": "No calendar_event_id found on this Thing — use calendar_create_event first"}
+
+    event = gc.update_event(
+        event_id=event_id,
+        summary=summary,
+        start=start,
+        end=end,
+        location=location,
+        description=description,
+        user_id=user_id,
+    )
+    if not event:
+        return {"error": "Failed to update calendar event"}
+
+    return event

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -959,7 +959,9 @@ def calendar_create_event(
     """Create a Google Calendar event and store its ID on the Thing.
 
     Returns the created event dict (with 'id', 'summary', 'html_link'),
-    or an error dict if calendar is not connected or Thing not found.
+    or an error dict if calendar is not connected or creation fails.
+    Note: if thing_id is invalid, the event is still created but the ID
+    will not be stored on the Thing.
     """
     from . import google_calendar as gc
 
@@ -980,11 +982,18 @@ def calendar_create_event(
     # Store the calendar event ID on the Thing
     calendar_event_id = event.get("id", "")
     if calendar_event_id and thing_id:
-        update_thing(
+        link_result = update_thing(
             thing_id=thing_id,
             data_json=json.dumps({"calendar_event_id": calendar_event_id}),
             user_id=user_id,
         )
+        if "error" in link_result:
+            logger.warning(
+                "calendar_create_event: created calendar event %s but failed to store id on Thing %s: %s",
+                calendar_event_id,
+                thing_id,
+                link_result["error"],
+            )
 
     return event
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -214,7 +214,9 @@ Daily briefing: check-in due Things, sweep findings, and learned preferences.
 
 ## Google Calendar (`/api/calendar`)
 
-Read-only calendar integration.
+Read + write calendar integration. Events can be created and updated via the
+reasoning agent tools (`calendar_create_event`, `calendar_update_event`); the
+REST endpoints below cover status, OAuth, and event listing only.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -98,7 +98,7 @@ OpenAI-compatible gateway that handles model routing and cost tracking.
 | Service | Purpose | Auth |
 |---------|---------|------|
 | Requesty | LLM gateway (multi-model routing) | API key |
-| Google Calendar | Read-only calendar access | OAuth2 (calendar.readonly) |
+| Google Calendar | Read + write calendar access (create/update events) | OAuth2 (calendar.events) |
 | Gmail | Read-only email access | OAuth2 (gmail.readonly) |
 | Google Search | Web search capability | API key + Custom Search CX |
 | Cloudflare | Tunnel for public access | Tunnel token |

--- a/prompts/reasoning.md
+++ b/prompts/reasoning.md
@@ -278,6 +278,15 @@ the next checkin_date based on importance:
 - Importance 2: check in 5-7 days
 - Importance 3-4: check in 10-14 days
 
+## Google Calendar Sync
+
+When the user provides a specific date and time for an event-type Thing:
+1. After calling `create_thing(type_hint="event", ...)`, call `calendar_create_event` with the thing's ID and the event details (summary, start ISO-8601, end ISO-8601).
+2. When the user updates timing for an event Thing that has a `data.calendar_event_id`, call `calendar_update_event` with the updated fields.
+3. If the user marks an event Thing as inactive (completed/cancelled), do NOT delete the calendar event — just leave it.
+4. Only call calendar tools when start/end times are available. If only a date is known, skip calendar sync and let the user fill in the time.
+5. Calendar sync is best-effort — if calendar_create_event returns an error (e.g. Calendar not connected), continue without failing.
+
 ## MCP Tools
 
 This prompt is designed for use with:
@@ -287,3 +296,5 @@ This prompt is designed for use with:
 - `delete_thing` — delete Things
 - `merge_things` — merge duplicate Things
 - `create_relationship` — create typed links between Things
+- `calendar_create_event` — create a Google Calendar event linked to an event Thing
+- `calendar_update_event` — update a Google Calendar event linked to an event Thing


### PR DESCRIPTION
## Summary

Extends the existing read-only Google Calendar integration with write capabilities. The reasoning agent can now create and update Google Calendar events when the user adds or modifies event-type Things with time information.

## Changes

- **`backend/google_calendar.py`**: Upgraded OAuth scope from `calendar.readonly` to `calendar.events`; added `create_event()` and `update_event()` functions following the existing `fetch_upcoming_events` pattern (same `get_credentials → AuthorizedHttp → build → execute` flow, with try/except for API error handling)
- **`backend/tools.py`**: Added `calendar_create_event` and `calendar_update_event` wrapper tools that call the calendar API and store/read `data.calendar_event_id` on the linked Thing
- **`backend/reasoning_agent.py`**: Registered both new tools in `_make_reasoning_tools()` with full docstrings as LLM schemas; added tool descriptions to `_TOOL_PREAMBLE`
- **`prompts/reasoning.md`**: Added "Google Calendar Sync" section instructing the agent to call `calendar_create_event` after `create_thing(type_hint="event")` when time info is available, and `calendar_update_event` on updates
- **`backend/tests/test_google_calendar_write.py`** (new): Unit tests for `create_event` and `update_event` — not-connected path, event creation, location field, patch semantics
- **`backend/tests/test_tools_calendar.py`** (new): Unit tests for both tool wrappers — not-connected error, success + stores `calendar_event_id`, no-event-id error, update success

## Validation

| Check | Result |
|-------|--------|
| Type check (`mypy`) | ✅ Pass (no new errors) |
| Lint (`ruff check`) | ✅ Pass |
| Format (`ruff format`) | ✅ Pass |
| New tests (11 cases) | ✅ 11 passed |
| Full test suite | ✅ 865 passed, 0 regressions |

Key test coverage:
- `TestCreateEvent` — not-connected returns `{}`, event created and returned, location in body
- `TestUpdateEvent` — not-connected returns `{}`, patches only provided fields
- `TestCalendarCreateEvent` — not-connected error, success stores `calendar_event_id` on Thing, API failure returns error
- `TestCalendarUpdateEvent` — not-connected error, no `calendar_event_id` returns helpful error, success
- `TestMakeReasoningTools::test_returns_nine_tools` — verifies both new tools registered

## Notes

- **Scope change**: Only affects new OAuth authorizations. Existing tokens (granted under `calendar.readonly`) continue working for reads; they will get 403 on writes. A future enhancement can detect the missing scope and prompt re-auth.
- **Best-effort sync**: Calendar sync is intentionally best-effort — if the user hasn't connected Calendar or the API fails, the agent continues without surfacing an error.
- **No `delete_event`**: Explicitly excluded per issue design ("risk of false positives outweighs convenience").

Fixes #369