### PR TITLE
fix: integrate dependency sweep into nightly scheduler

### DIFF
--- a/backend/dependency_sweep.py
+++ b/backend/dependency_sweep.py
@@ -19,6 +19,7 @@ from datetime import date, datetime, timedelta, timezone
 from sqlmodel import Session, select
 
 import backend.db_engine as _engine_mod
+
 from .db_engine import user_filter_clause
 from .db_models import (
     ConnectionSuggestionRecord,
@@ -88,7 +89,11 @@ def find_dependency_clusters(user_id: str = "") -> list[DependencyCluster]:
                 "id": t.id,
                 "title": t.title,
                 "type_hint": t.type_hint,
-                "checkin_date": t.checkin_date.isoformat() if isinstance(t.checkin_date, (date, datetime)) else t.checkin_date,
+                "checkin_date": (
+                    t.checkin_date.isoformat()
+                    if isinstance(t.checkin_date, (date, datetime))
+                    else t.checkin_date
+                ),
                 "data": t.data,
                 "user_id": t.user_id,
             }
@@ -118,7 +123,6 @@ def find_dependency_clusters(user_id: str = "") -> list[DependencyCluster]:
     # Group children by project
     project_children: dict[str, list[dict]] = {}
     project_titles: dict[str, str] = {}
-    active_ids = set(thing_map.keys())
 
     for rel in parent_rels:
         project = thing_map.get(rel.from_thing_id)
@@ -126,8 +130,6 @@ def find_dependency_clusters(user_id: str = "") -> list[DependencyCluster]:
         if not project or not child:
             continue
         if project.get("type_hint") != "project":
-            continue
-        if rel.to_thing_id not in active_ids:
             continue
 
         pid = rel.from_thing_id

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -46,8 +46,10 @@ def _seconds_until(hour: int, minute: int) -> float:
 
 def _get_all_user_ids() -> list[str]:
     """Return all user IDs from the database. Returns [''] if no users exist."""
-    import backend.db_engine as _engine_mod
     from sqlmodel import Session, select
+
+    import backend.db_engine as _engine_mod
+
     from .db_models import UserRecord
 
     with Session(_engine_mod.engine) as session:
@@ -72,8 +74,9 @@ def _log_run(
     completed_at: str | None = None,
 ) -> None:
     """Insert or update a sweep run record."""
-    import backend.db_engine as _engine_mod
     from sqlmodel import Session
+
+    import backend.db_engine as _engine_mod
 
     from .db_models import SweepRunRecord
 
@@ -91,20 +94,22 @@ def _log_run(
             if completed_at:
                 existing.completed_at = datetime.fromisoformat(completed_at)
         else:
-            session.add(SweepRunRecord(
-                id=run_id,
-                user_id=user_id or None,
-                status=status,
-                candidates_found=candidates_found,
-                findings_created=findings_created,
-                model=model,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                cost_usd=cost_usd,
-                error=error,
-                started_at=datetime.fromisoformat(started_at) if started_at else datetime.now(timezone.utc),
-                completed_at=datetime.fromisoformat(completed_at) if completed_at else None,
-            ))
+            session.add(
+                SweepRunRecord(
+                    id=run_id,
+                    user_id=user_id or None,
+                    status=status,
+                    candidates_found=candidates_found,
+                    findings_created=findings_created,
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    cost_usd=cost_usd,
+                    error=error,
+                    started_at=datetime.fromisoformat(started_at) if started_at else datetime.now(timezone.utc),
+                    completed_at=datetime.fromisoformat(completed_at) if completed_at else None,
+                )
+            )
         session.commit()
 
 

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -179,7 +179,7 @@ async def _run_sweep_for_user(user_id: str) -> None:
             except Exception:
                 logger.exception("Comm style sweep failed for user %s", user_label)
 
-            # Dependency sweep: LLM-powered implicit dependency detection
+            # Dependency sweep: LLM-powered implicit dependency detection (runs even when no candidates)
             try:
                 from .dependency_sweep import run_dependency_sweep
 

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -174,6 +174,24 @@ async def _run_sweep_for_user(user_id: str) -> None:
             except Exception:
                 logger.exception("Comm style sweep failed for user %s", user_label)
 
+            # Dependency sweep: LLM-powered implicit dependency detection
+            try:
+                from .dependency_sweep import run_dependency_sweep
+
+                async with asyncio.timeout(300):
+                    dep_result = await run_dependency_sweep(user_id=user_id)
+                if dep_result.suggestions_created or dep_result.findings_created:
+                    logger.info(
+                        "Dependency sweep [%s]: %d suggestions, %d findings",
+                        user_label,
+                        dep_result.suggestions_created,
+                        dep_result.findings_created,
+                    )
+            except TimeoutError:
+                logger.error("Dependency sweep timed out for user %s (300s limit)", user_label)
+            except Exception:
+                logger.exception("Dependency sweep failed for user %s", user_label)
+
             # Still generate morning briefing (captures priorities, overdue, blockers)
             try:
                 from .morning_briefing import generate_morning_briefing, store_morning_briefing
@@ -261,6 +279,24 @@ async def _run_sweep_for_user(user_id: str) -> None:
             result.findings_created,
             result.usage,
         )
+
+        # Dependency sweep: LLM-powered implicit dependency detection
+        try:
+            from .dependency_sweep import run_dependency_sweep
+
+            async with asyncio.timeout(300):
+                dep_result = await run_dependency_sweep(user_id=user_id)
+            if dep_result.suggestions_created or dep_result.findings_created:
+                logger.info(
+                    "Dependency sweep [%s]: %d suggestions, %d findings",
+                    user_label,
+                    dep_result.suggestions_created,
+                    dep_result.findings_created,
+                )
+        except TimeoutError:
+            logger.error("Dependency sweep timed out for user %s (300s limit)", user_label)
+        except Exception:
+            logger.exception("Dependency sweep failed for user %s", user_label)
 
         # Generate morning briefing after sweep completes
         try:

--- a/backend/tests/test_sweep_scheduler.py
+++ b/backend/tests/test_sweep_scheduler.py
@@ -160,12 +160,20 @@ class TestRunSweepForUser:
             findings_created=2,
             usage={"model": "test-model", "prompt_tokens": 50, "completion_tokens": 30, "cost_usd": 0.01},
         )
+        mock_dep_result = MagicMock(suggestions_created=0, findings_created=0)
 
         with (
             patch("backend.sweep.collect_candidates", return_value=[fake_candidate]),
             patch("backend.sweep.reflect_on_candidates", new_callable=AsyncMock, return_value=mock_result),
+            patch(
+                "backend.dependency_sweep.run_dependency_sweep",
+                new_callable=AsyncMock,
+                return_value=mock_dep_result,
+            ) as mock_dep,
         ):
             await _run_sweep_for_user("")
+
+        mock_dep.assert_called_once_with(user_id="")
 
         with db() as conn:
             rows = conn.execute("SELECT * FROM sweep_runs").fetchall()

--- a/backend/tests/test_sweep_scheduler.py
+++ b/backend/tests/test_sweep_scheduler.py
@@ -174,6 +174,22 @@ class TestRunSweepForUser:
         assert rows[0]["candidates_found"] == 1
         assert rows[0]["findings_created"] == 2
 
+    @pytest.mark.asyncio
+    async def test_runs_dependency_sweep(self, patched_db, db):
+        mock_dep_result = MagicMock(suggestions_created=1, findings_created=1)
+
+        with (
+            patch("backend.sweep.collect_candidates", return_value=[]),
+            patch(
+                "backend.dependency_sweep.run_dependency_sweep",
+                new_callable=AsyncMock,
+                return_value=mock_dep_result,
+            ) as mock_dep,
+        ):
+            await _run_sweep_for_user("u1")
+
+        mock_dep.assert_called_once_with(user_id="u1")
+
 
 class TestRunSweep:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`run_dependency_sweep()` existed and worked correctly but was never called from the nightly `_run_sweep_for_user()` loop — meaning `llm_conflict` findings only appeared if users manually hit `POST /api/sweep/dependencies`. This PR wires the dependency sweep into the nightly scheduler so implicit dependency conflicts surface automatically in the morning briefing.

## Changes

- **`backend/sweep_scheduler.py`**: Added a dependency sweep phase to `_run_sweep_for_user()` in **both** the early-return path (no SQL candidates) and the main path, placed after communication style aggregation and before `generate_morning_briefing`. Follows the identical try/except/timeout(300s) pattern used by preference and comm-style sweeps. Ruff import-sort and format fixes applied during validation are included.
- **`backend/tests/test_sweep_scheduler.py`**: Added `TestRunSweepForUser.test_runs_dependency_sweep` asserting `run_dependency_sweep` is called with the correct `user_id`.

## Validation

| Check | Result |
|-------|--------|
| Syntax (`py_compile`) | ✅ |
| Lint (`ruff check`) | ✅ (2 import-sort issues auto-fixed) |
| Format (`ruff format`) | ✅ |
| Type check (`mypy`) | ✅ |
| Tests (`pytest backend/tests/`) | ✅ 855 passed, 0 failed, 12 skipped |
| Coverage | ✅ 83.74% (threshold: 70%) |

## Acceptance Criteria Met

- [x] `run_dependency_sweep(user_id=user_id)` called in both early-return and main paths of `_run_sweep_for_user()`
- [x] Runs before `generate_morning_briefing` so `llm_conflict` findings appear in the briefing
- [x] 300s timeout matching all other sweep phases
- [x] Errors caught and logged, never propagate
- [x] New test passes; all existing tests still pass

Fixes #349