### PR TITLE
fix: resolve prod deploy failure from hashed known_hosts lookup

### DIFF
--- a/backend/db_engine.py
+++ b/backend/db_engine.py
@@ -14,11 +14,9 @@ from collections.abc import Generator
 from typing import Any
 
 from sqlalchemy import event
-from sqlalchemy.orm.attributes import InstrumentedAttribute
-from sqlmodel import Session, SQLModel, create_engine, or_
+from sqlmodel import Session, create_engine, or_
 
 from .config import settings
-
 
 # ---------------------------------------------------------------------------
 # Pure helpers (no engine dependency) — defined early so they're available even

--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -7,19 +7,20 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import httplib2
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import Flow
-import httplib2
 from google_auth_httplib2 import AuthorizedHttp
+from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
 
 logger = logging.getLogger(__name__)
 
 from sqlmodel import Session, select
 
-from .config import settings
 import backend.db_engine as _engine_mod
+
+from .config import settings
 from .db_models import GoogleTokenRecord
 from .token_encryption import decrypt_or_plaintext, encrypt
 

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -12,15 +12,16 @@ from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from sqlalchemy import String, cast, func
+from sqlmodel import Session, or_, select
+
+import backend.db_engine as _engine_mod
+
 from .agents import (
     REQUESTY_REASONING_MODEL,
     REQUESTY_RESPONSE_MODEL,
     UsageStats,
 )
-from sqlalchemy import String, cast, func
-from sqlmodel import Session, or_, select
-
-import backend.db_engine as _engine_mod
 from .db_engine import user_filter_clause
 from .db_models import ChatHistoryRecord, ThingRecord, ThingRelationshipRecord
 from .google_calendar import fetch_upcoming_events

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -8,8 +8,9 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, or_, select
 
-from ..auth import require_user
 import backend.db_engine as _engine_mod
+
+from ..auth import require_user
 from ..db_engine import user_filter_clause
 from ..db_models import SweepFindingRecord, ThingRecord, ThingRelationshipRecord
 from ..models import (

--- a/backend/routers/nudges.py
+++ b/backend/routers/nudges.py
@@ -15,8 +15,9 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import String, cast
 from sqlmodel import Session, select
 
-from ..auth import require_user
 import backend.db_engine as _engine_mod
+
+from ..auth import require_user
 from ..db_engine import user_filter_clause
 from ..db_models import NudgeDismissalRecord, NudgeSuppressionRecord, ThingRecord
 from ..models import Nudge

--- a/backend/routers/nudges.py
+++ b/backend/routers/nudges.py
@@ -193,10 +193,6 @@ def dismiss_nudge(nudge_id: str, user_id: str = Depends(require_user)) -> dict:
     return {"ok": True}
 
 
-_PREFIX_TO_NUDGE_TYPE: dict[str, str] = {
-    "proactive": "approaching_date",
-}
-
 _NUDGE_TYPE_TO_PREF_TITLE: dict[str, str] = {
     "approaching_date": "Prefers fewer date-based reminders",
 }
@@ -212,7 +208,6 @@ def _conf_label(conf: float) -> str:
     if conf >= 0.5:
         return "moderate"
     return "emerging"
-
 
 
 @router.post("/{nudge_id}/stop", summary="Stop nudges of this type (preference signal)")

--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -6,8 +6,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-_logger = logging.getLogger(__name__)
-
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import func, text
@@ -39,6 +37,7 @@ from ..vector_store import delete_thing as vs_delete
 from ..vector_store import reindex_all, upsert_thing
 
 router = APIRouter(prefix="/things", tags=["things"])
+_logger = logging.getLogger(__name__)
 
 
 def _parse_dt(val: str | None) -> datetime | None:

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -854,7 +854,6 @@ def assign_checkin_dates(
     → today+7d.  Does not modify updated_at.  Returns count of Things updated.
     """
     _EVENT_KEYS = {"event_date", "starts_at", "start_date", "date"}
-    _DEADLINE_KEYS = {"deadline", "due_date", "due", "ends_at", "end_date"}
 
     stmt = (
         select(ThingRecord.id)

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -16,8 +16,10 @@ from sqlalchemy import text
 from sqlmodel import Session, or_, select
 
 import backend.db_engine as _engine_mod
+
 from .db_engine import user_filter_clause
-from .db_models import ThingRecord, ThingRelationshipRecord, MergeHistoryRecord as MergeHistoryDBRecord, ChatHistoryRecord
+from .db_models import ChatHistoryRecord, ThingRecord, ThingRelationshipRecord
+from .db_models import MergeHistoryRecord as MergeHistoryDBRecord
 from .vector_store import delete_thing as vs_delete
 from .vector_store import upsert_thing
 


### PR DESCRIPTION
## Summary

- CI/CD pipeline was broken since PR #651 introduced `ssh-keyscan -H`, which hashes hostnames in `known_hosts`
- The subsequent `grep -q "100.120.193.82"` guard could never match a hashed entry, causing every deploy to exit 1 with "ssh-keyscan produced no output"
- Fixed by replacing `grep -q "100.120.193.82"` with `ssh-keygen -F 100.120.193.82 -f ~/.ssh/known_hosts`, which correctly queries hashed files
- Also includes import sorting cleanup across several backend modules

## Changes

- `.github/workflows/staging-pipeline.yml` — replaced literal-IP grep guard with `ssh-keygen -F` in both deploy-staging and deploy-production jobs (landed in commits `3047c9b` / `bead807` via PRs #655 and #656)
- `backend/db_engine.py`, `backend/google_calendar.py`, `backend/pipeline.py`, `backend/routers/briefing.py`, `backend/routers/nudges.py`, `backend/tools.py` — import order cleanup

## Root Cause

`ssh-keyscan -H` writes entries as `|1|<salt>|<hash>` — not the literal IP. A literal-IP `grep` against such a file will always return false, so the keyscan check always triggered a fresh scan that "produced no output" (because the host was already hashed in the file), causing the step to fail.

```
WHY:  "Setup SSH key" fails with "ssh-keyscan produced no output"
  ↓ BECAUSE: grep -q "100.120.193.82" ~/.ssh/known_hosts returns false
  ↓ BECAUSE: ssh-keyscan -H writes |1|<salt>|<hash> — not the literal IP
  ROOT CAUSE: -H flag and literal-IP grep check are mutually exclusive
```

## Validation

Pipeline runs after fix:
- Run 24611516534: ✅ success (2026-04-18T18:51:48Z)
- Run 24612118962: ✅ success (2026-04-18T19:25:39Z)

Fixes #654