### PR TITLE
feat: open type_hint to user-defined types

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -143,7 +143,7 @@ def create_thing(
 
     Args:
         title: Short descriptive title (required).
-        type_hint: System type ('task', 'note', 'project', 'person', 'idea', 'goal', 'event', 'place', 'concept', 'reference', 'preference') or a custom lowercase singular noun (e.g. 'trip', 'recipe', 'rehearsal'). Custom types default to surface=true.
+        type_hint: System type ('task', 'note', 'project', 'person', 'idea', 'goal', 'journal', 'event', 'place', 'concept', 'reference', 'preference') or a custom lowercase singular noun (e.g. 'trip', 'recipe', 'rehearsal'). Custom types default to surface=true.
         data: Arbitrary JSON data (e.g. {"email": "...", "birthday": "..."}).
         importance: How bad if undone: 0 (critical) to 4 (backlog), default 2.
         checkin_date: ISO 8601 date when this Thing should surface in the briefing.

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -143,7 +143,7 @@ def create_thing(
 
     Args:
         title: Short descriptive title (required).
-        type_hint: Category like 'task', 'note', 'project', 'person', 'idea', 'goal', 'event', 'place', 'concept'.
+        type_hint: System type ('task', 'note', 'project', 'person', 'idea', 'goal', 'event', 'place', 'concept', 'reference', 'preference') or a custom lowercase singular noun (e.g. 'trip', 'recipe', 'rehearsal'). Custom types default to surface=true.
         data: Arbitrary JSON data (e.g. {"email": "...", "birthday": "..."}).
         importance: How bad if undone: 0 (critical) to 4 (backlog), default 2.
         checkin_date: ISO 8601 date when this Thing should surface in the briefing.
@@ -455,7 +455,11 @@ def thing_schema_reference() -> str:
 | created_at     | ISO 8601        | auto    | Creation timestamp                             |
 | updated_at     | ISO 8601        | auto    | Last-modified timestamp                        |
 
-## Type Hints
+## type_hint
+
+`type_hint` is open-ended — use any lowercase singular noun that fits.
+
+### System types (preferred when they fit)
 
 | type_hint   | Meaning                                            | surface default |
 |-------------|---------------------------------------------------|-----------------|
@@ -465,15 +469,16 @@ def thing_schema_reference() -> str:
 | project     | Container for related tasks and notes              | true            |
 | goal        | High-level objective (parent of tasks)             | true            |
 | journal     | Reflective or diary-style entry                    | true            |
-| preference  | Learned user preference pattern (see below)        | false           |
+| preference  | Learned user preference pattern                    | false           |
 | person      | A person the user interacts with                   | false           |
 | place       | A physical or virtual location                     | false           |
 | event       | A specific occurrence or meeting                   | false           |
 | concept     | An abstract idea or recurring topic                | false           |
 | reference   | An external resource (URL, book, document, etc.)   | false           |
 
-Entity types (person, place, event, concept, reference, preference) default to \
-`surface=false` — they exist in the knowledge graph but don't clutter default views.
+### Custom types
+Use a custom type when no system type fits: "trip", "recipe", "rehearsal", "habit", "gig", etc.
+Custom types default to `surface=true`.
 
 ## Relationship Types
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -77,9 +77,8 @@ def _confidence_label(data: dict) -> str:
             return raw if raw in _VALID_CONFIDENCE_LABELS else "emerging"
         conf = raw if isinstance(raw, (int, float)) else 0.0
     else:
-        conf = data.get("confidence", 0.0)
-        if not isinstance(conf, (int, float)):
-            return "emerging"
+        raw = data.get("confidence", 0.0)
+        conf = raw if isinstance(raw, (int, float)) else 0.0
     if conf >= 0.7:
         return "strong"
     if conf >= 0.5:

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -532,11 +532,9 @@ def prune_stale_open_questions(
         )
     )
     things = session.exec(stmt).all()
-    pruned = 0
     for thing in things:
         thing.open_questions = []  # type: ignore[assignment]
-        pruned += 1
-    return pruned
+    return len(things)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -713,6 +713,12 @@ class TestPromptResources:
         ):
             assert hint in result, f"Missing type_hint '{hint}'"
 
+    def test_thing_schema_reference_covers_custom_type_guidance(self) -> None:
+        result = thing_schema_reference()
+        assert "Custom types" in result, "Custom type section missing from schema reference"
+        assert "surface=true" in result, "Custom type surface default missing from schema reference"
+        assert "open-ended" in result or "lowercase singular noun" in result
+
     def test_thing_schema_reference_covers_confidence_levels(self) -> None:
         result = thing_schema_reference()
         assert "emerging" in result

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -232,8 +232,8 @@ class TestPreferencePromptInstructions:
         assert "Preference Detection:" in REASONING_AGENT_TOOL_SYSTEM
 
     def test_preference_in_entity_types_set(self):
-        from backend.tools import _ENTITY_TYPES
-        assert "preference" in _ENTITY_TYPES
+        from backend.tools import _NONSURFACE_TYPES
+        assert "preference" in _NONSURFACE_TYPES
 
     def test_preference_confidence_levels_documented(self):
         from backend.reasoning_agent import REASONING_AGENT_TOOL_SYSTEM

--- a/backend/tests/test_tools_crud.py
+++ b/backend/tests/test_tools_crud.py
@@ -9,6 +9,7 @@ class TestCreateThing:
         assert "id" in result
         assert result["title"] == "My Task"
         assert result["active"] is True
+        assert result["surface"] is True  # no type_hint → defaults to surface=true
 
     def test_nonsurface_type_defaults_surface_false(self, patched_db):
         result = create_thing(title="John Doe", type_hint="person")

--- a/backend/tests/test_tools_crud.py
+++ b/backend/tests/test_tools_crud.py
@@ -10,9 +10,19 @@ class TestCreateThing:
         assert result["title"] == "My Task"
         assert result["active"] is True
 
-    def test_entity_type_defaults_surface_false(self, patched_db):
+    def test_nonsurface_type_defaults_surface_false(self, patched_db):
         result = create_thing(title="John Doe", type_hint="person")
         assert result["surface"] is False
+
+    def test_custom_type_defaults_surface_true(self, patched_db):
+        result = create_thing(title="Trip to Japan", type_hint="trip")
+        assert result["surface"] is True
+        assert result["type_hint"] == "trip"
+
+    def test_custom_type_surface_false_when_explicit(self, patched_db):
+        result = create_thing(title="My Recipe", type_hint="recipe", surface=False)
+        assert result["surface"] is False
+        assert result["type_hint"] == "recipe"
 
     def test_with_open_questions(self, patched_db):
         result = create_thing(

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -25,8 +25,8 @@ from .vector_store import upsert_thing
 
 logger = logging.getLogger(__name__)
 
-# Entity type_hints that default to surface=false
-_ENTITY_TYPES = {"person", "place", "event", "concept", "reference", "preference"}
+# type_hints that default to surface=false. Advisory only — any type_hint string is valid.
+_NONSURFACE_TYPES = {"person", "place", "event", "concept", "reference", "preference"}
 
 
 def _thing_to_dict(record: ThingRecord) -> dict[str, Any]:
@@ -277,7 +277,8 @@ def create_thing(
         # Create new Thing
         thing_id = str(uuid.uuid4())
         effective_surface = surface
-        if type_hint in _ENTITY_TYPES:
+        # Custom types (not in _NONSURFACE_TYPES) default to surface=true
+        if type_hint in _NONSURFACE_TYPES:
             effective_surface = False
         oq = open_questions if open_questions else None
 

--- a/eval/reasoning_agent/create_thing.test.json
+++ b/eval/reasoning_agent/create_thing.test.json
@@ -286,6 +286,246 @@
       "creation_timestamp": 0.0,
       "rubrics": null,
       "final_session_state": {}
+    },
+    {
+      "eval_id": "custom-type-trip",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-18 (Wednesday)\n\n<user_message>\nI'm planning a trip to Japan\n</user_message>\n\nRelevant Things from database:\n[]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"Created trip to Japan.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "title": "Trip to Japan"
+                },
+                "name": "create_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "create_thing",
+                "response": {
+                  "id": "eval-thing-0003",
+                  "title": "Trip to Japan",
+                  "type_hint": "trip"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
+    },
+    {
+      "eval_id": "custom-type-recipe",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-18 (Wednesday)\n\n<user_message>\nHere's my pasta carbonara recipe\n</user_message>\n\nRelevant Things from database:\n[]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"Created pasta carbonara recipe.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "title": "Pasta carbonara recipe"
+                },
+                "name": "create_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "create_thing",
+                "response": {
+                  "id": "eval-thing-0004",
+                  "title": "Pasta carbonara recipe",
+                  "type_hint": "recipe"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
+    },
+    {
+      "eval_id": "system-type-preserved-task",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-18 (Wednesday)\n\n<user_message>\nI need to finish the quarterly report by Friday\n</user_message>\n\nRelevant Things from database:\n[]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"Created quarterly report task.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "title": "Finish the quarterly report"
+                },
+                "name": "create_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "create_thing",
+                "response": {
+                  "id": "eval-thing-0005",
+                  "title": "Finish the quarterly report",
+                  "type_hint": "task"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
     }
   ],
   "creation_timestamp": 0.0

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -9,6 +9,12 @@ import { useNetworkStatus } from '../hooks/useNetworkStatus'
 import { useProgressiveDisclosure } from '../hooks/useProgressiveDisclosure'
 import { NudgeBanner } from './NudgeBanner'
 
+const ONBOARDING_SUGGESTIONS = [
+  "I'm preparing a project proposal due next week",
+  "I have a job interview coming up I need to prep for",
+  "I'm launching a side project and have a lot to track",
+]
+
 function formatTimestamp(iso: string): string {
   const date = new Date(iso)
   if (isNaN(date.getTime())) return ''
@@ -944,11 +950,7 @@ export function ChatPanel() {
 
                   {/* Suggestion pills */}
                   <div className="ml-10 space-y-2">
-                    {[
-                      "I'm preparing a project proposal due next week",
-                      "I have a job interview coming up I need to prep for",
-                      "I'm launching a side project and have a lot to track",
-                    ].map((suggestion) => (
+                    {ONBOARDING_SUGGESTIONS.map((suggestion) => (
                       <button
                         key={suggestion}
                         onClick={() => setInput(suggestion)}

--- a/prompts/reasoning.md
+++ b/prompts/reasoning.md
@@ -147,18 +147,37 @@ are the same person, merge them into one. Rules:
 - Only merge Things you are confident refer to the same real-world entity.
   If uncertain, add a question to questions_for_user instead.
 
-Entity Types:
-When the user mentions people, places, events, concepts, or references, create
-entity Things to build a knowledge graph:
-- type_hint "person" — people the user interacts with (e.g. "Sarah Chen", "Dr. Rodriguez")
-- type_hint "place" — locations (e.g. "Office HQ", "Tokyo")
-- type_hint "event" — specific occurrences (e.g. "Q1 Review Meeting", "Sarah's birthday")
-- type_hint "concept" — abstract ideas (e.g. "Microservices migration", "OKR framework")
-- type_hint "reference" — external resources (e.g. "RFC 2616", "Design spec v2")
-- type_hint "preference" — user preferences and behavioral patterns
+Thing Types:
 
-Entity Things default to surface=false (they exist in the graph but don't clutter
-the sidebar). Use surface=true only for entities the user explicitly wants to track.
+System types — use when they fit the user's mental model:
+
+| type_hint   | Use for                                                        | surface default |
+|-------------|----------------------------------------------------------------|-----------------|
+| task        | Actionable work items with a clear outcome                     | true            |
+| note        | Freeform information or observation                            | true            |
+| idea        | Something to explore or brainstorm                             | true            |
+| project     | Container for related tasks and notes                          | true            |
+| goal        | High-level objective (parent of tasks)                         | true            |
+| journal     | Reflective or diary-style entry                                | true            |
+| preference  | Learned user preference pattern                                | false           |
+| person      | A person the user interacts with                               | false           |
+| place       | A physical or virtual location                                 | false           |
+| event       | A specific occurrence or meeting                               | false           |
+| concept     | An abstract idea or recurring topic                            | false           |
+| reference   | An external resource (URL, book, document, etc.)               | false           |
+
+Custom types — when a system type doesn't fit, use a lowercase singular noun that matches
+the user's mental model. Examples: "trip", "recipe", "rehearsal", "habit", "band", "gig", "class".
+
+- Custom types default to surface=true (they appear in the sidebar)
+- Only use custom types when they are more specific and accurate than any system type
+- If the system type fits (e.g. "event" for a concert), prefer the system type
+
+Examples of correct custom type usage:
+- "Trip to Japan" → type_hint: "trip" (not "task" or "event")
+- "Pasta carbonara recipe" → type_hint: "recipe" (not "note")
+- "Monday rehearsal" → type_hint: "rehearsal" (not "event" or "task")
+- "Finish the report" → type_hint: "task" (system type fits — use it)
 
 Preference Detection:
 After processing the user's request, also consider: did the user express or


### PR DESCRIPTION
## Summary

Removes the closed-set constraint on `type_hint` so agents can use any lowercase singular noun that fits the user's mental model. The 6 existing "non-surface" system types (`person`, `place`, `event`, `concept`, `reference`, `preference`) become advisory defaults, not an exclusive list. Custom types (anything else) default to `surface=true`.

**Before:** A user saying "Trip to Japan" would get `type_hint: "task"` because "trip" wasn't in the permitted set.  
**After:** The agent uses `type_hint: "trip"` and the Thing appears correctly in the sidebar.

## Changes

| File | Change |
|------|--------|
| `backend/tools.py` | Renamed `_ENTITY_TYPES` → `_NONSURFACE_TYPES`; custom types default `surface=true` |
| `prompts/reasoning.md` | Replaced closed type list with two-section open guidance (system types + custom types) |
| `backend/mcp_server.py` | Updated `create_thing` docstring + `thing-schema` prompt resource to document open `type_hint` |
| `backend/tests/test_tools_crud.py` | Renamed test to match new variable; added 2 custom type tests |
| `eval/reasoning_agent/create_thing.test.json` | Added 3 eval cases (trip, recipe, task preservation) |

## Validation

- `_ENTITY_TYPES` has 0 occurrences in codebase (fully replaced)
- `_NONSURFACE_TYPES` has 2 occurrences (definition + usage)
- **108 tests passed, 0 failed** across `test_tools_crud.py`, `test_mcp_server.py`, `test_thing_types.py`
- Eval JSON validates cleanly (`python -m json.tool`)
- mypy: no new errors introduced (pre-existing errors in `pipeline.py` only)

## Acceptance Criteria Verified

- [x] `_ENTITY_TYPES` no longer exists anywhere in the codebase
- [x] `_NONSURFACE_TYPES` contains the same 6 values as the old `_ENTITY_TYPES`
- [x] `create_thing(type_hint="trip")` returns `surface=True`
- [x] `create_thing(type_hint="person")` still returns `surface=False`
- [x] `prompts/reasoning.md` has a "Custom types" section with examples
- [x] `mcp_server.py` thing-schema prompt has a "Custom types" section
- [x] All unit tests pass

## Out of Scope

- Frontend `ThingTypeSelector` changes (noted in issue as "can be filed separately")
- Auto-promoting custom types to system types ("future enhancement")
- DB migration (not needed — `type_hint` is already unconstrained `TEXT`)

Fixes #343