### PR TITLE
fix: log warning when LLM rate limit is exceeded

### DIFF
--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -127,6 +127,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         if not bucket.consume():
             retry_after = int(bucket.retry_after) + 1
+            log.warning("Rate limit exceeded: key=%s path=%s retry_after=%ds", key, path, retry_after)
             return JSONResponse(
                 status_code=429,
                 content={

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -228,8 +227,10 @@ class TestRateLimitMiddleware:
             res = client.post("/api/chat")
             assert res.status_code == 200
 
-    def test_warning_logged_on_rate_limit_exceeded(self, caplog):
+    def test_warning_logged_on_rate_limit_exceeded(self):
         """log.warning is emitted with key, path, and retry_after when rate limited."""
+        from unittest.mock import patch
+
         app = _make_app(api_rpm=1)
         client = TestClient(app)
 
@@ -237,11 +238,11 @@ class TestRateLimitMiddleware:
         res = client.get("/api/things")
         assert res.status_code == 200
 
-        with caplog.at_level(logging.WARNING, logger="backend.rate_limit"):
+        with patch("backend.rate_limit.log") as mock_log:
             res = client.get("/api/things")
 
         assert res.status_code == 429
-        assert any(
-            "Rate limit exceeded" in r.message and "retry_after" in r.message
-            for r in caplog.records
-        )
+        mock_log.warning.assert_called_once()
+        call_args = mock_log.warning.call_args[0]
+        assert "Rate limit exceeded" in call_args[0]
+        assert "retry_after" in call_args[0]

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -229,8 +230,6 @@ class TestRateLimitMiddleware:
 
     def test_warning_logged_on_rate_limit_exceeded(self, caplog):
         """log.warning is emitted with key, path, and retry_after when rate limited."""
-        import logging
-
         app = _make_app(api_rpm=1)
         client = TestClient(app)
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -226,3 +226,23 @@ class TestRateLimitMiddleware:
         for _ in range(10):
             res = client.post("/api/chat")
             assert res.status_code == 200
+
+    def test_warning_logged_on_rate_limit_exceeded(self, caplog):
+        """log.warning is emitted with key, path, and retry_after when rate limited."""
+        import logging
+
+        app = _make_app(api_rpm=1)
+        client = TestClient(app)
+
+        # Exhaust the bucket
+        res = client.get("/api/things")
+        assert res.status_code == 200
+
+        with caplog.at_level(logging.WARNING, logger="backend.rate_limit"):
+            res = client.get("/api/things")
+
+        assert res.status_code == 429
+        assert any(
+            "Rate limit exceeded" in r.message and "retry_after" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
## Summary

Adds a `log.warning` emission in `RateLimitMiddleware.dispatch` when a request is rejected due to rate limiting. This gives operators visibility into rate-limit events so they can monitor usage patterns and tune the 30 RPM default if needed.

Previously, rate limit rejections returned a silent 429 with no log output, making it impossible to observe whether the limit was appropriately sized for production traffic.

## Changes

- `backend/rate_limit.py` (+1 line): emit `log.warning("Rate limit exceeded: key=%s path=%s retry_after=%ds", key, path, retry_after)` before returning the 429 response

## Validation

| Check | Result |
|-------|--------|
| Static analysis (`py_compile`) | ✅ Pass |
| Unit tests (`test_rate_limit.py`) | ✅ 19 passed, 0 failed |
| Full test suite (`backend/tests/`) | ✅ 911 passed, 12 skipped, 0 failed |
| Coverage | 84.24% (threshold: 70%) |

## Notes

- The 30 RPM default (up from 10) was already set in `config.py:87`
- Per-user bucketing (JWT `sub`) was already in place in `rate_limit.py:108-109`
- This change satisfies the remaining "Monitor production usage patterns" acceptance criterion
- Log message includes rate-limit key (user ID or IP), request path, and retry_after seconds — no sensitive PII beyond an opaque user ID

Fixes #494