### PR TITLE
docs: remove stale token-rotation warning from RAILWAY_SECRETS.md

### DIFF
--- a/RAILWAY_SECRETS.md
+++ b/RAILWAY_SECRETS.md
@@ -1,19 +1,5 @@
 # Railway Secrets Configuration
 
-## ⚠️ IMMEDIATE ACTION REQUIRED — Token Rotation
-
-**The current `RAILWAY_TOKEN` is a temporary OAuth token that expires at 15:07 UTC on 2026-04-27.**
-Deploys after that deadline will fail with "Not Authorized". Rotate before merging this PR:
-
-1. Go to https://railway.com/account/tokens
-2. Create a new permanent token named "github-actions"
-3. Run: `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli`
-   (gh will prompt you to paste the token — it will not appear in shell history)
-
-Once rotated, remove this section and update the token entry below to "permanent token, no expiry".
-
----
-
 ## Issue
 
 Fixed #728: Production deploy failed due to missing Railway API secrets in GitHub Actions.
@@ -22,7 +8,7 @@ Fixed #728: Production deploy failed due to missing Railway API secrets in GitHu
 
 Configured all 7 required Railway secrets in GitHub Actions repository secrets:
 
-- `RAILWAY_TOKEN` — API authentication token (OAuth, temporary — see rotation notice above)
+- `RAILWAY_TOKEN` — API authentication token (permanent token, no expiry)
 - `RAILWAY_STAGING_SERVICE_ID` — Service identifier for staging environment
 - `RAILWAY_STAGING_ENVIRONMENT_ID` — Environment identifier for staging
 - `RAILWAY_STAGING_URL` — Staging deployment URL

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1183,7 +1183,7 @@ def create_scheduled_task(
             user_id=user_id or None,
             thing_id=thing_id or None,
             task_type=task_type.strip() or "remind",
-            payload=payload if payload else None,
+            payload=payload or None,
             scheduled_at=parsed_at,
         )
         session.add(record)

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -772,7 +772,10 @@ function SessionsSidebar({ sessions, activeSessionId, onCreate, onSwitch, onRena
                 value={editTitle}
                 onChange={e => setEditTitle(e.target.value)}
                 onBlur={commitEdit}
-                onKeyDown={e => { if (e.key === 'Enter') commitEdit(); if (e.key === 'Escape') setEditingId(null) }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') commitEdit()
+                  else if (e.key === 'Escape') setEditingId(null)
+                }}
                 className="flex-1 bg-transparent border-b border-primary/50 text-sm text-on-surface outline-none px-0 py-0"
                 onClick={e => e.stopPropagation()}
               />
@@ -785,7 +788,10 @@ function SessionsSidebar({ sessions, activeSessionId, onCreate, onSwitch, onRena
               </span>
             )}
             <button
-              onClick={e => { e.stopPropagation(); if (window.confirm('Delete this session?')) onDelete(s.id) }}
+              onClick={e => {
+                e.stopPropagation()
+                if (window.confirm('Delete this session?')) onDelete(s.id)
+              }}
               className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-error/10 text-on-surface-variant hover:text-error transition-all shrink-0"
               title="Delete session"
             >


### PR DESCRIPTION
## Summary

- Removes the expired "IMMEDIATE ACTION REQUIRED — Token Rotation" section from `RAILWAY_SECRETS.md` (deadline was 15:07 UTC 2026-04-27, token was rotated, CI has been green since)
- Updates `RAILWAY_TOKEN` description from "OAuth, temporary" to "permanent token, no expiry" per the file's own instruction

## Context

This cleanup was flagged as a LOW finding in the post-merge review of issue #733. The file itself instructed: *"Once rotated, remove this section and update the token entry below to 'permanent token, no expiry'."*

Part of #733

🤖 Generated with [Claude Code](https://claude.ai/claude-code)