### PR TITLE
fix: click-outside dismiss for briefing snooze menu

### DIFF
--- a/frontend/src/__tests__/BriefingPanel.test.tsx
+++ b/frontend/src/__tests__/BriefingPanel.test.tsx
@@ -50,6 +50,23 @@ describe('DueTodayRow', () => {
     expect(onChat).toHaveBeenCalledWith('thing-1', 'Write proposal')
   })
 
+  it('calls onSnoozeToggle when clicking outside the open snooze menu', () => {
+    const onSnoozeToggle = vi.fn()
+    render(
+      <DueTodayRow
+        item={mockItem}
+        onDone={vi.fn()}
+        onSnooze={vi.fn()}
+        onChat={vi.fn()}
+        snoozeMenuOpen={true}
+        onSnoozeToggle={onSnoozeToggle}
+      />
+    )
+    // Simulate mousedown on document body (outside the snooze menu)
+    fireEvent.mouseDown(document.body)
+    expect(onSnoozeToggle).toHaveBeenCalled()
+  })
+
   it('renders without reason when reasons array is empty', () => {
     const itemNoReasons: BriefingItem = { ...mockItem, reasons: [] }
     render(<DueTodayRow item={itemNoReasons} onDone={vi.fn()} onSnooze={vi.fn()} onChat={vi.fn()} snoozeMenuOpen={false} onSnoozeToggle={vi.fn()} />)

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore } from '../store'
 import type { SweepFinding, BriefingItem, LearnedPreference, CalendarEvent } from '../store'
@@ -59,8 +59,18 @@ function SnoozeMenu({ onSelect, onClose }: {
   onSelect: (date: string) => void
   onClose: () => void
 }) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [onClose])
+
   return (
-    <div className="absolute z-10 top-full left-0 mt-1 bg-surface-container-high border border-surface-container-highest rounded-xl shadow-lg overflow-hidden text-xs">
+    <div ref={menuRef} className="absolute z-10 top-full left-0 mt-1 bg-surface-container-high border border-surface-container-highest rounded-xl shadow-lg overflow-hidden text-xs">
       <button className="block w-full text-left px-4 py-2 hover:bg-surface-container-highest"
         onClick={() => { onSelect(getTomorrowISO()); onClose() }}>Tomorrow</button>
       <button className="block w-full text-left px-4 py-2 hover:bg-surface-container-highest"


### PR DESCRIPTION
## Summary

Adds click-outside dismiss to the `SnoozeMenu` popover in `BriefingPanel.tsx`. Previously, once opened, the snooze menu could only be closed by clicking the Snooze button again — standard popover UX expected by users was missing.

## Changes

- **`frontend/src/components/BriefingPanel.tsx`** (+11/-1): Added `useRef<HTMLDivElement>` and a `useEffect` mousedown listener to `SnoozeMenu`, mirroring the existing pattern from `ChatPanel.tsx:574-579`. Added `useRef` and `useEffect` to the React import.
- **`frontend/src/__tests__/BriefingPanel.test.tsx`** (+16/-0): Added test verifying that `mousedown` on `document.body` while the snooze menu is open triggers `onSnoozeToggle` (the close callback).

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc -b`) | ✅ No errors |
| Lint | ✅ 0 errors (2 pre-existing warnings in unrelated files) |
| Tests | ✅ 316 passed, 0 failed (26 test files) |
| Build | ✅ Compiled successfully |

## Before / After

**Before:** Click Snooze → menu opens → click anywhere outside → nothing happens. Must click Snooze again to close.

**After:** Click Snooze → menu opens → click anywhere outside → menu dismisses immediately.

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)