### PR TITLE
BriefingPanel: promote "The One Thing" to hero card

### DIFF
--- a/frontend/src/components/BriefingPanel.tsx
+++ b/frontend/src/components/BriefingPanel.tsx
@@ -327,9 +327,9 @@ export function BriefingPanel() {
   const todayISO = new Date().toLocaleDateString('en-CA')  // YYYY-MM-DD in local TZ
   const todayEvents = calendarEvents.filter(e => e.start.slice(0, 10) === todayISO)
 
-  const dueTodayItems = theOneThing ? [theOneThing, ...secondaryItems] : secondaryItems
+  const dueTodayItems = secondaryItems
 
-  const hasContent = dueTodayItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0 || todayEvents.length > 0
+  const hasContent = theOneThing != null || dueTodayItems.length > 0 || findings.length > 0 || learnedPreferences.length > 0 || todayEvents.length > 0
 
   return (
     <div className="flex-1 flex flex-col bg-canvas min-w-0 min-h-0">
@@ -405,6 +405,45 @@ export function BriefingPanel() {
               {todayEvents.map(e => <TodayEventRow key={e.id} event={e} />)}
             </div>
           </SectionCard>
+        )}
+
+        {/* The One Thing — hero card */}
+        {theOneThing && (
+          <section className="px-6 pb-4">
+            <div className="relative group">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary to-primary/20 blur-xl opacity-20 group-hover:opacity-30 transition-opacity rounded-[2rem]" />
+              <div className="relative bg-surface-container-high p-8 rounded-[2rem] border-l-4 border-primary overflow-hidden">
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-ideas animate-pulse shrink-0" />
+                    <span className="text-[10px] uppercase tracking-[0.2em] font-bold text-on-surface-variant">Most Important</span>
+                  </div>
+                  <h3 className="text-3xl font-black tracking-tighter text-on-surface leading-tight">
+                    {theOneThing.thing.title}
+                  </h3>
+                  {theOneThing.thing.checkin_date && (
+                    <p className="text-sm font-medium text-primary">
+                      Due {new Date(theOneThing.thing.checkin_date).toLocaleDateString(undefined, { weekday: 'long' })}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-2 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => handleDoneThing(theOneThing.thing.id)}
+                      className="text-xs text-primary hover:text-primary/80 font-medium"
+                    >
+                      Done
+                    </button>
+                    <button
+                      onClick={() => openChatWithContext(theOneThing.thing.id, theOneThing.thing.title)}
+                      className="text-xs text-on-surface-variant hover:text-on-surface"
+                    >
+                      Chat
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
         )}
 
         {/* Due Today */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -979,11 +979,14 @@ export function Sidebar() {
                 </div>
                 {/* Desktop hero card — existing glass card */}
                 <div
-                  className="hidden md:block glass p-5 rounded-2xl cursor-pointer hover:bg-surface-container-high/80 transition-colors"
+                  className="hidden md:block glass p-5 rounded-2xl border-l-4 border-primary cursor-pointer hover:bg-surface-container-high/80 transition-colors"
                   onClick={() => useStore.getState().openThingDetail(theOneThing.thing.id)}
                   role="button"
                 >
-                  <p className="text-label font-bold text-on-surface-variant mb-2">The One Thing</p>
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="w-2 h-2 rounded-full bg-ideas animate-pulse shrink-0" />
+                    <p className="text-label font-bold text-on-surface-variant">The One Thing</p>
+                  </div>
                   <h3 className="text-on-surface font-bold text-lg leading-tight">{theOneThing.thing.title}</h3>
                   {theOneThing.reasons.length > 0 && (
                     <p className="text-xs text-on-surface-variant mt-2 leading-snug">


### PR DESCRIPTION
## Summary
Promote \"The One Thing\" from a plain list row into a visually dominant hero card in BriefingPanel.tsx with gradient glow, pulsing indicator, and prominent styling. Add matching pulsing-dot + left-border treatment to the Sidebar.tsx desktop card for consistency.

## Changes
- **frontend/src/components/BriefingPanel.tsx** (+42/-2): Separated theOneThing from secondaryItems; renders as standalone hero card with gradient glow, pulsing dot, text-3xl font-black title, left-border-4 accent, and hover-revealed action buttons
- **frontend/src/components/Sidebar.tsx** (+4/-2): Added pulsing dot and border-l-4 border-primary to desktop \"The One Thing\" card

## Validation
✅ Build: TypeScript compilation completed without errors; Vite built in 467ms  
✅ Lint: 0 errors (2 pre-existing warnings unrelated to this PR)  
✅ Tests: 356 tests passed, 0 failed  
✅ Type check: No TypeScript errors  

## Screenshots / Visual Testing
Desktop briefing panel and mobile briefing panel screenshot tests have pre-existing blank snapshot issues due to a locator problem with `div.flex-1.flex.flex-col`. Sidebar screenshot tests pass without changes.

## Design Compliance
Implementation follows design spec in `design/reli_daily_briefing/code.html` and `design/reli_things_the_radar/code.html`, with visual hierarchy clearly distinguishing \"The One Thing\" from secondary items.

Fixes #690