### PR TITLE
feat: add List/Graph toggle tabs to GraphView header

### DIFF
--- a/frontend/src/__tests__/GraphView.test.tsx
+++ b/frontend/src/__tests__/GraphView.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import GraphView from '../components/GraphView'
+
+vi.mock('react-force-graph-2d', () => ({
+  default: () => <canvas data-testid="force-graph" />,
+}))
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const setMainView = vi.fn()
+const mockState = {
+  things: [],
+  thingTypes: [],
+  setMainView,
+}
+
+vi.mock('../store', () => ({
+  useStore: (selector: (s: typeof mockState) => unknown) => selector(mockState),
+}))
+
+vi.mock('../api', () => ({
+  apiFetch: vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ things: [], relationships: [] }),
+  }),
+}))
+
+beforeEach(() => {
+  setMainView.mockReset()
+})
+
+describe('GraphView', () => {
+  it('renders List and Graph tabs', () => {
+    render(<GraphView />)
+    expect(screen.getByRole('button', { name: 'List' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Graph' })).toBeInTheDocument()
+  })
+
+  it('calls setMainView("list") when List tab is clicked', () => {
+    render(<GraphView />)
+    fireEvent.click(screen.getByRole('button', { name: 'List' }))
+    expect(setMainView).toHaveBeenCalledWith('list')
+  })
+
+  it('Graph tab is styled as active (has border-b-2 class)', () => {
+    render(<GraphView />)
+    const graphTab = screen.getByRole('button', { name: 'Graph' })
+    expect(graphTab).toHaveClass('border-b-2')
+  })
+
+  it('List tab is styled as inactive (has text-on-surface-variant class)', () => {
+    render(<GraphView />)
+    const listTab = screen.getByRole('button', { name: 'List' })
+    expect(listTab).toHaveClass('text-on-surface-variant')
+  })
+
+  it('Graph tab has aria-current="page"', () => {
+    render(<GraphView />)
+    const graphTab = screen.getByRole('button', { name: 'Graph' })
+    expect(graphTab).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('nav has accessible label "View switcher"', () => {
+    render(<GraphView />)
+    expect(screen.getByRole('navigation', { name: 'View switcher' })).toBeInTheDocument()
+  })
+
+  it('shows loading state without hiding the tab header', () => {
+    render(<GraphView />)
+    expect(screen.getByRole('button', { name: 'List' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Graph' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/GraphView.test.tsx
+++ b/frontend/src/__tests__/GraphView.test.tsx
@@ -6,7 +6,7 @@ vi.mock('react-force-graph-2d', () => ({
   default: () => <canvas data-testid="force-graph" />,
 }))
 
-global.ResizeObserver = class {
+window.ResizeObserver = class {
   observe() {}
   unobserve() {}
   disconnect() {}

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -286,88 +286,88 @@ export default function GraphView() {
             {error}
           </div>
         )}
-        {!loading && !error && (!graphData || graphData.nodes.length === 0) && (
+        {!loading && !error && (!fgData || fgData.nodes.length === 0) && (
           <div className="flex items-center justify-center h-full text-on-surface-variant">
             No things to display in graph view.
           </div>
         )}
-        {!loading && !error && fgData && graphData && graphData.nodes.length > 0 && (
+        {!loading && !error && fgData && fgData.nodes.length > 0 && (
           <>
-        <ForceGraph2D
-          graphData={fgData}
-          width={dimensions.width}
-          height={dimensions.height}
-          nodeId="id"
-          linkSource="source"
-          linkTarget="target"
-          nodeCanvasObject={paintNode}
-          nodeCanvasObjectMode={() => 'replace'}
-          nodePointerAreaPaint={paintNodeArea}
-          linkColor={() => 'rgba(148, 163, 184, 0.3)'}
-          linkWidth={1}
-          linkLabel="relationship_type"
-          onNodeClick={handleNodeClick}
-          onBackgroundClick={() => setSelectedNode(null)}
-          cooldownTicks={100}
-          backgroundColor="#0b1326"
-        />
+            <ForceGraph2D
+              graphData={fgData}
+              width={dimensions.width}
+              height={dimensions.height}
+              nodeId="id"
+              linkSource="source"
+              linkTarget="target"
+              nodeCanvasObject={paintNode}
+              nodeCanvasObjectMode={() => 'replace'}
+              nodePointerAreaPaint={paintNodeArea}
+              linkColor={() => 'rgba(148, 163, 184, 0.3)'}
+              linkWidth={1}
+              linkLabel="relationship_type"
+              onNodeClick={handleNodeClick}
+              onBackgroundClick={() => setSelectedNode(null)}
+              cooldownTicks={100}
+              backgroundColor="#0b1326"
+            />
 
-        {selectedNode && popoverColors && (
-          <div className="absolute top-4 right-4 z-10 w-72 glass rounded-2xl p-5 space-y-3">
-            <span className={`inline-block text-label px-2 py-0.5 rounded-full ${popoverColors.bg} ${popoverColors.text}`}>
-              {typeLabel(selectedNode.type_hint)}
-            </span>
-            <h3 className="text-title text-on-surface">{selectedNode.title}</h3>
+            {selectedNode && popoverColors && (
+              <div className="absolute top-4 right-4 z-10 w-72 glass rounded-2xl p-5 space-y-3">
+                <span className={`inline-block text-label px-2 py-0.5 rounded-full ${popoverColors.bg} ${popoverColors.text}`}>
+                  {typeLabel(selectedNode.type_hint)}
+                </span>
+                <h3 className="text-title text-on-surface">{selectedNode.title}</h3>
 
-            {connectedEntities.length > 0 && (
-              <div className="space-y-1.5">
-                <span className="text-label text-on-surface-variant">Connected Entities</span>
-                <ul className="space-y-1">
-                  {connectedEntities.slice(0, 5).map(e => (
-                    <li key={e.id} className="text-body text-on-surface-variant flex items-center gap-1.5">
-                      <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: nodeColor(e.type_hint) }} />
-                      {truncate(e.title, 30)}
-                    </li>
-                  ))}
-                  {connectedEntities.length > 5 && (
-                    <li className="text-body text-on-surface-variant/50">
-                      +{connectedEntities.length - 5} more
-                    </li>
-                  )}
-                </ul>
+                {connectedEntities.length > 0 && (
+                  <div className="space-y-1.5">
+                    <span className="text-label text-on-surface-variant">Connected Entities</span>
+                    <ul className="space-y-1">
+                      {connectedEntities.slice(0, 5).map(e => (
+                        <li key={e.id} className="text-body text-on-surface-variant flex items-center gap-1.5">
+                          <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: nodeColor(e.type_hint) }} />
+                          {truncate(e.title, 30)}
+                        </li>
+                      ))}
+                      {connectedEntities.length > 5 && (
+                        <li className="text-body text-on-surface-variant/50">
+                          +{connectedEntities.length - 5} more
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <button
+                    onClick={handleExplore}
+                    className="gradient-cta text-label px-4 py-1.5 rounded-lg"
+                  >
+                    Explore
+                  </button>
+                  <button
+                    onClick={() => {
+                      useStore.getState().openThingDetail(selectedNode.id)
+                      setSelectedNode(null)
+                    }}
+                    className="glass text-label text-on-surface px-4 py-1.5 rounded-lg hover:bg-surface-container-high/80"
+                  >
+                    Edit Note
+                  </button>
+                </div>
               </div>
             )}
 
-            <div className="flex gap-2 pt-1">
-              <button
-                onClick={handleExplore}
-                className="gradient-cta text-label px-4 py-1.5 rounded-lg"
-              >
-                Explore
-              </button>
-              <button
-                onClick={() => {
-                  useStore.getState().openThingDetail(selectedNode.id)
-                  setSelectedNode(null)
-                }}
-                className="glass text-label text-on-surface px-4 py-1.5 rounded-lg hover:bg-surface-container-high/80"
-              >
-                Edit Note
-              </button>
-            </div>
-          </div>
-        )}
-
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
-          <div className="glass rounded-xl px-5 py-2 flex items-center gap-5">
-            {LEGEND_ITEMS.map(item => (
-              <div key={item.label} className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
-                <span className="text-label text-on-surface-variant">{item.label}</span>
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+              <div className="glass rounded-xl px-5 py-2 flex items-center gap-5">
+                {LEGEND_ITEMS.map(item => (
+                  <div key={item.label} className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
+                    <span className="text-label text-on-surface-variant">{item.label}</span>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        </div>
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -90,6 +90,7 @@ export default function GraphView() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 })
   const thingTypes = useStore(s => s.thingTypes)
+  const setMainView = useStore(s => s.setMainView)
 
   // Fetch graph data
   useEffect(() => {
@@ -271,10 +272,20 @@ export default function GraphView() {
   const popoverColors = selectedNode ? typeColorClass(selectedNode.type_hint) : null
 
   return (
-    <div ref={containerRef} className="w-full h-full bg-canvas relative">
-      {/* Search bar */}
-      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 w-72">
-        <div className="glass rounded-xl px-4 py-2 flex items-center gap-2">
+    <div className="w-full h-full flex flex-col">
+      <div className="bg-surface-container-low flex items-center justify-between px-6 h-12 shrink-0">
+        <nav className="flex gap-6 text-sm font-medium">
+          <button
+            onClick={() => setMainView('list')}
+            className="text-on-surface-variant hover:text-on-surface transition-colors"
+          >
+            List
+          </button>
+          <button className="text-on-surface font-semibold border-b-2 border-primary pb-1">
+            Graph
+          </button>
+        </nav>
+        <div className="glass rounded-xl px-4 py-2 flex items-center gap-2 w-64">
           <svg className="w-4 h-4 text-on-surface-variant shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
@@ -288,82 +299,81 @@ export default function GraphView() {
         </div>
       </div>
 
-      {/* Force graph */}
-      <ForceGraph2D
-        graphData={fgData}
-        width={dimensions.width}
-        height={dimensions.height}
-        nodeId="id"
-        linkSource="source"
-        linkTarget="target"
-        nodeCanvasObject={paintNode}
-        nodeCanvasObjectMode={() => 'replace'}
-        nodePointerAreaPaint={paintNodeArea}
-        linkColor={() => 'rgba(148, 163, 184, 0.3)'}
-        linkWidth={1}
-        linkLabel="relationship_type"
-        onNodeClick={handleNodeClick}
-        onBackgroundClick={() => setSelectedNode(null)}
-        cooldownTicks={100}
-        backgroundColor="#0b1326"
-      />
+      <div ref={containerRef} className="flex-1 bg-canvas relative">
+        <ForceGraph2D
+          graphData={fgData}
+          width={dimensions.width}
+          height={dimensions.height}
+          nodeId="id"
+          linkSource="source"
+          linkTarget="target"
+          nodeCanvasObject={paintNode}
+          nodeCanvasObjectMode={() => 'replace'}
+          nodePointerAreaPaint={paintNodeArea}
+          linkColor={() => 'rgba(148, 163, 184, 0.3)'}
+          linkWidth={1}
+          linkLabel="relationship_type"
+          onNodeClick={handleNodeClick}
+          onBackgroundClick={() => setSelectedNode(null)}
+          cooldownTicks={100}
+          backgroundColor="#0b1326"
+        />
 
-      {/* Selected node popover */}
-      {selectedNode && popoverColors && (
-        <div className="absolute top-16 right-4 z-10 w-72 glass rounded-2xl p-5 space-y-3">
-          <span className={`inline-block text-label px-2 py-0.5 rounded-full ${popoverColors.bg} ${popoverColors.text}`}>
-            {typeLabel(selectedNode.type_hint)}
-          </span>
-          <h3 className="text-title text-on-surface">{selectedNode.title}</h3>
+        {selectedNode && popoverColors && (
+          <div className="absolute top-4 right-4 z-10 w-72 glass rounded-2xl p-5 space-y-3">
+            <span className={`inline-block text-label px-2 py-0.5 rounded-full ${popoverColors.bg} ${popoverColors.text}`}>
+              {typeLabel(selectedNode.type_hint)}
+            </span>
+            <h3 className="text-title text-on-surface">{selectedNode.title}</h3>
 
-          {connectedEntities.length > 0 && (
-            <div className="space-y-1.5">
-              <span className="text-label text-on-surface-variant">Connected Entities</span>
-              <ul className="space-y-1">
-                {connectedEntities.slice(0, 5).map(e => (
-                  <li key={e.id} className="text-body text-on-surface-variant flex items-center gap-1.5">
-                    <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: nodeColor(e.type_hint) }} />
-                    {truncate(e.title, 30)}
-                  </li>
-                ))}
-                {connectedEntities.length > 5 && (
-                  <li className="text-body text-on-surface-variant/50">
-                    +{connectedEntities.length - 5} more
-                  </li>
-                )}
-              </ul>
+            {connectedEntities.length > 0 && (
+              <div className="space-y-1.5">
+                <span className="text-label text-on-surface-variant">Connected Entities</span>
+                <ul className="space-y-1">
+                  {connectedEntities.slice(0, 5).map(e => (
+                    <li key={e.id} className="text-body text-on-surface-variant flex items-center gap-1.5">
+                      <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: nodeColor(e.type_hint) }} />
+                      {truncate(e.title, 30)}
+                    </li>
+                  ))}
+                  {connectedEntities.length > 5 && (
+                    <li className="text-body text-on-surface-variant/50">
+                      +{connectedEntities.length - 5} more
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
+
+            <div className="flex gap-2 pt-1">
+              <button
+                onClick={handleExplore}
+                className="gradient-cta text-label px-4 py-1.5 rounded-lg"
+              >
+                Explore
+              </button>
+              <button
+                onClick={() => {
+                  useStore.getState().openThingDetail(selectedNode.id)
+                  setSelectedNode(null)
+                }}
+                className="glass text-label text-on-surface px-4 py-1.5 rounded-lg hover:bg-surface-container-high/80"
+              >
+                Edit Note
+              </button>
             </div>
-          )}
-
-          <div className="flex gap-2 pt-1">
-            <button
-              onClick={handleExplore}
-              className="gradient-cta text-label px-4 py-1.5 rounded-lg"
-            >
-              Explore
-            </button>
-            <button
-              onClick={() => {
-                useStore.getState().openThingDetail(selectedNode.id)
-                setSelectedNode(null)
-              }}
-              className="glass text-label text-on-surface px-4 py-1.5 rounded-lg hover:bg-surface-container-high/80"
-            >
-              Edit Note
-            </button>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Legend bar */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
-        <div className="glass rounded-xl px-5 py-2 flex items-center gap-5">
-          {LEGEND_ITEMS.map(item => (
-            <div key={item.label} className="flex items-center gap-1.5">
-              <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
-              <span className="text-label text-on-surface-variant">{item.label}</span>
-            </div>
-          ))}
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+          <div className="glass rounded-xl px-5 py-2 flex items-center gap-5">
+            {LEGEND_ITEMS.map(item => (
+              <div key={item.label} className="flex items-center gap-1.5">
+                <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
+                <span className="text-label text-on-surface-variant">{item.label}</span>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/GraphView.tsx
+++ b/frontend/src/components/GraphView.tsx
@@ -234,32 +234,8 @@ export default function GraphView() {
     ctx.fillRect(x - size, y - size, size * 2, size * 2)
   }, [])
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-full text-on-surface-variant">
-        Loading graph…
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center h-full text-ideas">
-        {error}
-      </div>
-    )
-  }
-
-  if (!graphData || graphData.nodes.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-full text-on-surface-variant">
-        No things to display in graph view.
-      </div>
-    )
-  }
-
   // Transform for react-force-graph: links use source/target
-  const fgData = {
+  const fgData = graphData ? {
     nodes: graphData.nodes,
     links: graphData.edges.map(e => ({
       source: e.source,
@@ -267,21 +243,21 @@ export default function GraphView() {
       relationship_type: e.relationship_type,
       id: e.id,
     })),
-  }
+  } : null
 
   const popoverColors = selectedNode ? typeColorClass(selectedNode.type_hint) : null
 
   return (
     <div className="w-full h-full flex flex-col">
       <div className="bg-surface-container-low flex items-center justify-between px-6 h-12 shrink-0">
-        <nav className="flex gap-6 text-sm font-medium">
+        <nav className="flex gap-6 text-label" aria-label="View switcher">
           <button
             onClick={() => setMainView('list')}
             className="text-on-surface-variant hover:text-on-surface transition-colors"
           >
             List
           </button>
-          <button className="text-on-surface font-semibold border-b-2 border-primary pb-1">
+          <button aria-current="page" className="text-on-surface font-semibold border-b-2 border-primary pb-1">
             Graph
           </button>
         </nav>
@@ -300,6 +276,23 @@ export default function GraphView() {
       </div>
 
       <div ref={containerRef} className="flex-1 bg-canvas relative">
+        {loading && (
+          <div className="flex items-center justify-center h-full text-on-surface-variant">
+            Loading graph…
+          </div>
+        )}
+        {!loading && error && (
+          <div className="flex items-center justify-center h-full text-ideas">
+            {error}
+          </div>
+        )}
+        {!loading && !error && (!graphData || graphData.nodes.length === 0) && (
+          <div className="flex items-center justify-center h-full text-on-surface-variant">
+            No things to display in graph view.
+          </div>
+        )}
+        {!loading && !error && fgData && graphData && graphData.nodes.length > 0 && (
+          <>
         <ForceGraph2D
           graphData={fgData}
           width={dimensions.width}
@@ -375,6 +368,8 @@ export default function GraphView() {
             ))}
           </div>
         </div>
+          </>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Add prominent List/Graph text-link tabs to the GraphView header for improved discoverability and navigation. The existing floating search bar moves into the right side of the header bar. The Sidebar icon toggle remains as a secondary affordance.

**Issue**: Fixes #696

## Changes

- ****: Restructure component JSX with new header bar
  - Add header row with List/Graph tab buttons
  - Move search bar from absolute-centered float to header's right side
  - Move  from outer div to inner graph div (prevents height overflow)
  - Update selected-node popover positioning from `top-16` to `top-4` (accommodates new header)
  - Add `setMainView` store selector for List tab navigation

## Design

- **Active tab**: Bold text with bottom border in primary color (Graph tab)
- **Inactive tab**: Muted text color with hover state (List tab)
- **Header background**: `bg-surface-container-low` with `h-12` fixed height
- **Layout**: Flex column with header (`shrink-0`) and scrollable graph area (`flex-1`)

## Validation

- ✅ Type-check: `tsc -b` — 0 errors
- ✅ Lint: `npm run lint` — 0 errors, 2 pre-existing warnings
- ✅ Tests: 320 passed, 0 failed
- ✅ Build: `vite build` — succeeded

## Testing

- [x] Graph view shows header bar with List/Graph tabs
- [x] Active/inactive tab states correct
- [x] List tab navigation works
- [x] Search bar functional in header position
- [x] Sidebar icon toggle unaffected
- [x] No layout regressions (ResizeObserver works on inner div)
