### PR TITLE
fix: add retry loop and timeout to ssh-keyscan in deploy pipeline

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -39,9 +39,14 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H 100.120.193.82 >> ~/.ssh/known_hosts
+          for i in 1 2 3 4 5; do
+            ssh-keyscan -T 30 -H 100.120.193.82 >> ~/.ssh/known_hosts 2>/dev/null
+            ssh-keygen -F 100.120.193.82 -f ~/.ssh/known_hosts > /dev/null 2>&1 && break
+            echo "ssh-keyscan attempt $i/5 failed, retrying in 5s..."
+            sleep 5
+          done
           if ! ssh-keygen -F 100.120.193.82 -f ~/.ssh/known_hosts > /dev/null 2>&1; then
-            echo "ERROR: host key not found in known_hosts — host may be unreachable or keyscan failed"
+            echo "ERROR: host key not found after 5 attempts — host unreachable"
             exit 1
           fi
 
@@ -139,9 +144,14 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H 100.120.193.82 >> ~/.ssh/known_hosts
+          for i in 1 2 3 4 5; do
+            ssh-keyscan -T 30 -H 100.120.193.82 >> ~/.ssh/known_hosts 2>/dev/null
+            ssh-keygen -F 100.120.193.82 -f ~/.ssh/known_hosts > /dev/null 2>&1 && break
+            echo "ssh-keyscan attempt $i/5 failed, retrying in 5s..."
+            sleep 5
+          done
           if ! ssh-keygen -F 100.120.193.82 -f ~/.ssh/known_hosts > /dev/null 2>&1; then
-            echo "ERROR: host key not found in known_hosts — host may be unreachable or keyscan failed"
+            echo "ERROR: host key not found after 5 attempts — host unreachable"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- `ssh-keyscan` in both staging and production "Setup SSH key" steps had no retry logic and used the default 5s timeout
- When Tailscale peer route propagation is slow, keyscan completes before the host is reachable, leaving `known_hosts` empty and failing the guard check
- Added a retry loop (up to 5 attempts, `-T 30` per attempt) to both staging and production SSH key setup steps

## Changes

**File**: `.github/workflows/staging-pipeline.yml`

- Replaced bare `ssh-keyscan -H <host>` with a `for i in 1 2 3 4 5` retry loop using `-T 30`
- On each iteration: run keyscan, check with `ssh-keygen -F`, break on success, otherwise sleep 5s and retry
- Applied to both `deploy-staging` (line ~42) and `deploy-production` (line ~142) — identical fix in both places

## Root Cause

`ssh-keyscan` fires immediately after the Tailscale action reports success. Tailscale signals success when the daemon connects to the control plane, but peer route propagation to a specific IP (100.120.193.82) can take additional seconds. The failed run showed a 5.0s step duration — exactly the default keyscan timeout — confirming a race condition.

## Validation

- YAML syntax validated (`python3 yaml.safe_load`)
- Lint: 0 errors (2 pre-existing warnings, unrelated)
- Tests: 319 passed, 0 failed
- Build: compiled successfully

Fixes #680