### PR TITLE
fix: tighten open_questions prompt & add stale question pruning

### DIFF
--- a/backend/dependency_sweep.py
+++ b/backend/dependency_sweep.py
@@ -16,6 +16,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 
+from sqlalchemy import or_
 from sqlmodel import Session, select
 
 import backend.db_engine as _engine_mod
@@ -324,26 +325,17 @@ async def detect_cluster_dependencies(
                     if not reason:
                         continue
 
-                    # Check for existing suggestion (pending/deferred)
-                    existing = session.exec(
+                    # Check for existing suggestion in either direction (pending/deferred)
+                    existing_sugg = session.exec(
                         select(ConnectionSuggestionRecord).where(
                             ConnectionSuggestionRecord.status.in_(["pending", "deferred"]),  # type: ignore[union-attr]
-                            ConnectionSuggestionRecord.from_thing_id == from_id,
-                            ConnectionSuggestionRecord.to_thing_id == to_id,
+                            or_(
+                                (ConnectionSuggestionRecord.from_thing_id == from_id) & (ConnectionSuggestionRecord.to_thing_id == to_id),
+                                (ConnectionSuggestionRecord.from_thing_id == to_id) & (ConnectionSuggestionRecord.to_thing_id == from_id),
+                            ),
                         )
                     ).first()
-                    if existing:
-                        continue
-
-                    # Check reverse direction too
-                    existing_rev = session.exec(
-                        select(ConnectionSuggestionRecord).where(
-                            ConnectionSuggestionRecord.status.in_(["pending", "deferred"]),  # type: ignore[union-attr]
-                            ConnectionSuggestionRecord.from_thing_id == to_id,
-                            ConnectionSuggestionRecord.to_thing_id == from_id,
-                        )
-                    ).first()
-                    if existing_rev:
+                    if existing_sugg:
                         continue
 
                     # Check for existing relationship in this direction

--- a/backend/routers/nudges.py
+++ b/backend/routers/nudges.py
@@ -189,17 +189,12 @@ def dismiss_nudge(nudge_id: str, user_id: str = Depends(require_user)) -> dict:
     return {"ok": True}
 
 
-_PREFIX_TO_NUDGE_TYPE: dict[str, str] = {
-    "proactive": "approaching_date",
-}
-
-
 @router.post("/{nudge_id}/stop", summary="Stop nudges of this type (preference signal)")
 def stop_nudge_type(nudge_id: str, user_id: str = Depends(require_user)) -> dict:
     """Suppress all nudges of this type and record a negative preference signal."""
     # Extract nudge_type from nudge_id (format: "{type}_{thing_id}_{key}")
     prefix = nudge_id.split("_")[0] if "_" in nudge_id else nudge_id
-    nudge_type = _PREFIX_TO_NUDGE_TYPE.get(prefix, prefix)
+    nudge_type = "approaching_date" if prefix == "proactive" else prefix
 
     today_str = date.today().isoformat()
     with Session(_engine_mod.engine) as session:

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -506,6 +506,35 @@ def find_open_questions(session: Session, user_id: str = "") -> list[SweepCandid
     return candidates
 
 
+def prune_stale_open_questions(
+    session: Session, stale_days: int = 14, user_id: str = ""
+) -> int:
+    """Clear open_questions on active Things not updated in *stale_days*.
+
+    Returns the number of Things pruned.
+    """
+    cutoff = (date.today() - timedelta(days=stale_days)).isoformat()
+
+    stmt = (
+        select(ThingRecord)
+        .where(
+            ThingRecord.active == True,  # noqa: E712
+            ThingRecord.open_questions.is_not(None),  # type: ignore[union-attr]
+            cast(ThingRecord.open_questions, String).notin_(["[]", "null"]),
+            ThingRecord.updated_at < cutoff,  # type: ignore[operator]
+            user_filter_clause(ThingRecord.user_id, user_id),
+        )
+    )
+    things = session.exec(stmt).all()  # type: ignore[arg-type]
+    count = 0
+    for thing in things:
+        thing.open_questions = None  # type: ignore[assignment]
+        count += 1
+    if count:
+        session.commit()
+    return count
+
+
 # ---------------------------------------------------------------------------
 # Gap detection — incomplete Things
 # ---------------------------------------------------------------------------
@@ -1218,6 +1247,8 @@ def collect_candidates(
         if gap_candidates:
             _generate_template_gap_questions(session, gap_candidates)
             session.commit()
+
+        prune_stale_open_questions(session, stale_days=stale_days, user_id=user_id)
 
         candidates = (
             find_approaching_dates(session, today, window_days, user_id=user_id)

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -511,6 +511,7 @@ def prune_stale_open_questions(
 ) -> int:
     """Clear open_questions on active Things not updated in *stale_days*.
 
+    Scoped to *user_id* when provided; operates across all users when omitted.
     Returns the number of Things pruned.
     """
     cutoff = (date.today() - timedelta(days=stale_days)).isoformat()
@@ -532,6 +533,7 @@ def prune_stale_open_questions(
         count += 1
     if count:
         session.commit()
+        logger.info("Pruned stale open_questions from %d thing(s)", count)
     return count
 
 
@@ -1248,6 +1250,7 @@ def collect_candidates(
             _generate_template_gap_questions(session, gap_candidates)
             session.commit()
 
+        # Prune before collection so stale questions don't surface as candidates this sweep.
         prune_stale_open_questions(session, stale_days=stale_days, user_id=user_id)
 
         candidates = (

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -9,11 +9,8 @@ from sqlmodel import Session
 from backend.db_models import ThingRecord
 from backend.sweep import (
     _generate_template_gap_questions as generate_gap_questions,
-)
-from backend.sweep import (
     collect_candidates,
     find_approaching_dates,
-    prune_stale_open_questions,
     find_completed_projects,
     find_cross_project_duplicate_effort,
     find_cross_project_resource_conflicts,
@@ -25,6 +22,7 @@ from backend.sweep import (
     find_orphan_things,
     find_overdue_checkins,
     find_stale_things,
+    prune_stale_open_questions,
 )
 
 # ---------------------------------------------------------------------------
@@ -506,6 +504,19 @@ class TestPruneStaleOpenQuestions:
         assert not t1.open_questions
         assert t2.open_questions is not None
 
+    def test_empty_list_not_pruned(self, patched_db, db):
+        stale = (date.today() - timedelta(days=15)).isoformat()
+        with db() as conn:
+            conn.execute(
+                """INSERT INTO things (id, title, type_hint, checkin_date, active, surface,
+                   data, open_questions, created_at, updated_at)
+                   VALUES (?, ?, NULL, NULL, 1, 1, NULL, ?, ?, ?)""",
+                ("t1", "Empty List", "[]", stale, stale),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 0
+
 
 # ---------------------------------------------------------------------------
 # Information gaps
@@ -848,6 +859,16 @@ class TestCollectCandidates:
         results = collect_candidates()
         types = {c.finding_type for c in results}
         assert "cross_project_duplicate_effort" in types
+
+    def test_prune_fires_in_collect_candidates(self, patched_db, db):
+        """Stale open questions are cleared when collect_candidates runs."""
+        stale = (date.today() - timedelta(days=15)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "sq1", "Stale Q", open_questions=["Why?"], updated_at=stale)
+        collect_candidates()
+        with Session(_engine_mod.engine) as session:
+            thing = session.get(ThingRecord, "sq1")
+        assert not thing.open_questions
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -5,12 +5,15 @@ from datetime import date, timedelta
 
 import backend.db_engine as _engine_mod
 from sqlmodel import Session
+
+from backend.db_models import ThingRecord
 from backend.sweep import (
     _generate_template_gap_questions as generate_gap_questions,
 )
 from backend.sweep import (
     collect_candidates,
     find_approaching_dates,
+    prune_stale_open_questions,
     find_completed_projects,
     find_cross_project_duplicate_effort,
     find_cross_project_resource_conflicts,
@@ -423,6 +426,85 @@ class TestOpenQuestions:
         with Session(_engine_mod.engine) as session:
             results = find_open_questions(session)
         assert "1 unanswered question:" in results[0].message  # no 's'
+
+
+# ---------------------------------------------------------------------------
+# Prune stale open questions
+# ---------------------------------------------------------------------------
+
+
+class TestPruneStaleOpenQuestions:
+    def test_stale_questions_pruned(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(
+                conn, "t1", "Old Q", open_questions=["Why?"],
+                updated_at=(date.today() - timedelta(days=15)).isoformat(),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 1
+        with Session(_engine_mod.engine) as session:
+            thing = session.get(ThingRecord, "t1")
+        assert not thing.open_questions
+
+    def test_recent_questions_not_pruned(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(
+                conn, "t1", "Fresh Q", open_questions=["What?"],
+                updated_at=date.today().isoformat(),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 0
+        with Session(_engine_mod.engine) as session:
+            thing = session.get(ThingRecord, "t1")
+        assert thing.open_questions is not None
+
+    def test_boundary_day_not_pruned(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(
+                conn, "t1", "Boundary Q", open_questions=["When?"],
+                updated_at=(date.today() - timedelta(days=14)).isoformat(),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 0
+
+    def test_no_questions_skipped(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(
+                conn, "t1", "No Q",
+                updated_at=(date.today() - timedelta(days=15)).isoformat(),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 0
+
+    def test_inactive_things_skipped(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(
+                conn, "t1", "Inactive Q", open_questions=["Why?"], active=False,
+                updated_at=(date.today() - timedelta(days=15)).isoformat(),
+            )
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14)
+        assert count == 0
+
+    def test_user_id_isolation(self, patched_db, db):
+        stale = (date.today() - timedelta(days=15)).isoformat()
+        with db() as conn:
+            _insert_thing(conn, "t1", "User A Q", open_questions=["Why?"], updated_at=stale)
+            conn.execute("UPDATE things SET user_id = 'user-a' WHERE id = 't1'")
+            _insert_thing(conn, "t2", "User B Q", open_questions=["How?"], updated_at=stale)
+            conn.execute("UPDATE things SET user_id = 'user-b' WHERE id = 't2'")
+        with Session(_engine_mod.engine) as session:
+            count = prune_stale_open_questions(session, stale_days=14, user_id="user-a")
+        assert count == 1
+        with Session(_engine_mod.engine) as session:
+            t1 = session.get(ThingRecord, "t1")
+            t2 = session.get(ThingRecord, "t2")
+        assert not t1.open_questions
+        assert t2.open_questions is not None
 
 
 # ---------------------------------------------------------------------------

--- a/prompts/reasoning.md
+++ b/prompts/reasoning.md
@@ -44,12 +44,16 @@ Rules:
 - "delete" items: list of UUIDs to hard-delete
 - "merge" items: unify duplicate Things (see Merging below)
 - "relationships": create typed links between Things (see below)
-- "open_questions": when creating or updating a Thing, proactively generate 1-3
-  open questions that would help deepen understanding of that Thing. These are
-  knowledge gaps — things the user hasn't told us yet that would make the Thing
-  more actionable or complete. Examples: "What's the deadline for this?",
-  "Who else is involved?", "What does success look like?", "What's the budget?",
-  "Are there any blockers?". Tailor questions to the Thing's type and context.
+- "open_questions": generate 0-2 open questions ONLY if answering them would
+  unblock a specific next action Reli could take. Test: "If the user answered
+  this, what concrete step could Reli take that it can't take now?" If the
+  answer is "nothing specific", skip the question. Do NOT generate curiosity
+  questions, broad exploratory questions, or questions about history/motivation.
+  If the Thing is already actionable as-is, generate zero questions.
+  Bad: "How did you settle on the name?" (no action unlocked)
+  Bad: "Do you have goals for X?" (too vague)
+  Good: "What's the deadline?" (unlocks scheduling)
+  Good: "Hotel or Airbnb?" (unlocks booking search)
   Don't ask questions whose answers are already in the Thing's data or title.
   For completed/deleted items, omit open_questions.
 - NEVER create a Thing that already exists in the "Relevant Things" list. If a


### PR DESCRIPTION
## Summary

- Tighten the `open_questions` rule in `prompts/reasoning.md` to only generate 0–2 questions that would unblock a concrete Reli action (adds action-gate test with explicit bad/good examples)
- Add `prune_stale_open_questions()` to `backend/sweep.py` that NULLs `open_questions` on active Things not updated in 14+ days
- Wire pruning into `collect_candidates()` so it runs on every sweep pass

## Changes

| File | Change |
|------|--------|
| `prompts/reasoning.md` | Replaced open_questions rule: action-gate test, 0-2 cap, bad/good examples (+10/-6) |
| `backend/sweep.py` | Added `prune_stale_open_questions()` + wire-in call in `collect_candidates()` (+31) |
| `backend/tests/test_sweep.py` | Added `TestPruneStaleOpenQuestions` with 6 behavioural test cases (+82) |

## Validation

| Check | Result |
|-------|--------|
| Import check | ✅ |
| `TestPruneStaleOpenQuestions` (6 tests) | ✅ 6/6 passed |
| Full sweep suite | ✅ 89 passed, 0 failed (no regressions) |
| mypy (new code) | ✅ clean |

### Implementation notes

- Cutoff uses `date.today()` (not `datetime.now(timezone.utc)`) to match the date-only ISO strings stored in `updated_at` — avoids boundary-day string comparison mismatch
- Pruning uses ORM iteration consistent with `dismiss_stale_findings()` pattern in the same file

Fixes #348