### PR TITLE
ci: run Railway token health check daily instead of weekly

### DIFF
--- a/.github/workflows/railway-token-health.yml
+++ b/.github/workflows/railway-token-health.yml
@@ -2,7 +2,7 @@ name: Railway Token Health Check
 
 on:
   schedule:
-    - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
+    - cron: '0 9 * * *'  # Every day at 09:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/railway-token-health.yml
+++ b/.github/workflows/railway-token-health.yml
@@ -37,7 +37,7 @@ jobs:
           if [ -z "$RAILWAY_TOKEN" ]; then
             create_issue_if_absent "Railway token missing" \
               "Railway token missing — RAILWAY_TOKEN secret is not set" \
-              "The RAILWAY_TOKEN GitHub secret is missing. See DEPLOYMENT_SECRETS.md for rotation instructions."
+              "The RAILWAY_TOKEN GitHub secret is missing. See docs/RAILWAY_TOKEN_ROTATION_742.md for rotation instructions."
             exit 1
           fi
           RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
@@ -48,7 +48,7 @@ jobs:
             MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
             create_issue_if_absent "Railway token expired" \
               "Railway token expired — rotate RAILWAY_TOKEN before next deploy" \
-              "Weekly token health check failed: \`$MSG\`. See DEPLOYMENT_SECRETS.md Token Rotation section."
+              "Daily token health check failed: \`$MSG\`. See docs/RAILWAY_TOKEN_ROTATION_742.md for rotation instructions."
             exit 1
           fi
           echo "RAILWAY_TOKEN is valid."

--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -97,7 +97,6 @@ export function FeedbackDialog() {
   return (
     <div data-screenshot-exclude className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="bg-surface-container-low rounded-xl shadow-2xl w-full max-w-md mx-4">
-        {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Send Feedback</h2>
           <button
@@ -111,7 +110,6 @@ export function FeedbackDialog() {
           </button>
         </div>
 
-        {/* Content */}
         <div className="px-6 py-5 space-y-4">
           {result?.success ? (
             <div className="text-center py-4">
@@ -188,7 +186,6 @@ export function FeedbackDialog() {
                 </p>
               </div>
 
-              {/* Screenshot */}
               <div>
                 {screenshotBase64 ? (
                   <div className="relative inline-block">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1070,12 +1070,14 @@ export function Sidebar() {
                 </h2>
                 {conflictAlerts.map((alert, i) => {
                   const severityColor = SEVERITY_COLORS[alert.severity] ?? 'text-primary'
-                  const severityIcon = alert.severity === 'critical' ? '\u{1F6A8}' : alert.severity === 'warning' ? '\u26A0\uFE0F' : '\u2139\uFE0F'
-                  const typeIcon = alert.alert_type === 'blocking_chain' ? '\u{1F6D1}' : alert.alert_type === 'schedule_overlap' ? '\u{1F4C5}' : '\u23F0'
+                  const SEVERITY_ICONS: Record<string, string> = { critical: '\u{1F6A8}', warning: '\u26A0\uFE0F' }
+                  const ALERT_TYPE_ICONS: Record<string, string> = { blocking_chain: '\u{1F6D1}', schedule_overlap: '\u{1F4C5}' }
+                  const severityIcon = SEVERITY_ICONS[alert.severity] ?? '\u2139\uFE0F'
+                  const alertTypeIcon = ALERT_TYPE_ICONS[alert.alert_type] ?? '\u23F0'
                   return (
                     <div key={`conflict-${i}`} className="px-4 py-1.5 hover:bg-surface-container-high transition-colors">
                       <div className="flex items-start gap-2">
-                        <span className="text-sm mt-0.5 shrink-0">{typeIcon}</span>
+                        <span className="text-sm mt-0.5 shrink-0">{alertTypeIcon}</span>
                         <div className="flex-1 min-w-0">
                           <p className={`text-sm leading-snug ${severityColor}`}>
                             {alert.message}


### PR DESCRIPTION
## Summary

- Change Railway token health check cron from `0 9 * * 1` (Mondays only) to `0 9 * * *` (every day)
- The weekly schedule can miss token expiry by up to 6 days, causing recurring deploy failures

## Why

The `RAILWAY_TOKEN` has expired 4 times (#733, #739, #742, #755) because previous rotations used short-TTL tokens. The weekly health check doesn't catch this fast enough — worst case is the token expires Tuesday and we don't find out until the following Monday (6 days of broken deploys).

Daily checks reduce worst-case mean time to detect from ~6 days to ~23 hours, well within acceptable CI/CD impact.

## Note

This PR does **not** fix the current expired token — that requires human action (see `docs/RAILWAY_TOKEN_ROTATION_742.md`). This prevents the *next* expiry from going undetected for days.

Part of #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)