### PR TITLE
feat: add get_user_profile MCP tool

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -144,7 +144,9 @@ def create_thing(
 
     Args:
         title: Short descriptive title (required).
-        type_hint: System type ('task', 'note', 'project', 'person', 'idea', 'goal', 'journal', 'event', 'place', 'concept', 'reference', 'preference') or a custom lowercase singular noun (e.g. 'trip', 'recipe', 'rehearsal'). Custom types default to surface=true.
+        type_hint: System type ('task', 'note', 'project', 'person', 'idea', 'goal', 'journal', 'event',
+            'place', 'concept', 'reference', 'preference') or a custom lowercase singular noun
+            (e.g. 'trip', 'recipe', 'rehearsal'). Custom types default to surface=true.
         data: Arbitrary JSON data (e.g. {"email": "...", "birthday": "..."}).
         importance: How bad if undone: 0 (critical) to 4 (backlog), default 2.
         checkin_date: ISO 8601 date when this Thing should surface in the briefing.

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -339,6 +339,21 @@ def get_open_questions(limit: int = 50) -> list[dict[str, Any]]:
 
 
 @mcp.tool()
+def get_user_profile() -> dict[str, Any]:
+    """Get the current user's profile Thing with all resolved relationships.
+
+    Returns the user's anchor Thing (type_hint=person, surface=false) with its
+    full field set plus a 'relationships' list. Each relationship includes:
+    - id, relationship_type, direction ('incoming' or 'outgoing')
+    - related_thing_id, related_thing_title
+
+    Call this once at session start to load who the user is. Returns an error
+    dict if no profile Thing exists.
+    """
+    return shared_tools.get_user_profile(user_id=_user_id())
+
+
+@mcp.tool()
 def get_conflicts(window: int = 14) -> list[dict[str, Any]]:
     """Detect blockers, schedule overlaps, and deadline conflicts among Things.
 

--- a/backend/sweep_scheduler.py
+++ b/backend/sweep_scheduler.py
@@ -417,14 +417,16 @@ async def _process_scheduled_tasks() -> None:
                 else:
                     finding_type = f"scheduled_{task_type}"
                     default_message = f"Scheduled {task_type} task due"
-                session.add(SweepFindingRecord(
-                    id=str(uuid.uuid4()),
-                    thing_id=task_record.thing_id,
-                    finding_type=finding_type,
-                    message=payload.get("message", default_message),
-                    priority=2,
-                    user_id=user_id or None,
-                ))
+                session.add(
+                    SweepFindingRecord(
+                        id=str(uuid.uuid4()),
+                        thing_id=task_record.thing_id,
+                        finding_type=finding_type,
+                        message=payload.get("message", default_message),
+                        priority=2,
+                        user_id=user_id or None,
+                    )
+                )
 
                 task_record.executed_at = datetime.now(timezone.utc)
                 task_record.result = {"status": "executed", "task_type": task_type}

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -22,6 +22,7 @@ from backend.mcp_server import (
     get_conflicts,
     get_open_questions,
     get_thing,
+    get_user_profile,
     list_relationships,
     mcp,
     merge_things,
@@ -353,6 +354,7 @@ class TestMcpMetadata:
             "get_briefing",
             "get_open_questions",
             "get_conflicts",
+            "get_user_profile",
             "chat_history",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
@@ -603,6 +605,40 @@ class TestGetConflicts:
         assert len(result) == 2
         assert result[0]["severity"] == "critical"
         assert result[1]["alert_type"] == "schedule_overlap"
+
+
+# ---------------------------------------------------------------------------
+# get_user_profile
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserProfile:
+    @patch("backend.mcp_server.shared_tools.get_user_profile")
+    def test_returns_profile(self, mock_get: MagicMock) -> None:
+        profile = {
+            "thing": {"id": "u1", "title": "Alice", "type_hint": "person"},
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationship_type": "works_with",
+                    "direction": "outgoing",
+                    "related_thing_id": "t2",
+                    "related_thing_title": "Bob",
+                }
+            ],
+        }
+        mock_get.return_value = profile
+        result = get_user_profile()
+        mock_get.assert_called_once_with(user_id="")
+        assert result["thing"]["id"] == "u1"
+        assert result["relationships"][0]["direction"] == "outgoing"
+
+    @patch("backend.mcp_server.shared_tools.get_user_profile")
+    def test_no_profile_returns_error(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = {"error": "User profile Thing not found"}
+        result = get_user_profile()
+        assert "error" in result
+        assert result["error"] == "User profile Thing not found"
 
 
 # MCP Prompt Resources (Phase 2)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -637,6 +637,7 @@ class TestGetUserProfile:
     def test_no_profile_returns_error(self, mock_get: MagicMock) -> None:
         mock_get.return_value = {"error": "User profile Thing not found"}
         result = get_user_profile()
+        mock_get.assert_called_once_with(user_id="")
         assert "error" in result
         assert result["error"] == "User profile Thing not found"
 

--- a/backend/tests/test_tools_crud.py
+++ b/backend/tests/test_tools_crud.py
@@ -1,6 +1,6 @@
 """Tests for tools.create_thing(), update_thing(), delete_thing() basic coverage."""
 
-from backend.tools import create_thing, update_thing, delete_thing, get_thing
+from backend.tools import create_thing, update_thing, delete_thing, get_thing, create_relationship, get_user_profile
 
 
 class TestCreateThing:
@@ -56,3 +56,47 @@ class TestDeleteThing:
         # Verify it's gone
         fetched = get_thing(thing["id"])
         assert "error" in fetched
+
+
+class TestGetUserProfile:
+    def test_no_profile_returns_error(self, patched_db):
+        result = get_user_profile()
+        assert result == {"error": "User profile Thing not found"}
+
+    def test_empty_relationships(self, patched_db):
+        create_thing(title="Alice", type_hint="person")
+        result = get_user_profile()
+        assert "error" not in result
+        assert result["relationships"] == []
+
+    def test_returns_profile_with_outgoing_relationship(self, patched_db):
+        profile = create_thing(title="Alice", type_hint="person")
+        other = create_thing(title="Bob")
+        create_relationship(
+            from_thing_id=profile["id"],
+            to_thing_id=other["id"],
+            relationship_type="works_with",
+        )
+        result = get_user_profile()
+        assert "error" not in result
+        assert result["thing"]["id"] == profile["id"]
+        assert result["thing"]["title"] == "Alice"
+        rels = result["relationships"]
+        assert len(rels) == 1
+        assert rels[0]["direction"] == "outgoing"
+        assert rels[0]["related_thing_title"] == "Bob"
+        assert rels[0]["relationship_type"] == "works_with"
+
+    def test_incoming_direction(self, patched_db):
+        profile = create_thing(title="Alice", type_hint="person")
+        sender = create_thing(title="Carol")
+        create_relationship(
+            from_thing_id=sender["id"],
+            to_thing_id=profile["id"],
+            relationship_type="reports_to",
+        )
+        result = get_user_profile()
+        rels = result["relationships"]
+        assert len(rels) == 1
+        assert rels[0]["direction"] == "incoming"
+        assert rels[0]["related_thing_title"] == "Carol"

--- a/backend/tests/test_user_isolation.py
+++ b/backend/tests/test_user_isolation.py
@@ -12,6 +12,7 @@ from backend.tools import (
     merge_things,
     create_relationship,
     delete_relationship,
+    get_user_profile,
 )
 
 
@@ -103,3 +104,22 @@ class TestCreateRelationshipIsolation:
         t2 = _make_thing(title="Thing 2")
         result = create_relationship(t1["id"], t2["id"], "related", user_id=USER_B)
         assert result == {"error": "Unauthorized"}
+
+
+class TestGetUserProfileIsolation:
+    def test_user_sees_own_profile(self, patched_db):
+        create_thing(title="Alice", type_hint="person", user_id=USER_A)
+        result = get_user_profile(user_id=USER_A)
+        assert "error" not in result
+        assert result["thing"]["title"] == "Alice"
+
+    def test_user_cannot_see_other_profile(self, patched_db):
+        create_thing(title="Alice", type_hint="person", user_id=USER_A)
+        result = get_user_profile(user_id=USER_B)
+        assert result == {"error": "User profile Thing not found"}
+
+    def test_no_user_id_returns_first_person(self, patched_db):
+        """Empty user_id bypasses filter (system/admin access)."""
+        create_thing(title="Alice", type_hint="person", user_id=USER_A)
+        result = get_user_profile(user_id="")
+        assert "error" not in result

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -758,7 +758,7 @@ def get_user_profile(
     """
     with Session(_engine_mod.engine) as session:
         stmt = select(ThingRecord).where(
-            ThingRecord.surface == False,
+            ThingRecord.surface == False,  # noqa: E712
             ThingRecord.type_hint == "person",
             user_filter_clause(ThingRecord.user_id, user_id),
         )

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -744,6 +744,60 @@ def list_relationships(
 
 
 # ---------------------------------------------------------------------------
+# get_user_profile
+# ---------------------------------------------------------------------------
+
+
+def get_user_profile(
+    user_id: str = "",
+) -> dict[str, Any]:
+    """Get the user's anchor Thing (type_hint=person, surface=false) with resolved relationships.
+
+    Returns dict with 'thing' and 'relationships' (each with direction, related_thing_id,
+    related_thing_title), or an error dict if no profile Thing exists.
+    """
+    with Session(_engine_mod.engine) as session:
+        stmt = select(ThingRecord).where(
+            ThingRecord.surface == False,
+            ThingRecord.type_hint == "person",
+            user_filter_clause(ThingRecord.user_id, user_id),
+        )
+        record = session.exec(stmt).first()
+        if not record:
+            return {"error": "User profile Thing not found"}
+
+        thing = _thing_to_dict(record)
+        thing_id = record.id
+
+        rel_rows = session.execute(
+            text(
+                "SELECT r.id, r.relationship_type, r.from_thing_id, r.to_thing_id, "
+                "  CASE WHEN r.from_thing_id = :tid THEN t_to.title ELSE t_from.title END AS related_title, "
+                "  CASE WHEN r.from_thing_id = :tid THEN t_to.id ELSE t_from.id END AS related_id, "
+                "  CASE WHEN r.from_thing_id = :tid THEN 'outgoing' ELSE 'incoming' END AS direction "
+                " FROM thing_relationships r "
+                " LEFT JOIN things t_from ON r.from_thing_id = t_from.id "
+                " LEFT JOIN things t_to ON r.to_thing_id = t_to.id "
+                " WHERE r.from_thing_id = :tid OR r.to_thing_id = :tid"
+            ),
+            {"tid": thing_id},
+        ).fetchall()
+
+        relationships = [
+            {
+                "id": r.id,
+                "relationship_type": r.relationship_type,
+                "direction": r.direction,
+                "related_thing_id": r.related_id or "",
+                "related_thing_title": r.related_title or "Unknown",
+            }
+            for r in rel_rows
+        ]
+
+    return {"thing": thing, "relationships": relationships}
+
+
+# ---------------------------------------------------------------------------
 # delete_relationship
 # ---------------------------------------------------------------------------
 

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -753,8 +753,11 @@ def get_user_profile(
 ) -> dict[str, Any]:
     """Get the user's anchor Thing (type_hint=person, surface=false) with resolved relationships.
 
-    Returns dict with 'thing' and 'relationships' (each with direction, related_thing_id,
-    related_thing_title), or an error dict if no profile Thing exists.
+    Returns dict with 'thing' and 'relationships'. Each relationship includes:
+    - id, relationship_type, direction ('incoming' or 'outgoing')
+    - related_thing_id, related_thing_title
+
+    Returns an error dict if no profile Thing exists.
     """
     with Session(_engine_mod.engine) as session:
         stmt = select(ThingRecord).where(
@@ -771,7 +774,7 @@ def get_user_profile(
 
         rel_rows = session.execute(
             text(
-                "SELECT r.id, r.relationship_type, r.from_thing_id, r.to_thing_id, "
+                "SELECT r.id, r.relationship_type, "
                 "  CASE WHEN r.from_thing_id = :tid THEN t_to.title ELSE t_from.title END AS related_title, "
                 "  CASE WHEN r.from_thing_id = :tid THEN t_to.id ELSE t_from.id END AS related_id, "
                 "  CASE WHEN r.from_thing_id = :tid THEN 'outgoing' ELSE 'incoming' END AS direction "


### PR DESCRIPTION
## Summary

Adds a `get_user_profile()` MCP tool that exposes the user's anchor Thing (type_hint=person, surface=false) with all resolved relationships. This gives calling agents a single deterministic call to load "who the user is" at session start.

## Changes

- **`backend/tools.py`** (+54 lines): New `get_user_profile(user_id)` shared tool function — mirrors `get_thing` pattern, reuses the SQL logic from the existing `GET /things/me` REST endpoint.
- **`backend/mcp_server.py`** (+15 lines): Registers `get_user_profile()` as an MCP tool, delegating to `shared_tools.get_user_profile(user_id=_user_id())`.
- **`backend/tests/test_mcp_server.py`** (+36 lines): `TestGetUserProfile` class with two test cases: happy path (returns `thing` + `relationships`) and error path (no anchor Thing → returns error dict).

## Validation

- Ruff lint: ✅ no new errors (pre-existing 12 baseline errors unchanged; `# noqa: E712` added for intentional SQLModel boolean comparison)
- Tests: ✅ 89 passed, 0 failed (`test_mcp_server.py` + `test_tools_crud.py`)
- No schema migrations required — reads existing data only

## Return Shape

```json
{
  "thing": { "id": "...", "title": "Alice", "type_hint": "person", ... },
  "relationships": [
    {
      "id": "r1",
      "relationship_type": "works_with",
      "direction": "outgoing",
      "related_thing_id": "t2",
      "related_thing_title": "Bob"
    }
  ]
}
```

Error case: `{"error": "User profile Thing not found"}`

Fixes #242