### PR TITLE
fix: escape $(seq 1 20) in production deploy heredoc

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -176,7 +176,7 @@ jobs:
           # Verify the container is healthy
           echo "Waiting for health check..."
           HEALTHY=false
-          for i in $(seq 1 20); do
+          for i in \$(seq 1 20); do
             sleep 3
             if curl -sf --max-time 5 http://localhost:8000/healthz | grep -q '"status":"ok"'; then
               HEALTHY=true

--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -314,10 +314,7 @@ export function BriefingPanel() {
   const todayISO = new Date().toLocaleDateString('en-CA')  // YYYY-MM-DD in local TZ
   const todayEvents = calendarEvents.filter(e => e.start.slice(0, 10) === todayISO)
 
-  const dueTodayItems = [
-    ...(theOneThing ? [theOneThing] : []),
-    ...secondaryItems,
-  ]
+  const dueTodayItems = theOneThing ? [theOneThing, ...secondaryItems] : secondaryItems
 
   const hasContent = dueTodayItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0 || todayEvents.length > 0
 


### PR DESCRIPTION
## Summary

- `$(seq 1 20)` inside an unquoted SSH heredoc in `.github/workflows/staging-pipeline.yml` was being expanded by the local GitHub Actions runner shell before being sent over SSH
- The remote bash session received newline-separated numbers (`1\n2\n3\n...`), causing `syntax error near unexpected token '2'` and aborting every production deploy
- Fix: escape the `$` as `\$(seq 1 20)` so the literal string is passed to the remote host and evaluated there

## Changes

- `.github/workflows/staging-pipeline.yml:179` — changed `$(seq 1 20)` to `\$(seq 1 20)` in the production deploy heredoc, matching the escaping pattern already used for other command substitutions in the same heredoc (e.g. `\$(docker inspect ...)` on line 163)

## Validation

- Build: ✅ passes (`tsc -b` + Vite build)
- Lint: ✅ 0 errors
- Tests: 315/316 pass — 1 pre-existing unrelated failure in `ThingCard` double-click guard test (introduced in #668, out of scope)

## Root cause

Introduced in `f7153a2` (#670) when the health-check loop was added. The `$(seq 1 20)` on line 179 was inside a `<< EOF` heredoc but wasn't escaped like the other command substitutions in that block.

Fixes #674