### PR TITLE
docs: investigation for issue #774 (11th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md
+++ b/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md
@@ -42,9 +42,9 @@ WHY: run `25153294867` failed
   Evidence: CI log line `2026-04-30T07:34:56.5710012Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
 
 ↓ BECAUSE: `secrets.RAILWAY_TOKEN` has reached its expiry and was not rotated when investigation PRs #770 and #772 landed
-  Evidence: identical failure on the next run `25153282216` (07:34:33Z) on the same SHA `0ca82844`; identical failure on the prior post-merge run `25151102981` for #771; the rotation cannot happen on a PR merge — only via railway.com.
+  Evidence: identical failure on the immediately-prior run `25153282216` (07:34:33Z) on the same SHA `0ca82844`; identical failure on the prior post-merge run `25151102981` for #771; the rotation cannot happen on a PR merge — only via railway.com.
 
-↓ ROOT CAUSE: prior rotations created Railway tokens with a finite TTL instead of selecting **No expiration**. No human has yet performed the rotation that resolves the current expiry window — the auto-pickup cron has now produced 11 occurrences across 9 unique issues (`#733 → #739 → #742 → #755 → #762 → #769 → #771 → #774`, with #751, #766 also re-firing on the same expired secret, plus 3 internal re-fires of #762).
+↓ ROOT CAUSE: prior rotations created Railway tokens with a finite TTL instead of selecting **No expiration**. The auto-pickup cron has now produced **11 occurrences across 10 unique issues** (`#733 → #739 → #742 → #755 → #762 → #751 → #766 → #762 (re-fire) → #769 → #771 → #774`). No human has yet performed the rotation that resolves the current expiry window.
 
 ### Affected Files
 
@@ -213,7 +213,7 @@ gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 1     
 
 **Deferred follow-ups** (file by a human after #774 closes and rotation is verified):
 
-1. **Investigation-only loop-stopper for `archon:in-progress`** (P2) — the auto-pickup cron has produced 11 occurrences across 9 unique issues on the same expired secret because no PR ever lands on no-op investigations. The cron should suppress re-firing while a `RAILWAY_TOKEN` issue is open.
+1. **Investigation-only loop-stopper for `archon:in-progress`** (P2) — the auto-pickup cron has produced 11 occurrences across 10 unique issues on the same expired secret because no PR ever lands on no-op investigations. The cron should suppress re-firing while a `RAILWAY_TOKEN` issue is open.
 2. **Migrate away from long-lived `RAILWAY_TOKEN` PAT** (P2) — service-account token or scheduled-rotation automation. Railway has no OIDC trust feature as of April 2026.
 3. **Standardise on `backboard.railway.com` across all `curl` sites** (P3) — defensive against future `.app` retirement; ~7 call sites today.
 4. **Rename secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN`** (P3) — Railway CLI conventions now treat `RAILWAY_TOKEN` as project-only; renaming the secret avoids the ambiguity that triggered finding 1 in PR #768's `web-research.md`.

--- a/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md
+++ b/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md
@@ -1,0 +1,228 @@
+# Investigation: Prod deploy failed on main (11th `RAILWAY_TOKEN` expiration)
+
+**Issue**: #774 (https://github.com/alexsiri7/reli/issues/774)
+**Type**: BUG
+**Investigated**: 2026-04-30T08:05:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | The pre-flight `Validate Railway secrets` step at `.github/workflows/staging-pipeline.yml:32-58` aborts every staging+prod deploy on `main` — nothing ships until a human rotates the GitHub Actions secret. |
+| Complexity | LOW | No code change is permitted; the canonical runbook already exists at `docs/RAILWAY_TOKEN_ROTATION_742.md` and the action is one Railway dashboard rotation + one `gh secret set`. |
+| Confidence | HIGH | Run [`25153294867`](https://github.com/alexsiri7/reli/actions/runs/25153294867) emits `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` on 2026-04-30T07:34:56Z; the immediately-prior run [`25153282216`](https://github.com/alexsiri7/reli/actions/runs/25153282216) on the same SHA `0ca82844` (merge of investigation PR #770) failed identically at 07:34:33Z, proving the secret is still bad. |
+
+---
+
+## Problem Statement
+
+The `RAILWAY_TOKEN` GitHub Actions secret is still expired. The `Validate Railway secrets` pre-flight step in `.github/workflows/staging-pipeline.yml` calls Railway's `me{id}` GraphQL probe, receives `Not Authorized`, and aborts the deploy.
+
+This is the **11th identical recurrence** of the same failure mode — the post-merge CI of investigation PR #770 (which itself documented the 9th occurrence) produced two more sister failures (issues #773 and #774) within 21 seconds of each other, confirming that no human has yet rotated the secret since #771's investigation PR #772 merged.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+This is a **process / human-action defect**, not a code defect. The workflow is failing closed exactly as designed (`.github/workflows/staging-pipeline.yml:32-58`), and editing it to mask the failure would itself be a defect. Per `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+### Evidence Chain
+
+WHY: run `25153294867` failed
+↓ BECAUSE: the `Validate Railway secrets` job step exited 1
+  Evidence: `.github/workflows/staging-pipeline.yml:53-58` — `if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then … exit 1; fi`
+
+↓ BECAUSE: Railway returned `Not Authorized` to the `me{id}` GraphQL probe
+  Evidence: CI log line `2026-04-30T07:34:56.5710012Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: `secrets.RAILWAY_TOKEN` has reached its expiry and was not rotated when investigation PRs #770 and #772 landed
+  Evidence: identical failure on the next run `25153282216` (07:34:33Z) on the same SHA `0ca82844`; identical failure on the prior post-merge run `25151102981` for #771; the rotation cannot happen on a PR merge — only via railway.com.
+
+↓ ROOT CAUSE: prior rotations created Railway tokens with a finite TTL instead of selecting **No expiration**. No human has yet performed the rotation that resolves the current expiry window — the auto-pickup cron has now produced 11 occurrences across 9 unique issues (`#733 → #739 → #742 → #755 → #762 → #769 → #771 → #774`, with #751, #766 also re-firing on the same expired secret, plus 3 internal re-fires of #762).
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` | NEW | CREATE | This investigation artifact (lineage update + human-action checklist) |
+
+**Deliberately not changed** (per `CLAUDE.md`):
+- `.github/workflows/staging-pipeline.yml` — failing closed correctly; editing it would mask the real defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is correct.
+- No `.github/RAILWAY_TOKEN_ROTATION_*.md` will be created — Category 1 error.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step using `me{id}` probe.
+- `.github/workflows/staging-pipeline.yml:60-80` — `Deploy staging image to Railway` (`serviceInstanceUpdate` mutation), would also fail without rotation.
+- `.github/workflows/railway-token-health.yml` — independent health-check workflow (`Railway Token Health Check`, id `267379829`) that the operator uses to verify the new secret before re-running deploys.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical rotation runbook referenced from `CLAUDE.md`.
+
+### Git History
+
+- **Most recent CI failure**: run `25153294867` at 2026-04-30T07:34:43Z on SHA `0ca82844` (the merge commit of investigation PR #770).
+- **Sibling failure on same SHA**: run `25153282216` at 2026-04-30T07:34:22Z (also failed at the same step).
+- **Prior occurrences (canonical chain)**: per the lineage table below, this is the 11th.
+
+| # | Issue | Investigation PR | Notes |
+|---|-------|------------------|-------|
+| 1 | #733 | (fix-only) | |
+| 2 | #739 | (fix-only) | |
+| 3 | #742 | #743 | |
+| 4 | #755 | #761 | |
+| 5 | #762 | #764 | |
+| 6 | #751 | #765 | |
+| 7 | #766 | #767 | |
+| 8 | #762 (re-fire) | #768 | |
+| 9 | #769 | #770 | |
+| 10 | #771 | #772 | |
+| 11 | **#774** | **(this PR)** | Sibling: #773 — same run `25153294867`, filed by a different cron template ("Main CI red"). |
+
+---
+
+## Implementation Plan
+
+### Step 1 (Human) — Mint a new Railway Workspace token with No expiration
+
+**Where**: https://railway.com/account/tokens
+**Action**: Create a new **Workspace** token, **Expiration: No expiration**. Suggested name: `github-actions-permanent`.
+
+Rationale:
+- `staging-pipeline.yml:50` uses `Authorization: Bearer $RAILWAY_TOKEN` — the workspace contract. Project tokens require the `Project-Access-Token` header and would still fail the `me{id}` probe.
+- The recurrence-breaker is **No expiration**. If the dashboard does not offer that option, pick the longest TTL available, record the dropdown options as a comment on this issue, and a follow-up bead will amend `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**Why**: prior rotations were finite-TTL — that is what causes this exact issue every few days.
+
+---
+
+### Step 2 (Human) — Update the GitHub Actions secret
+
+```bash
+gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+# Paste the new token value when prompted.
+```
+
+---
+
+### Step 3 (Either) — Verify the new token
+
+```bash
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run list --workflow railway-token-health.yml --repo alexsiri7/reli --limit 1
+# Expect: conclusion: success
+```
+
+---
+
+### Step 4 (Either) — Unblock the failed deploy
+
+```bash
+gh run rerun 25153294867 --repo alexsiri7/reli --failed
+gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 1
+# Expect: conclusion: success
+```
+
+---
+
+### Step 5 (Either) — Close the issue and clear the label
+
+Close #774 (and its sibling #773) with a comment linking the green run, then remove the `archon:in-progress` label so the auto-pickup cron stops re-firing.
+
+---
+
+## Patterns to Follow
+
+**This investigation mirrors PR #770 (issue #769) and PR #772 (issue #771) exactly** — same lineage table format, same human-action checklist, same scope-boundary discipline. No code or workflow changes; the canonical runbook is reused.
+
+```yaml
+# SOURCE: .github/workflows/staging-pipeline.yml:32-58
+# This step is correct — it fails closed when the secret is bad.
+# DO NOT EDIT it to "fix" the deploy; that would mask the real defect.
+- name: Validate Railway secrets
+  env:
+    RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    ...
+  run: |
+    ...
+    RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+      -H "Authorization: Bearer $RAILWAY_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{me{id}}"}')
+    if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+      MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+      echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+      ...
+      exit 1
+    fi
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge case | Mitigation |
+|------------------|------------|
+| Dashboard no longer offers "No expiration" | Pick the longest TTL, record options on issue, file a follow-up bead to amend `docs/RAILWAY_TOKEN_ROTATION_742.md`. |
+| Fresh Workspace token still returns `Not Authorized` | Per PR #768's `web-research.md` Finding 1, Railway may have tightened `RAILWAY_TOKEN` to project-only — switch the workflow header to `Project-Access-Token` in a separate bead. |
+| Sibling issue #773 left open after #774 closes | Close #773 in the same operation, removing the `archon:in-progress` label on both. |
+| New deploys file additional sister issues before rotation lands | Expected; the auto-pickup cron will keep firing until `RAILWAY_TOKEN` is rotated. The loop-stopper is a deferred follow-up (below). |
+| Agents create a `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming success | Category 1 error per `CLAUDE.md` — explicitly forbidden. This investigation does not do that. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# Health-check the new secret (after human rotation):
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run list --workflow railway-token-health.yml --repo alexsiri7/reli --limit 1   # expect: success
+
+# Re-run the failed deploy:
+gh run rerun 25153294867 --repo alexsiri7/reli --failed
+gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 1       # expect: success
+```
+
+### Manual Verification
+
+1. Confirm the new token shows **No expiration** in https://railway.com/account/tokens.
+2. Confirm `https://reli.interstellarai.net` returns 200 after the deploy.
+3. Confirm both #774 and the sibling #773 are closed and the `archon:in-progress` label is removed on both.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE**:
+- This investigation artifact + the GitHub comment posted to #774.
+- Updating the lineage table to reflect the 11th recurrence.
+
+**OUT OF SCOPE (do not touch)**:
+- `.github/workflows/staging-pipeline.yml` — the `Validate Railway secrets` step is correct (failing closed); editing it would mask the real defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is already correct.
+- A new `web-research.md` — the one in #762/#768's artifact still applies.
+- Any `.github/RAILWAY_TOKEN_ROTATION_*.md` file — Category 1 error per `CLAUDE.md`.
+- The actual token rotation — agent-out-of-scope per `CLAUDE.md`.
+
+**Deferred follow-ups** (file by a human after #774 closes and rotation is verified):
+
+1. **Investigation-only loop-stopper for `archon:in-progress`** (P2) — the auto-pickup cron has produced 11 occurrences across 9 unique issues on the same expired secret because no PR ever lands on no-op investigations. The cron should suppress re-firing while a `RAILWAY_TOKEN` issue is open.
+2. **Migrate away from long-lived `RAILWAY_TOKEN` PAT** (P2) — service-account token or scheduled-rotation automation. Railway has no OIDC trust feature as of April 2026.
+3. **Standardise on `backboard.railway.com` across all `curl` sites** (P3) — defensive against future `.app` retirement; ~7 call sites today.
+4. **Rename secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN`** (P3) — Railway CLI conventions now treat `RAILWAY_TOKEN` as project-only; renaming the secret avoids the ambiguity that triggered finding 1 in PR #768's `web-research.md`.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7, 1M context)
+- **Timestamp**: 2026-04-30T08:05:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md`
+- **Workflow run id**: `d3bc806d703d06a72e9e4d5a496d8f35`

--- a/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md
+++ b/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md
@@ -1,0 +1,113 @@
+## Validation Results
+
+**Generated**: 2026-04-30 08:20
+**Workflow ID**: d3bc806d703d06a72e9e4d5a496d8f35
+**Status**: ALL_PASS (docs-only PR — standard checks N/A)
+
+---
+
+## Summary
+
+This is a **docs-only investigation PR** for issue #774 (the 11th `RAILWAY_TOKEN`
+expiration). Per `CLAUDE.md` § "Railway Token Rotation" and the investigation
+artifact's scope boundaries, **no source code, workflow, or runbook files are
+changed**. The deliverable is a single Markdown investigation document.
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No `.ts`/`.tsx`/`.py` files modified |
+| Lint | N/A | No source files modified |
+| Format | N/A | Markdown-only change |
+| Tests | N/A | No source / no test changes |
+| Build | N/A | No source files modified |
+| Branch diff vs `origin/main` | ✅ | (will be a single new `investigation.md` once committed) |
+
+---
+
+## Scope Confirmation
+
+`git diff origin/main --stat` at validation time: **0 files, 0 changes** on the
+worktree itself (the investigation artifact lives at the workspace path
+`/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md`
+and is staged for the implementation/finalize step to copy into
+`artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` and commit —
+mirroring the pattern of PR #770, #772, #768, #767, #765, #764).
+
+---
+
+## Why standard checks are skipped
+
+The five standard validation commands assume a Node/TypeScript or Python source
+diff:
+
+- `npm run type-check` (frontend) — would compile current `frontend/**/*.ts(x)`,
+  but those files are **untouched** on this branch (HEAD == `origin/main` =
+  `0ca8284`). Re-running would only re-prove `origin/main` is green, which is
+  already established by CI.
+- `npm run lint` (frontend) — same reasoning.
+- `npm run build` (frontend) — same.
+- `npm test` / `npm test:screenshots` — no UI or component changes; no new tests
+  to add.
+- `pytest` (backend) — no Python file modified.
+
+Running them would consume cycles without providing signal. They are explicitly
+**not required** for documentation-only PRs in this repo (precedent: PRs #770,
+#772, #768, #767, #765, #764 all merged green as docs-only investigations
+without modifying any source).
+
+---
+
+## Type Check
+
+**Command**: `npm --prefix frontend run build` (`tsc -b && vite build`)
+**Result**: N/A (no `.ts`/`.tsx` files in this branch's diff)
+
+## Lint
+
+**Command**: `npm --prefix frontend run lint` (`eslint .`)
+**Result**: N/A (no JS/TS source files in this branch's diff)
+
+## Format
+
+**Command**: (none defined for Markdown in this repo)
+**Result**: N/A — Markdown rendered correctly; lineage table syntax matches PR #770/#772.
+
+## Tests
+
+**Command**: `npm --prefix frontend test` (`vitest run`)
+**Result**: N/A (no source or test changes)
+
+## Build
+
+**Command**: `npm --prefix frontend run build`
+**Result**: N/A (no source changes)
+
+---
+
+## Files Modified During Validation
+
+None.
+
+---
+
+## Files in the PR Deliverable
+
+| File | Status |
+|------|--------|
+| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` | Investigation artifact (in workspace; pending copy-into-repo + commit by `archon-finalize-pr`) |
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to:
+1. Copy the workspace investigation artifact into
+   `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` in the
+   repo.
+2. Commit and push.
+3. Open / update the PR with body referencing `Fixes #774` and the lineage from
+   the investigation.
+4. After merge, the human-action checklist in `investigation.md` (mint No-expiry
+   Railway Workspace token + `gh secret set RAILWAY_TOKEN` + re-run failed
+   deploy) resolves the underlying defect — agent scope ends with the artifact
+   landing.

--- a/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md
+++ b/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md
@@ -11,7 +11,8 @@
 This is a **docs-only investigation PR** for issue #774 (the 11th `RAILWAY_TOKEN`
 expiration). Per `CLAUDE.md` § "Railway Token Rotation" and the investigation
 artifact's scope boundaries, **no source code, workflow, or runbook files are
-changed**. The deliverable is a single Markdown investigation document.
+changed**. The deliverable is three Markdown artifact files (investigation,
+web-research, and this validation document).
 
 | Check | Result | Details |
 |-------|--------|---------|
@@ -20,7 +21,7 @@ changed**. The deliverable is a single Markdown investigation document.
 | Format | N/A | Markdown-only change |
 | Tests | N/A | No source / no test changes |
 | Build | N/A | No source files modified |
-| Branch diff vs `origin/main` | ✅ | (will be a single new `investigation.md` once committed) |
+| Branch diff vs `origin/main` | ✅ | three new artifact files under `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/` |
 
 ---
 
@@ -94,7 +95,9 @@ None.
 
 | File | Status |
 |------|--------|
-| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` | Investigation artifact (in workspace; pending copy-into-repo + commit by `archon-finalize-pr`) |
+| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` | Investigation artifact |
+| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/web-research.md`  | Root-cause research notes |
+| `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md`    | This file |
 
 ---
 

--- a/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/web-research.md
+++ b/artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/web-research.md
@@ -1,0 +1,183 @@
+# Web Research: fix #774
+
+**Researched**: 2026-04-30T08:02:33Z
+**Workflow ID**: d3bc806d703d06a72e9e4d5a496d8f35
+**Issue**: alexsiri7/reli#774 — "Prod deploy failed on main" — staging-pipeline workflow's `Validate Railway secrets` step exits with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. This is the **11th recurrence** in the series tracked by `pipeline-health-cron.sh` (preceding incidents: #733, #739, #742, #751, #762, #766, #771, etc.).
+
+---
+
+## Summary
+
+The recurring failure is not a CI bug — it's the `RAILWAY_TOKEN` GitHub Actions secret repeatedly going invalid. Research surfaced three distinct root-cause angles that all match the symptom and that prior runbooks have not fully ruled out: (1) Railway's docs do not document an indefinite TTL for any token type, and account/workspace tokens commonly carry a server-side expiry that the dashboard does not warn about; (2) the `me { id }` validation query the workflow runs **only succeeds for an account-scoped (personal) token**, so a token generated under the wrong workspace context will fail the same way an expired one does; (3) the workflow validates against `https://backboard.railway.app/graphql/v2`, while community reports indicate `https://backboard.railway.com/graphql/v2` is the authoritative endpoint and `.app` returns `Not Authorized`. Issue #774 likely reflects (1) again, but (2) and (3) are worth verifying because they would reproduce the same `Not Authorized` text without an actual expiry.
+
+---
+
+## Findings
+
+### 1. Railway token types and what `me { id }` requires
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Why the validation step fails even with newly minted tokens
+
+**Key Information**:
+
+- Four token types exist: **Account Token** (broadest scope, "All your resources and workspaces"), **Workspace Token** ("Single workspace", "Best For: Team CI/CD, shared automation"), **Project Token** ("Single environment in a project", "Deployments, service-specific automation"), and **OAuth**.
+- Account & Workspace tokens are generated from `https://railway.com/account/tokens`. To get a true *account* token (not workspace-scoped), the workspace dropdown must be left at **"No workspace"**.
+- Project tokens are generated from a different page — inside Project → Settings → Tokens.
+- Crucially, the `RAILWAY_TOKEN` env var and `RAILWAY_API_TOKEN` env var have *different* expected token types: `RAILWAY_TOKEN` for project-level actions, `RAILWAY_API_TOKEN` for account-level actions ([CLI guide](https://docs.railway.com/guides/cli)).
+
+---
+
+### 2. The `{ me { id } }` query rejects project & misconfigured workspace tokens
+
+**Source**: [API Token "Not Authorized" Error for Public API and MCP — Railway Help Station](https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1)
+**Authority**: Railway-staff-answered support thread
+**Relevant to**: Direct reproduction of `Not Authorized` from a non-expired token
+
+**Key Information**:
+
+- > "From the dashboard home, click your user banner at the very BOTTOM of the navigation sidebar. Click the 3 dots and then 'Account Settings'" then navigate to Tokens. Critically, when creating the token, users should leave the workspace field as "No workspace" rather than assigning it to a specific workspace.
+- A token created from a *project* or *team/workspace* context lacks the permissions that the `me`/`teams` queries require, and the API answers `Not Authorized` — visually identical to expiry.
+- Cross-confirmed by [GraphQL requests returning "Not Authorized" for PAT](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52) and [RAILWAY_TOKEN invalid or expired](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20): "RAILWAY_TOKEN now only accepts *project token*" — i.e. environments where the CLI consumes `RAILWAY_TOKEN` won't accept account tokens, and yet the workflow's *validation* `me` query won't accept project tokens. There's a built-in trap here.
+
+---
+
+### 3. Token expiration is undocumented for project/account/workspace tokens
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens)
+**Authority**: Official Railway documentation
+**Relevant to**: Whether a true "no expiration" token even exists
+
+**Key Information**:
+
+- The OAuth flow has explicit TTLs: > "Access tokens expire after one hour." and > "The new refresh token has a fresh one-year lifetime from the time of issuance."
+- For **project / account / workspace tokens, no TTL is documented anywhere** — `docs.railway.com/integrations/api`, `docs.railway.com/guides/cli`, and the Login & Tokens page are silent on it.
+- Implication: `docs/RAILWAY_TOKEN_ROTATION_742.md` in this repo recommends "Expiration: No expiration" as a UI option. Per the public docs there is no such documented setting; if the dashboard offers it, that's good — but there is no published guarantee that such a token survives indefinitely. The 1-year refresh-token lifetime is suggestive of an industry pattern (~365 days) which would explain *some* recurrences but not an 11-incident cadence.
+
+---
+
+### 4. GraphQL endpoint host discrepancy (`.app` vs `.com`)
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api), corroborated by [Railway GraphQL API on Postman](https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api) and several Help Station threads ([GraphQL requests returning Not Authorized](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52))
+**Authority**: Official docs + community reports
+**Relevant to**: The `Validate Railway secrets` step in `.github/workflows/staging-pipeline.yml`
+
+**Key Information**:
+
+- Community reports state: > "The correct API endpoint is `https://backboard.railway.com/graphql/v2`, whereas `https://backboard.railway.app/graphql/v2` is incorrect" and that `.app` returns `Not Authorized`.
+- The current `.github/workflows/staging-pipeline.yml:48` calls `https://backboard.railway.app/graphql/v2`. If `.app` is being phased out / has stricter auth than `.com`, the validation could trip even for a token that the deployment step (which uses the Railway CLI binary, not the workflow's curl) accepts.
+- ⚠️ Caveat: the validation step has worked in *previous* successful deploys against the same `.app` URL, so this isn't a clean cause for #774 alone. But it is a low-cost fix that removes a confound.
+
+---
+
+### 5. Railway's official guidance for GitHub Actions has shifted
+
+**Source**: [Token for GitHub Action — Railway Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Railway employee answer
+**Relevant to**: Picking the right token type going forward
+
+**Key Information**:
+
+- > "use a Railway API token scoped to the user account, not a project token" — set as `RAILWAY_API_TOKEN`.
+- The same thread contradicts the docs and the [official Railway blog "Using GitHub Actions with Railway"](https://blog.railway.com/p/github-actions), which says to use a *project* token in `RAILWAY_TOKEN`.
+- The contradiction is real and current: project tokens are simpler but cannot create preview environments or be validated with `me`; account tokens are more powerful but riskier in scope.
+- For reli's narrow use case (single project, single environment, deploy + URL probe), a **project token in `RAILWAY_TOKEN`** would be sufficient *if* the validation step is rewritten to use a project-scoped query (or removed in favour of letting the deploy step itself fail loudly).
+
+---
+
+### 6. Permanent solution direction: GitHub OIDC
+
+**Source**: [OpenID Connect — GitHub Docs](https://docs.github.com/en/actions/concepts/security/openid-connect)
+**Authority**: GitHub official
+**Relevant to**: Eliminating the rotation problem entirely
+
+**Key Information**:
+
+- OIDC lets workflows mint short-lived cloud tokens at job time, removing the long-lived secret entirely.
+- **Railway does not currently advertise OIDC / workload-identity-federation support** — searches across docs, blog, and Help Station turn up no Railway-specific OIDC integration. AWS, GCP, Azure, HCP, Databricks all support it; Railway does not.
+- This is therefore a *medium-term* recommendation to file with Railway, not an immediate fix.
+
+---
+
+## Code Examples
+
+The current validation block, for context:
+
+```yaml
+# From .github/workflows/staging-pipeline.yml:36-58 (current main)
+- name: Validate Railway secrets
+  env:
+    RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    SERVICE_ID: ${{ secrets.RAILWAY_STAGING_SERVICE_ID }}
+    ENV_ID: ${{ secrets.RAILWAY_STAGING_ENVIRONMENT_ID }}
+    STAGING_URL: ${{ secrets.RAILWAY_STAGING_URL }}
+  run: |
+    # ...presence checks elided...
+    RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+      -H "Authorization: Bearer $RAILWAY_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{me{id}}"}')
+    if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+      MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+      echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+      exit 1
+    fi
+```
+
+A more robust validation that doesn't require `me`-class permissions (project-token-friendly):
+
+```yaml
+# Alternative: validate by querying the project the token is already scoped to.
+# Replace { me { id } } with a project-scoped query, e.g. fetching the
+# environment id we already have in secrets:
+RESP=$(curl -sf -X POST "https://backboard.railway.com/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":\"query{environment(id:\\\"$ENV_ID\\\"){id name}}\"}")
+```
+
+(Note the host change to `.com`. Verify against Railway's current API docs before merging.)
+
+---
+
+## Gaps and Conflicts
+
+- **Conflict**: Railway's official blog says "use a project token" for GitHub Actions; Railway employees on Help Station say "use an account token". Both are reachable from a Google search today.
+- **Gap**: No official documentation states whether project / account / workspace tokens *expire* on a fixed schedule. The 11-incident cadence in this repo is the strongest evidence we have, and even that is noisy — some past rotations may have used a TTL'd token by accident.
+- **Gap**: Whether `backboard.railway.app` is deprecated, soft-deprecated, or fully equivalent to `.com` is not authoritatively documented; community reports differ.
+- **Gap**: No public Railway OIDC / federated-identity flow exists at the time of writing.
+- **Limitation of this research**: I could not query Railway support directly or test the two endpoints, so the `.app` vs `.com` finding is based on community reports and would benefit from a one-curl confirmation.
+
+---
+
+## Recommendations
+
+1. **Short term (fixes #774):** Rotate `RAILWAY_TOKEN` per the existing runbook in `docs/RAILWAY_TOKEN_ROTATION_742.md`. Per CLAUDE.md, this is a human action — file the rotation request, do not produce a "rotation done" doc. Then re-run the failed deploy.
+
+2. **Medium term (reduce recurrence):** Confirm the token currently in `RAILWAY_TOKEN` is an **account token created with workspace = "No workspace"** at `https://railway.com/account/tokens`, with the dashboard's "no expiration" option selected if available. Document the exact UI path used in the rotation runbook so the next rotator does not accidentally pick a TTL'd or workspace-scoped token (which both produce the same `Not Authorized` symptom as expiry).
+
+3. **Medium term (remove the validation confound):** Switch the validation curl from `https://backboard.railway.app/graphql/v2` to `https://backboard.railway.com/graphql/v2`. Independently, replace `{ me { id } }` with a project-scoped query so the validation works regardless of whether the secret is an account or project token. This makes future failures unambiguously about the token, not about the validator.
+
+4. **Long term (eliminate rotation entirely):** File a feature request with Railway for GitHub Actions OIDC / workload-identity support. Until then, accept that rotation is part of operating against Railway and consider adding a calendar reminder ~330 days after each rotation rather than waiting for the cron-filed issue.
+
+5. **Do NOT:** Attempt to rotate the token from CI, write a "rotation done" markdown file, or in any way claim success on the rotation action — per CLAUDE.md "Railway Token Rotation" section, this is a Category 1 error.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Docs — Public API | https://docs.railway.com/integrations/api | Authoritative list of token types and scopes |
+| 2 | Railway Docs — Login & Tokens | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth TTL details; silence on PAT TTL |
+| 3 | Railway Docs — Using the CLI | https://docs.railway.com/guides/cli | RAILWAY_TOKEN vs RAILWAY_API_TOKEN |
+| 4 | Railway Blog — Using GitHub Actions with Railway | https://blog.railway.com/p/github-actions | Official "use project token" guidance |
+| 5 | Help Station — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Railway staff: "use account token" (contradicts blog) |
+| 6 | Help Station — RAILWAY_TOKEN invalid or expired | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | "RAILWAY_TOKEN now only accepts project token" |
+| 7 | Help Station — API Token "Not Authorized" | https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1 | Token-creation UX trap: workspace field must be "No workspace" |
+| 8 | Help Station — GraphQL requests returning Not Authorized for PAT | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | Same `Not Authorized` text from valid-but-wrong-scope tokens |
+| 9 | Postman — Railway GraphQL API | https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api | Endpoint host reference |
+| 10 | railwayapp/cli#699 | https://github.com/railwayapp/cli/issues/699 | Linux-specific CLI auth failure (not the cause here, but useful for ruling out) |
+| 11 | GitHub Docs — OpenID Connect | https://docs.github.com/en/actions/concepts/security/openid-connect | OIDC mechanics for the long-term recommendation |
+| 12 | docs/RAILWAY_TOKEN_ROTATION_742.md (in-repo) | n/a | Existing rotation runbook — referenced by CLAUDE.md |


### PR DESCRIPTION
## Summary

Adds the canonical investigation artifact for **issue #774** — the **11th recurrence** of the `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure on the staging-pipeline workflow. Per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate the Railway API token; this PR records the lineage and points operators at the existing runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) so the issue can transition out of `archon:in-progress` while a human performs the rotation.

## Lineage

Canonical chain — **10 unique issues across 11 occurrences** (#762 fired twice; #773 is a same-run sibling of #774, not a separate occurrence):

| # | Issue | Investigation PR |
|---|-------|------------------|
| 1 | #733 | (no investigation PR — fix-only) |
| 2 | #739 | (no investigation PR — fix-only) |
| 3 | #742 | #743 |
| 4 | #755 | #761 |
| 5 | #762 | #764 |
| 6 | #751 | #765 |
| 7 | #766 | #767 |
| 8 | #762 (re-fire) | #768 |
| 9 | #769 | #770 |
| 10 | #771 | #772 |
| 11 | **#774** | **this PR** |

Sibling: #773 — same workflow run `25153294867`, filed by a different cron template ("Main CI red"). Should be closed alongside #774.

Pipeline run [`25153294867`](https://github.com/alexsiri7/reli/actions/runs/25153294867) at 2026-04-30T07:34:56Z (post-merge of investigation PR #770 on SHA `0ca82844`) failed with the identical "Not Authorized" error — confirming the secret has not yet been rotated since #771's investigation PR #772 merged.

## Changes

- **Added**: `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/investigation.md` — recurrence record, lineage update, human-action checklist, scope boundaries.
- **Added**: `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/web-research.md` — root-cause angles (token type traps, undocumented TTLs, `.app` vs `.com` endpoint).
- **Added**: `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md` — confirms docs-only scope and standard checks N/A.
- **Not changed** (deliberate, per `CLAUDE.md`):
  - No edits to `.github/workflows/staging-pipeline.yml` — the `Validate Railway secrets` step (lines 32–58) is correctly failing closed; editing it would mask the real defect.
  - No edits to `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is already correct.
  - No `.github/RAILWAY_TOKEN_ROTATION_*.md` file (would be a Category 1 error per `CLAUDE.md` — claiming success on an action the agent cannot perform).

## Required human action

The fix is a single human action documented in `docs/RAILWAY_TOKEN_ROTATION_742.md`:

1. Mint a Workspace token at https://railway.com/account/tokens with **No expiration**.
2. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` with the new value.
3. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` to verify.
4. `gh run rerun 25153294867 --repo alexsiri7/reli --failed` to unblock the deploy.
5. Close #774 and sibling #773; remove `archon:in-progress` label on both.

## Validation

Docs-only change — code-level checks N/A (full details in `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/validation.md`):

| Check | Result | Reason |
|---|---|---|
| Type check | N/A | No `*.py`/`*.ts`/`*.tsx` changed |
| Lint | N/A | No source files changed |
| Format | N/A | Markdown-only |
| Tests | N/A | No source / no test changes |
| Build | N/A | No source files changed |

`git diff origin/main...HEAD` confirms only the three artifact files under `artifacts/runs/d3bc806d703d06a72e9e4d5a496d8f35/` are touched.

## Test plan

- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (Workspace token, **No expiration**)
- [ ] `railway-token-health.yml` workflow run succeeds against the new secret
- [ ] Re-run of failed prod-deploy run `25153294867` succeeds
- [ ] `https://reli.interstellarai.net` returns 200 after the deploy
- [ ] Issues #774 and sibling #773 closed; `archon:in-progress` label removed on both

Fixes #774

Generated with [Claude Code](https://claude.com/claude-code)
