### PR TITLE
fix: add Railway API token auth check to deploy pre-flight

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -46,6 +46,15 @@ jobs:
             echo "See DEPLOYMENT_SECRETS.md for setup instructions."
             exit 1
           fi
+          RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+            -H "Authorization: Bearer $RAILWAY_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"query":"{me{id}}"}')
+          if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
+            echo "::error::RAILWAY_TOKEN is invalid or expired: $(echo "$RESP" | jq -r '.errors[0].message')"
+            echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
+            exit 1
+          fi
 
       - name: Deploy staging image to Railway
         env:
@@ -151,6 +160,15 @@ jobs:
           if [ -n "$missing" ]; then
             echo "::error::Missing required secrets:$missing"
             echo "See DEPLOYMENT_SECRETS.md for setup instructions."
+            exit 1
+          fi
+          RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+            -H "Authorization: Bearer $RAILWAY_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"query":"{me{id}}"}')
+          if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
+            echo "::error::RAILWAY_TOKEN is invalid or expired: $(echo "$RESP" | jq -r '.errors[0].message')"
+            echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
             exit 1
           fi
 

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -46,12 +46,13 @@ jobs:
             echo "See DEPLOYMENT_SECRETS.md for setup instructions."
             exit 1
           fi
-          RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+          RESP=$(curl -s -X POST "https://backboard.railway.app/graphql/v2" \
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"query":"{me{id}}"}')
-          if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
-            echo "::error::RAILWAY_TOKEN is invalid or expired: $(echo "$RESP" | jq -r '.errors[0].message')"
+          if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+            MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+            echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
             echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
             exit 1
           fi
@@ -162,12 +163,13 @@ jobs:
             echo "See DEPLOYMENT_SECRETS.md for setup instructions."
             exit 1
           fi
-          RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+          RESP=$(curl -s -X POST "https://backboard.railway.app/graphql/v2" \
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"query":"{me{id}}"}')
-          if echo "$RESP" | jq -e '.errors' > /dev/null 2>&1; then
-            echo "::error::RAILWAY_TOKEN is invalid or expired: $(echo "$RESP" | jq -r '.errors[0].message')"
+          if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+            MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+            echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
             echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fixes production deploy failures caused by invalid or expired Railway API tokens passing the existing validation check. The previous validation only checked that `RAILWAY_TOKEN` was non-empty, not that it was valid.

## Changes

Updated `.github/workflows/staging-pipeline.yml`:
- Added Railway API token authentication check to the **staging** validate step: calls `me { id }` query to verify token is accepted by Railway API
- Added the same token authentication check to the **production** validate step
- Both checks run after the empty-secret gate, providing a clear error message if the token is invalid or expired

This catches token validity issues during the validate step with an actionable error message, rather than failing later in the deploy step with a cryptic "Not Authorized" response.

## Validation

- ✅ YAML syntax valid
- ✅ TypeScript compilation passes (tsc -b)
- ✅ Lint: 0 errors (2 pre-existing warnings)
- ✅ All 373 tests pass
- ✅ Build succeeds

**Fixes #737**