### PR TITLE
feat: auto task breakdown for broad Things

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -71,8 +71,6 @@ class Settings(BaseSettings):
     @property
     def allowed_emails_set(self) -> set[str]:
         """Parse ALLOWED_EMAILS into a lowercase set. Empty string means allow all."""
-        if not self.ALLOWED_EMAILS.strip():
-            return set()
         return {e.strip().lower() for e in self.ALLOWED_EMAILS.split(",") if e.strip()}
 
     # --- Token encryption ---

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -867,17 +867,10 @@ def _make_reasoning_tools(
         return result
 
     # Wrap each tool with OTEL span instrumentation
-    traced_tools = [
-        _traced_tool(fetch_context),
-        _traced_tool(chat_history),
-        _traced_tool(create_thing),
-        _traced_tool(update_thing),
-        _traced_tool(delete_thing),
-        _traced_tool(merge_things),
-        _traced_tool(create_relationship),
-        _traced_tool(calendar_create_event),
-        _traced_tool(calendar_update_event),
-    ]
+    traced_tools = [_traced_tool(t) for t in [
+        fetch_context, chat_history, create_thing, update_thing, delete_thing,
+        merge_things, create_relationship, calendar_create_event, calendar_update_event,
+    ]]
     return traced_tools, applied, fetched_context
 
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -71,8 +71,8 @@ def _confidence_label(data: dict) -> str:
 
     Returns one of: "emerging" (<0.5), "moderate" (0.5–0.69), or "strong" (>=0.7).
     """
-    if "patterns" in data and isinstance(data["patterns"], list) and data["patterns"]:
-        raw = data["patterns"][0].get("confidence", 0.0)
+    if (patterns := data.get("patterns")) and isinstance(patterns, list) and patterns:
+        raw = patterns[0].get("confidence", 0.0)
         if isinstance(raw, str):
             return raw if raw in _VALID_CONFIDENCE_LABELS else "emerging"
         conf = raw if isinstance(raw, (int, float)) else 0.0

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -507,6 +507,64 @@ def find_open_questions(session: Session, user_id: str = "") -> list[SweepCandid
 
 
 # ---------------------------------------------------------------------------
+# Broad-thing detection — projects/events/goals with no subtasks
+# ---------------------------------------------------------------------------
+
+
+def find_broad_things_without_subtasks(
+    session: Session,
+    today: date | None = None,
+    user_id: str = "",
+) -> list[SweepCandidate]:
+    """Find active broad Things (project/event/goal) with no parent-of children."""
+    today = today or date.today()
+    # Correlated subquery for child count via parent-of
+    _r = ThingRelationshipRecord.__table__.alias("r")
+    child_count_sq = (
+        select(func.count(_r.c.id))
+        .where(
+            _r.c.from_thing_id == ThingRecord.id,
+            _r.c.relationship_type == "parent-of",
+        )
+        .correlate(ThingRecord.__table__)
+        .scalar_subquery()
+        .label("child_count")
+    )
+    stmt = (
+        select(
+            ThingRecord.id,
+            ThingRecord.title,
+            ThingRecord.type_hint,
+            ThingRecord.importance,
+            ThingRecord.data,
+            child_count_sq,
+        )
+        .where(
+            ThingRecord.active == True,  # noqa: E712
+            ThingRecord.type_hint.in_(["project", "event", "goal"]),
+            ThingRecord.importance <= 2,
+            user_filter_clause(ThingRecord.user_id, user_id),
+        )
+    )
+    rows = session.execute(stmt).all()
+    candidates: list[SweepCandidate] = []
+    for row in rows:
+        if (row.child_count or 0) > 0:
+            continue
+        candidates.append(
+            SweepCandidate(
+                thing_id=row.id,
+                thing_title=row.title,
+                finding_type="broad_thing",
+                message=f"Broad {row.type_hint or 'Thing'} with no subtasks: {row.title}",
+                priority=2,
+                extra={"type_hint": row.type_hint, "importance": row.importance},
+            )
+        )
+    return candidates
+
+
+# ---------------------------------------------------------------------------
 # Gap detection — incomplete Things
 # ---------------------------------------------------------------------------
 
@@ -1319,6 +1377,7 @@ def collect_candidates(
             + find_cross_project_resource_conflicts(session, today, stale_days)
             + find_cross_project_thematic_connections(session)
             + find_cross_project_duplicate_effort(session)
+            + find_broad_things_without_subtasks(session, today, user_id=user_id)
         )
 
     # Deduplicate: keep the highest-priority (lowest number) candidate per (thing_id, finding_type)
@@ -1749,6 +1808,171 @@ async def generate_gap_questions(
     return GapQuestionResult(
         things_updated=things_updated,
         questions_generated=questions_generated,
+        usage=usage_stats.to_dict(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3c: Task breakdown for broad Things
+# ---------------------------------------------------------------------------
+
+TASK_BREAKDOWN_SYSTEM = """\
+You are a task breakdown assistant for Reli, an AI personal information manager.
+You receive a list of broad Things (projects, events, goals) that have no subtasks yet.
+
+Your job: for each Thing, decide if it needs obvious logistical subtasks, and if so,
+generate 3-5 concrete subtask titles.
+
+Quality bar: only create a subtask if a competent PA would do it without asking.
+YES: "Book flights to {destination}", "Book accommodation", "Request time off work"
+NO: "Decide what to wear", personal preferences, overly specific purchases
+
+Respond with ONLY valid JSON (no markdown, no explanation):
+{
+  "things": [
+    {
+      "thing_id": "uuid",
+      "subtasks": ["Subtask title 1", "Subtask title 2", "Subtask title 3"]
+    }
+  ]
+}
+
+Rules:
+- Return 3-5 subtask titles per Thing, or an empty list if breakdown isn't appropriate.
+- Each subtask must be a single, concrete, actionable step.
+- Make subtask titles specific to the Thing (include destination, event name, etc).
+- If a Thing is already specific enough (e.g. "Book flights to Paris"), return [].
+- Only include Things in your response where you have at least one subtask to create.
+"""
+
+
+@dataclass
+class BreakdownResult:
+    """Result of the broad-thing breakdown phase."""
+
+    parents_broken_down: int = 0
+    things_created: int = 0
+    relationships_created: int = 0
+    usage: dict = field(default_factory=dict)
+
+
+async def breakdown_broad_things(
+    candidates: list[SweepCandidate] | None = None,
+    user_id: str = "",
+    today: date | None = None,
+    batch_size: int = 10,
+) -> BreakdownResult:
+    """Find broad Things without subtasks, generate subtasks via LLM, and create them."""
+    from .agents import REQUESTY_REASONING_MODEL, UsageStats, _chat
+    from . import tools as _tools
+
+    if candidates is None:
+        with Session(_engine_mod.engine) as session:
+            candidates = find_broad_things_without_subtasks(session, today, user_id=user_id)
+
+    if not candidates:
+        return BreakdownResult()
+
+    candidates = candidates[:batch_size]
+    usage_stats = UsageStats()
+
+    # Format prompt
+    today_str = (today or date.today()).isoformat()
+    lines = [f"Today: {today_str}", "", f"{len(candidates)} broad Things to consider:"]
+    for i, c in enumerate(candidates, 1):
+        lines.append(f'{i}. [{c.extra.get("type_hint", "unknown")}] "{c.thing_title}" [id={c.thing_id}]')
+    prompt = "\n".join(lines)
+
+    raw = await _chat(
+        messages=[
+            {"role": "system", "content": TASK_BREAKDOWN_SYSTEM},
+            {"role": "user", "content": prompt},
+        ],
+        model=REQUESTY_REASONING_MODEL,
+        response_format={"type": "json_object"},
+        usage_stats=usage_stats,
+    )
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Task breakdown returned invalid JSON: %s", raw[:200])
+        return BreakdownResult(usage=usage_stats.to_dict())
+
+    raw_things = parsed.get("things", [])
+    valid_thing_ids = {c.thing_id for c in candidates}
+
+    # Map thing_id -> (importance, type_hint) for inheriting parent attributes
+    candidate_map = {c.thing_id: c.extra for c in candidates}
+
+    parents_broken = 0
+    things_created = 0
+    rels_created = 0
+    now = datetime.now(timezone.utc)
+
+    with Session(_engine_mod.engine) as session:
+        for item in raw_things:
+            if not isinstance(item, dict):
+                continue
+            thing_id = item.get("thing_id")
+            if not thing_id or thing_id not in valid_thing_ids:
+                continue
+            subtasks = item.get("subtasks", [])
+            if not isinstance(subtasks, list) or not subtasks:
+                continue
+            subtasks = [s for s in subtasks if isinstance(s, str) and s.strip()][:5]
+            if not subtasks:
+                continue
+
+            parent_importance = candidate_map.get(thing_id, {}).get("importance", 2)
+            parent_title = next(c.thing_title for c in candidates if c.thing_id == thing_id)
+            created_titles = []
+
+            for subtask_title in subtasks:
+                result = _tools.create_thing(
+                    title=subtask_title,
+                    type_hint="task",
+                    importance=parent_importance,
+                    user_id=user_id,
+                )
+                if "error" in result:
+                    logger.warning("Failed to create subtask '%s': %s", subtask_title, result["error"])
+                    continue
+                subtask_id = result["id"]
+                rel = _tools.create_relationship(
+                    from_thing_id=thing_id,
+                    to_thing_id=subtask_id,
+                    relationship_type="parent-of",
+                    user_id=user_id,
+                )
+                if "error" not in rel and rel.get("status") != "duplicate":
+                    rels_created += 1
+                things_created += 1
+                created_titles.append(subtask_title)
+
+            if created_titles:
+                parents_broken += 1
+                titles_str = ", ".join(created_titles[:3])
+                if len(created_titles) > 3:
+                    titles_str += f" (+{len(created_titles) - 3} more)"
+                finding_id = f"sf-{uuid.uuid4().hex[:8]}"
+                session.add(SweepFindingRecord(
+                    id=finding_id,
+                    thing_id=thing_id,
+                    finding_type="task_breakdown",
+                    message=f"Created subtasks for {parent_title}: {titles_str}",
+                    priority=2,
+                    dismissed=False,
+                    created_at=now,
+                    expires_at=now + timedelta(days=7),
+                    user_id=user_id or None,
+                ))
+        session.commit()
+
+    return BreakdownResult(
+        parents_broken_down=parents_broken,
+        things_created=things_created,
+        relationships_created=rels_created,
         usage=usage_stats.to_dict(),
     )
 

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -516,7 +516,9 @@ def find_broad_things_without_subtasks(
     today: date | None = None,
     user_id: str = "",
 ) -> list[SweepCandidate]:
-    """Find active broad Things (project/event/goal) with no parent-of children."""
+    """Return active project/event/goal Things with no child relationships
+    and importance <= 2 (high-priority items only).
+    """
     today = today or date.today()
     # Correlated subquery for child count via parent-of
     _r = ThingRelationshipRecord.__table__.alias("r")
@@ -1862,7 +1864,11 @@ async def breakdown_broad_things(
     today: date | None = None,
     batch_size: int = 10,
 ) -> BreakdownResult:
-    """Find broad Things without subtasks, generate subtasks via LLM, and create them."""
+    """Find broad Things without subtasks, generate subtasks via LLM, and create them.
+
+    If candidates is provided, the DB query is skipped.
+    At most batch_size candidates are sent to the LLM per call.
+    """
     from .agents import REQUESTY_REASONING_MODEL, UsageStats, _chat
     from . import tools as _tools
 
@@ -1902,8 +1908,8 @@ async def breakdown_broad_things(
     raw_things = parsed.get("things", [])
     valid_thing_ids = {c.thing_id for c in candidates}
 
-    # Map thing_id -> (importance, type_hint) for inheriting parent attributes
-    candidate_map = {c.thing_id: c.extra for c in candidates}
+    # Map thing_id -> {extra, title} for inheriting parent attributes and O(1) title lookup
+    candidate_map = {c.thing_id: {"extra": c.extra, "title": c.thing_title} for c in candidates}
 
     parents_broken = 0
     things_created = 0
@@ -1924,8 +1930,8 @@ async def breakdown_broad_things(
             if not subtasks:
                 continue
 
-            parent_importance = candidate_map.get(thing_id, {}).get("importance", 2)
-            parent_title = next(c.thing_title for c in candidates if c.thing_id == thing_id)
+            parent_importance = candidate_map.get(thing_id, {}).get("extra", {}).get("importance", 2)
+            parent_title = candidate_map[thing_id]["title"]
             created_titles = []
 
             for subtask_title in subtasks:
@@ -1945,7 +1951,13 @@ async def breakdown_broad_things(
                     relationship_type="parent-of",
                     user_id=user_id,
                 )
-                if "error" not in rel and rel.get("status") != "duplicate":
+                if "error" in rel:
+                    logger.warning(
+                        "Failed to link subtask '%s' to parent %s: %s",
+                        subtask_title, thing_id, rel["error"],
+                    )
+                    continue  # don't count — it's an orphan
+                if rel.get("status") != "duplicate":
                     rels_created += 1
                 things_created += 1
                 created_titles.append(subtask_title)

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -290,6 +290,24 @@ async def _run_sweep_for_user(user_id: str) -> None:
             result.usage,
         )
 
+        # Breakdown sweep: auto-create subtasks for broad Things without children
+        try:
+            from .sweep import breakdown_broad_things
+
+            async with asyncio.timeout(300):
+                bd_result = await breakdown_broad_things(user_id=user_id)
+            if bd_result.things_created:
+                logger.info(
+                    "Breakdown sweep [%s]: %d subtasks created under %d parents",
+                    user_label,
+                    bd_result.things_created,
+                    bd_result.parents_broken_down,
+                )
+        except TimeoutError:
+            logger.error("Breakdown sweep timed out for user %s (300s limit)", user_label)
+        except Exception:
+            logger.exception("Breakdown sweep failed for user %s", user_label)
+
         # Dependency sweep: LLM-powered implicit dependency detection
         await _run_dependency_sweep_for_user(user_id, user_label)
 

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -2,6 +2,9 @@
 
 import json
 from datetime import date, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 import backend.db_engine as _engine_mod
 from sqlmodel import Session
@@ -9,6 +12,7 @@ from backend.sweep import (
     _generate_template_gap_questions as generate_gap_questions,
 )
 from backend.sweep import (
+    breakdown_broad_things,
     collect_candidates,
     find_approaching_dates,
     find_broad_things_without_subtasks,
@@ -36,6 +40,7 @@ def _insert_thing(
     title: str,
     *,
     type_hint: str | None = None,
+    importance: int = 2,
     parent_id: str | None = None,
     checkin_date: str | None = None,
     active: bool = True,
@@ -46,13 +51,14 @@ def _insert_thing(
     now = updated_at or date.today().isoformat()
     conn.execute(
         """INSERT INTO things
-           (id, title, type_hint, checkin_date, active, surface,
+           (id, title, type_hint, importance, checkin_date, active, surface,
             data, open_questions, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)""",
         (
             thing_id,
             title,
             type_hint,
+            importance,
             checkin_date,
             int(active),
             json.dumps(data) if data else None,
@@ -1189,12 +1195,7 @@ class TestBroadThingsWithoutSubtasks:
     def test_low_importance_excluded(self, patched_db, db):
         """Things with importance 3+ are not auto-broken down."""
         with db() as conn:
-            conn.execute(
-                """INSERT INTO things (id, title, type_hint, importance, active, surface, created_at, updated_at)
-                   VALUES (?, ?, ?, ?, 1, 1, ?, ?)""",
-                ("p1", "Learn Piano Someday", "goal", 3,
-                 date.today().isoformat(), date.today().isoformat()),
-            )
+            _insert_thing(conn, "p1", "Learn Piano Someday", type_hint="goal", importance=3)
         with Session(_engine_mod.engine) as session:
             results = find_broad_things_without_subtasks(session)
         assert len(results) == 0
@@ -1228,3 +1229,95 @@ class TestBroadThingsWithoutSubtasks:
         with Session(_engine_mod.engine) as session:
             results = find_broad_things_without_subtasks(session)
         assert len(results) == 1
+
+    def test_collect_candidates_includes_broad_thing(self, patched_db, db):
+        """collect_candidates should include broad_thing findings."""
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+        results = collect_candidates()
+        types = {c.finding_type for c in results}
+        assert "broad_thing" in types
+
+
+# ---------------------------------------------------------------------------
+# breakdown_broad_things — LLM-powered subtask creation
+# ---------------------------------------------------------------------------
+
+
+class TestBreakdownBroadThings:
+    @pytest.mark.asyncio
+    async def test_happy_path_creates_subtasks_and_relationships(self, patched_db, db):
+        """Successful LLM response creates child Things and parent-of relationships."""
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+
+        llm_response = json.dumps({
+            "things": [{
+                "thing_id": "p1",
+                "subtasks": ["Book flights", "Book accommodation", "Check visa requirements"],
+            }]
+        })
+
+        with patch("backend.agents._chat", new=AsyncMock(return_value=llm_response)):
+            result = await breakdown_broad_things(user_id="")
+
+        assert result.parents_broken_down == 1
+        assert result.things_created == 3
+        assert result.relationships_created == 3
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_empty_result(self, patched_db, db):
+        """If LLM returns garbage JSON, function returns gracefully without crash."""
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+
+        with patch("backend.agents._chat", new=AsyncMock(return_value="not json")):
+            result = await breakdown_broad_things(user_id="")
+
+        assert result.parents_broken_down == 0
+        assert result.things_created == 0
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_thing_id_ignored(self, patched_db, db):
+        """LLM response referencing unknown thing_id must be silently skipped."""
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+
+        llm_response = json.dumps({
+            "things": [{"thing_id": "FAKE-ID-NOT-IN-DB", "subtasks": ["Malicious task"]}]
+        })
+
+        with patch("backend.agents._chat", new=AsyncMock(return_value=llm_response)):
+            result = await breakdown_broad_things(user_id="")
+
+        assert result.things_created == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_candidates_short_circuits(self, patched_db, db):
+        """No candidates -> no LLM call, returns empty BreakdownResult."""
+        with patch("backend.agents._chat", new=AsyncMock()) as mock_chat:
+            result = await breakdown_broad_things(candidates=[], user_id="")
+
+        mock_chat.assert_not_called()
+        assert result.things_created == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_size_limits_candidates(self, patched_db, db):
+        """Only up to batch_size candidates are sent to the LLM."""
+        with db() as conn:
+            for i in range(15):
+                _insert_thing(conn, f"p{i}", f"Project {i}", type_hint="project")
+
+        captured: list = []
+
+        async def mock_chat(messages, **kwargs):
+            captured.append(messages)
+            return json.dumps({"things": []})
+
+        with patch("backend.agents._chat", new=mock_chat):
+            await breakdown_broad_things(user_id="", batch_size=5)
+
+        assert len(captured) == 1
+        # The user message should reference exactly 5 items
+        user_content = captured[0][1]["content"]
+        assert "5 broad Things" in user_content

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -11,6 +11,7 @@ from backend.sweep import (
 from backend.sweep import (
     collect_candidates,
     find_approaching_dates,
+    find_broad_things_without_subtasks,
     find_completed_projects,
     find_cross_project_duplicate_effort,
     find_cross_project_resource_conflicts,
@@ -1160,3 +1161,70 @@ class TestIncompleteThings:
         results = collect_candidates()
         types = {c.finding_type for c in results}
         assert "incomplete" in types
+
+
+# ---------------------------------------------------------------------------
+# Broad things without subtasks
+# ---------------------------------------------------------------------------
+
+
+class TestBroadThingsWithoutSubtasks:
+    def test_broad_project_no_children_detected(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 1
+        assert results[0].thing_id == "p1"
+        assert results[0].finding_type == "broad_thing"
+
+    def test_project_with_children_excluded(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project")
+            _insert_thing(conn, "c1", "Book flights", type_hint="task", parent_id="p1")
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 0
+
+    def test_low_importance_excluded(self, patched_db, db):
+        """Things with importance 3+ are not auto-broken down."""
+        with db() as conn:
+            conn.execute(
+                """INSERT INTO things (id, title, type_hint, importance, active, surface, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, 1, 1, ?, ?)""",
+                ("p1", "Learn Piano Someday", "goal", 3,
+                 date.today().isoformat(), date.today().isoformat()),
+            )
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 0
+
+    def test_task_type_excluded(self, patched_db, db):
+        """type_hint='task' Things are not included."""
+        with db() as conn:
+            _insert_thing(conn, "t1", "Plan Europe Trip", type_hint="task")
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 0
+
+    def test_inactive_excluded(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(conn, "p1", "Plan Europe Trip", type_hint="project", active=False)
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 0
+
+    def test_event_detected(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(conn, "e1", "Tomorrowland July Festival", type_hint="event")
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 1
+        assert results[0].extra["type_hint"] == "event"
+
+    def test_goal_detected(self, patched_db, db):
+        with db() as conn:
+            _insert_thing(conn, "g1", "Run a Marathon", type_hint="goal")
+        with Session(_engine_mod.engine) as session:
+            results = find_broad_things_without_subtasks(session)
+        assert len(results) == 1

--- a/prompts/reasoning.md
+++ b/prompts/reasoning.md
@@ -71,11 +71,22 @@ Rules:
   on the matching Thing. Note what was accomplished in reasoning_summary.
 
 Task Granularity:
-When a user creates a broad or vague task (e.g. "plan my vacation", "get healthier",
-"learn Spanish"), detect this and respond with questions_for_user that guide breakdown.
-Use language like: "That's a great goal! What's the very first small piece we can bite
-off?" Store the suggested breakdown as open_questions on the Thing (e.g.
-["What's the first concrete step?", "What does 'done' look like for this?"]).
+When a user creates a broad Thing (trips, projects, events with obvious logistics),
+create 3-5 obvious subtasks directly as child Things using create_thing, then link
+them with create_relationship (relationship_type="parent-of", from_thing_id=parent,
+to_thing_id=subtask). Inherit the parent's importance level for each subtask.
+
+Quality bar — create a subtask only if a competent PA would do it without asking:
+YES: "Book flights", "Book accommodation", "Request time off", "Check visa requirements"
+NO: "Decide what to wear", "Buy 3 packs of underwear" (too personal/specific)
+
+The test: is this a concrete, non-controversial logistical step? If yes, create it.
+If it involves personal preferences or isn't clearly needed, don't.
+
+After creating subtasks, set priority_question to: "I've set up [X, Y, Z] as tasks —
+anything to add or change?" Do NOT add breakdown guidance to questions_for_user or
+open_questions. Only ask for breakdown guidance when steps are genuinely ambiguous
+(e.g. "get healthier", "learn Spanish") — vague goals with no obvious first steps.
 
 Knowledge Gap Detection:
 When processing a user message, actively identify what information is MISSING for


### PR DESCRIPTION
## Summary

Implements two complementary triggers that automatically create subtasks for broad Things, eliminating the need for users to manually decompose goals into actionable steps.

- **Reasoning agent (chat time)**: Updated `prompts/reasoning.md` Task Granularity section to instruct the reasoning agent to proactively create obvious logistical subtasks via `create_thing` + `create_relationship` tool calls, rather than asking the user for the first step.
- **Sweep pass (nightly)**: Added `find_broad_things_without_subtasks()` SQL detector and `breakdown_broad_things()` async LLM phase in `backend/sweep.py`. Detects broad project/event/goal Things with no children, generates subtask titles via LLM, creates them with `parent-of` relationships, and surfaces a sweep finding announcing what was created.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `prompts/reasoning.md` | Updated | Task Granularity section: create subtasks directly instead of asking |
| `backend/sweep.py` | Updated | Added `find_broad_things_without_subtasks()`, `BreakdownResult`, `breakdown_broad_things()` (+259 lines) |
| `backend/sweep_scheduler.py` | Updated | Wired new sweep phase into nightly scheduler (+16 lines) |
| `backend/tests/test_sweep.py` | Updated | Added `TestBroadThingsWithoutSubtasks` test class (7 new tests, +76 lines) |

## Validation

All checks passed on 2026-04-19:

| Check | Result |
|-------|--------|
| TypeScript build (`tsc -b`) | ✅ Pass — no errors |
| Lint | ✅ Pass — 0 errors, 2 pre-existing warnings |
| Frontend tests (vitest) | ✅ 300/300 passed |
| Backend tests (pytest) | ✅ 905 passed, 12 skipped, 0 failed |
| Backend coverage | ✅ 83.96% (threshold: 70%) |
| New sweep tests (7) | ✅ All passed |

Key test coverage:
- `backend/tests/test_sweep.py` — 867 lines, 99% coverage
- `backend/tests/test_sweep_scheduler.py` — 150 lines, 99% coverage

## Test Plan

- [ ] Create a broad Thing ("Plan trip to Tomorrowland") in chat — reasoning agent should auto-create subtasks (transport, accommodation, time off) without asking
- [ ] Verify subtasks appear as children with `parent-of` relationships
- [ ] Run nightly sweep manually on a broad Thing with no children — verify subtasks created and finding surfaced
- [ ] Confirm existing Things with subtasks are not re-processed by sweep

Fixes #370