### PR TITLE
docs: investigation for issue #786 (16th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md
+++ b/artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md
@@ -10,7 +10,7 @@
 |--------|-------|-----------|
 | Severity | HIGH | The `Validate Railway secrets` pre-flight at `.github/workflows/staging-pipeline.yml:32-58` is still aborting every prod deploy on `main`. Run `25161929515` (11:04:46Z, the run #786 cites) and the sibling run `25161923407` (11:04:37Z, same SHA `d21b401d`) both failed with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. Nothing ships until a human rotates the GitHub Actions secret. |
 | Complexity | LOW | No code change is permitted (per `CLAUDE.md` § "Railway Token Rotation"); the canonical runbook already exists at `docs/RAILWAY_TOKEN_ROTATION_742.md` and the action is one Railway dashboard rotation + one `gh secret set`. |
-| Confidence | HIGH | The CI log for run `25161929515` emits the canonical error string verbatim at `2026-04-30T11:04:52Z`: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`. Issue #781 (14th) closed at 11:00:15Z and #783 (15th) closed at 11:00:14Z — #786 was filed 4 minutes 40 seconds later (11:04:55Z) on the merge commit of #781's investigation PR (`d21b401d`), proving the secret was not rotated in that window. |
+| Confidence | HIGH | The CI log for run `25161929515` emits the canonical error string verbatim at `2026-04-30T11:04:52Z`: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`. Issue #781 (14th) closed at 11:00:15Z and #783 (15th) closed at 11:00:14Z; the failing deploy (run `25161929515`) ran 4m40s later at 11:04:55Z (per the issue body's `Deployed at:`), and the auto-pickup cron then filed #786 at 11:30:32Z (`createdAt`) on the merge commit of #781's investigation PR (`d21b401d`) — proving the secret was not rotated in the 4m40s deploy window nor in the subsequent 25m37s before the cron fired. |
 
 ---
 
@@ -18,7 +18,7 @@
 
 The `RAILWAY_TOKEN` GitHub Actions secret is still expired. The `Validate Railway secrets` pre-flight step in `.github/workflows/staging-pipeline.yml` calls Railway's `{me{id}}` GraphQL probe, receives `Not Authorized`, and aborts the deploy.
 
-This is the **16th identical recurrence** of the same failure mode. Issues #781 (14th) and #783 (15th) closed at 2026-04-30T11:00:15Z and 11:00:14Z respectively; the auto-pickup cron filed #786 at 11:04:55Z — 4 minutes 40 seconds after both closed cleanly — on the merge commit of #781's investigation PR (#782, SHA `d21b401d`). A sibling run `25161923407` at 11:04:37Z on the same SHA failed identically.
+This is the **16th identical recurrence** of the same failure mode. Issues #781 (14th) and #783 (15th) closed at 2026-04-30T11:00:15Z and 11:00:14Z respectively; the failing deploy (run `25161929515`) ran at 11:04:55Z — 4 minutes 40 seconds after both closed cleanly — on the merge commit of #781's investigation PR (#782, SHA `d21b401d`); the auto-pickup cron then filed #786 at 11:30:32Z, 25m37s after the deploy completed and 30m17s after the prior issues closed. A sibling run `25161923407` at 11:04:37Z on the same SHA failed identically.
 
 ---
 
@@ -69,7 +69,7 @@ WHY: run `25161929515` (cited by #786) failed
 
 - **Issue-cited failure**: run `25161929515` at 2026-04-30T11:04:46Z on SHA `d21b401d` (merge commit of investigation PR #782 for issue #781).
 - **Sibling failure proving secret is still bad**: run `25161923407` at 2026-04-30T11:04:37Z on the same SHA `d21b401d` — failed identically.
-- **Issue timing**: #781 (14th) closed at 11:00:15Z; #783 (15th) closed at 11:00:14Z; #786 was filed at 11:04:55Z — 4 minutes 40 seconds after both closed cleanly. The merge of #782 (the investigation PR for #781) triggered a fresh `staging-pipeline` run which immediately went red on the same expired secret, and the auto-pickup cron filed #786 against it.
+- **Issue timing**: #781 (14th) closed at 11:00:15Z; #783 (15th) closed at 11:00:14Z; the failing deploy (run `25161929515`) ran at 11:04:55Z — 4m40s after both closed cleanly; the auto-pickup cron filed #786 at 11:30:32Z, 25m37s after the deploy completed and 30m17s after the prior issues closed. The merge of #782 (the investigation PR for #781) triggered a fresh `staging-pipeline` run which immediately went red on the same expired secret, and the auto-pickup cron filed #786 against it.
 - **Prior occurrences (canonical chain)**: per the lineage table below, this is the 16th.
 
 | # | Issue | Investigation PR | Notes |
@@ -89,7 +89,7 @@ WHY: run `25161929515` (cited by #786) failed
 | 13 | #779 | #780 | |
 | 14 | #781 | #782 | Auto-pickup cron re-fired against `25158268693` *after* #779 closed cleanly. |
 | 15 | #783 | #784 | "Main CI red: Deploy to staging" — same expired secret, different cron template (sibling track). Filed against run `25159527419` (merge of #780). |
-| 16 | **#786** | **(this PR)** | "Prod deploy failed on main" — auto-pickup cron re-fired against `25161929515` (merge of #782 for #781) at 11:04:55Z, **4m40s after both #781 and #783 closed cleanly at ~11:00:15Z**. Confirms the loop-stopper deferred follow-up #1 from PR #782 is still unresolved. |
+| 16 | **#786** | **(this PR)** | "Prod deploy failed on main" — failing deploy (run `25161929515`, merge of #782 for #781) ran at 11:04:55Z, **4m40s after both #781 and #783 closed cleanly at ~11:00:15Z**; auto-pickup cron filed #786 at 11:30:32Z (25m37s after the deploy completed, 30m17s after siblings closed). Confirms the loop-stopper deferred follow-up #1 from PR #782 is still unresolved. |
 
 ---
 
@@ -180,7 +180,7 @@ Close #786 with a comment linking the green run, then remove the `archon:in-prog
 | Dashboard no longer offers "No expiration" | Pick the longest TTL, record options on issue, file a follow-up bead to amend `docs/RAILWAY_TOKEN_ROTATION_742.md`. |
 | Fresh Workspace token still returns `Not Authorized` | Per prior runs' `web-research.md` § Finding 2, the `{me{id}}` probe specifically requires an *account* (personal) token; a workspace token will be rejected by validation even if it would deploy successfully. If rotation lands and the probe still fails, switch the dashboard creation to "no workspace selected" (account token) or change the validation query in a separate bead. |
 | Sibling "Main CI red" issue filed in the next cron window | Close it alongside #786 and remove `archon:in-progress` on both. |
-| New deploys file additional sister issues before rotation lands | Expected; the auto-pickup cron will keep firing until `RAILWAY_TOKEN` is rotated. The 4m40s gap between #781/#783 closing and #786 filing is itself an instance of this — the loop-stopper is a deferred follow-up (below). |
+| New deploys file additional sister issues before rotation lands | Expected; the auto-pickup cron will keep firing until `RAILWAY_TOKEN` is rotated. The 4m40s gap between #781/#783 closing and the failing deploy (and 30m17s gap to #786 filing) is itself an instance of this — the loop-stopper is a deferred follow-up (below). |
 | Agents create a `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming success | Category 1 error per `CLAUDE.md` — explicitly forbidden. This investigation does not do that. |
 
 ---
@@ -222,7 +222,7 @@ gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 3     
 
 **Deferred follow-ups** (file by a human after #786 closes and rotation is verified):
 
-1. **Investigation-only loop-stopper for `archon:in-progress`** (P0, escalated again) — the auto-pickup cron has now produced 16 occurrences across 15 unique issues on the same expired secret because no PR ever lands on no-op investigations. Issue #786 was filed *4m40s after* both #781 and #783 closed cleanly, proving the cron is still firing on every red `staging-pipeline` run regardless of recent rotation-pending state. The cron should suppress re-firing while *any* `Prod deploy failed on main` issue exists for an unrotated secret (e.g. gate on a successful `railway-token-health` run rather than just on the absence of an open `archon:in-progress` sibling).
+1. **Investigation-only loop-stopper for `archon:in-progress`** (P0, escalated again) — the auto-pickup cron has now produced 16 occurrences across 15 unique issues on the same expired secret because no PR ever lands on no-op investigations. The failing deploy that issue #786 cites ran *4m40s after* both #781 and #783 closed cleanly, and the auto-pickup cron then filed #786 30m17s after they closed (25m37s after the deploy) — proving the cron is still firing on every red `staging-pipeline` run regardless of recent rotation-pending state, and that the suppression window must accommodate a ~25-minute filing latency rather than an instantaneous one. The cron should suppress re-firing while *any* `Prod deploy failed on main` issue exists for an unrotated secret (e.g. gate on a successful `railway-token-health` run rather than just on the absence of an open `archon:in-progress` sibling).
 2. **Migrate away from long-lived `RAILWAY_TOKEN` PAT** (P2) — service-account token or scheduled-rotation automation. Railway has no OIDC trust feature as of April 2026.
 3. **Standardise on `backboard.railway.com` across all `curl` sites** (P3) — defensive against future `.app` retirement.
 4. **Rename secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN`** (P3) — Railway CLI conventions now treat `RAILWAY_TOKEN` as project-only; renaming the secret avoids the ambiguity that triggered finding 1 in PR #768's `web-research.md`.

--- a/artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md
+++ b/artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md
@@ -1,0 +1,238 @@
+# Investigation: Prod deploy failed on main (16th `RAILWAY_TOKEN` expiration)
+
+**Issue**: #786 (https://github.com/alexsiri7/reli/issues/786)
+**Type**: BUG
+**Investigated**: 2026-04-30T11:36:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | The `Validate Railway secrets` pre-flight at `.github/workflows/staging-pipeline.yml:32-58` is still aborting every prod deploy on `main`. Run `25161929515` (11:04:46Z, the run #786 cites) and the sibling run `25161923407` (11:04:37Z, same SHA `d21b401d`) both failed with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. Nothing ships until a human rotates the GitHub Actions secret. |
+| Complexity | LOW | No code change is permitted (per `CLAUDE.md` § "Railway Token Rotation"); the canonical runbook already exists at `docs/RAILWAY_TOKEN_ROTATION_742.md` and the action is one Railway dashboard rotation + one `gh secret set`. |
+| Confidence | HIGH | The CI log for run `25161929515` emits the canonical error string verbatim at `2026-04-30T11:04:52Z`: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`. Issue #781 (14th) closed at 11:00:15Z and #783 (15th) closed at 11:00:14Z — #786 was filed 4 minutes 40 seconds later (11:04:55Z) on the merge commit of #781's investigation PR (`d21b401d`), proving the secret was not rotated in that window. |
+
+---
+
+## Problem Statement
+
+The `RAILWAY_TOKEN` GitHub Actions secret is still expired. The `Validate Railway secrets` pre-flight step in `.github/workflows/staging-pipeline.yml` calls Railway's `{me{id}}` GraphQL probe, receives `Not Authorized`, and aborts the deploy.
+
+This is the **16th identical recurrence** of the same failure mode. Issues #781 (14th) and #783 (15th) closed at 2026-04-30T11:00:15Z and 11:00:14Z respectively; the auto-pickup cron filed #786 at 11:04:55Z — 4 minutes 40 seconds after both closed cleanly — on the merge commit of #781's investigation PR (#782, SHA `d21b401d`). A sibling run `25161923407` at 11:04:37Z on the same SHA failed identically.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+This is a **process / human-action defect**, not a code defect. The workflow is failing closed exactly as designed (`.github/workflows/staging-pipeline.yml:32-58`), and editing it to mask the failure would itself be a defect. Per `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+### Evidence Chain
+
+WHY: run `25161929515` (cited by #786) failed
+↓ BECAUSE: the `Validate Railway secrets` job step exited 1
+  Evidence: `.github/workflows/staging-pipeline.yml:53-58` — `if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then … exit 1; fi`
+
+↓ BECAUSE: Railway returned `Not Authorized` to the `{me{id}}` GraphQL probe
+  Evidence: CI log line `2026-04-30T11:04:52.3402629Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: `secrets.RAILWAY_TOKEN` is still expired even after investigation PRs #780 (issue #779), #782 (issue #781), and #784 (issue #783) merged at ~10:00Z, ~11:00Z, and ~11:00Z respectively
+  Evidence: sibling run `25161923407` at 11:04:37Z on the same SHA `d21b401d` (the merge of #782) failed identically — `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`. The rotation cannot happen on a PR merge — only via railway.com.
+
+↓ ROOT CAUSE: prior rotations created Railway tokens with a finite TTL instead of selecting **No expiration**, *or* the token created was a workspace token that is rejected by the `{me{id}}` probe (see prior runs' `web-research.md` § Findings 1-2). The auto-pickup cron has now produced **16 occurrences across 15 unique issues** (`#733 → #739 → #742 → #755 → #762 → #751 → #766 → #762 (re-fire) → #769 → #771 → #774 → #777 → #779 → #781 → #783 → #786`). No human has yet performed the rotation that resolves the current expiry window.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md` | NEW | CREATE | This investigation artifact (lineage update + human-action checklist) |
+
+**Deliberately not changed** (per `CLAUDE.md`):
+- `.github/workflows/staging-pipeline.yml` — failing closed correctly; editing it would mask the real defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is correct.
+- No `.github/RAILWAY_TOKEN_ROTATION_*.md` will be created — Category 1 error.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step using `{me{id}}` probe (the staging-job copy that issue #786 cites).
+- `.github/workflows/staging-pipeline.yml:149-175` — `Validate Railway secrets` step in the production job (would also fail without rotation; currently skipped because the staging job aborts first).
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` (`serviceInstanceUpdate` + `serviceInstanceDeploy` mutations), would also fail without rotation.
+- `.github/workflows/railway-token-health.yml` — independent health-check workflow that the operator uses to verify the new secret before re-running deploys.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical rotation runbook referenced from `CLAUDE.md`.
+
+### Git History
+
+- **Issue-cited failure**: run `25161929515` at 2026-04-30T11:04:46Z on SHA `d21b401d` (merge commit of investigation PR #782 for issue #781).
+- **Sibling failure proving secret is still bad**: run `25161923407` at 2026-04-30T11:04:37Z on the same SHA `d21b401d` — failed identically.
+- **Issue timing**: #781 (14th) closed at 11:00:15Z; #783 (15th) closed at 11:00:14Z; #786 was filed at 11:04:55Z — 4 minutes 40 seconds after both closed cleanly. The merge of #782 (the investigation PR for #781) triggered a fresh `staging-pipeline` run which immediately went red on the same expired secret, and the auto-pickup cron filed #786 against it.
+- **Prior occurrences (canonical chain)**: per the lineage table below, this is the 16th.
+
+| # | Issue | Investigation PR | Notes |
+|---|-------|------------------|-------|
+| 1 | #733 | (fix-only) | |
+| 2 | #739 | (fix-only) | |
+| 3 | #742 | #743 | |
+| 4 | #755 | #761 | |
+| 5 | #762 | #764 | |
+| 6 | #751 | #765 | |
+| 7 | #766 | #767 | |
+| 8 | #762 (re-fire) | #768 | |
+| 9 | #769 | #770 | |
+| 10 | #771 | #772 | |
+| 11 | #774 | #776 | Sibling: #773 / PR #775 — same workflow run, different cron template. |
+| 12 | #777 | #778 | |
+| 13 | #779 | #780 | |
+| 14 | #781 | #782 | Auto-pickup cron re-fired against `25158268693` *after* #779 closed cleanly. |
+| 15 | #783 | #784 | "Main CI red: Deploy to staging" — same expired secret, different cron template (sibling track). Filed against run `25159527419` (merge of #780). |
+| 16 | **#786** | **(this PR)** | "Prod deploy failed on main" — auto-pickup cron re-fired against `25161929515` (merge of #782 for #781) at 11:04:55Z, **4m40s after both #781 and #783 closed cleanly at ~11:00:15Z**. Confirms the loop-stopper deferred follow-up #1 from PR #782 is still unresolved. |
+
+---
+
+## Implementation Plan
+
+### Step 1 (Human) — Mint a new Railway Workspace token with No expiration
+
+**Where**: https://railway.com/account/tokens
+**Action**: Create a new **Workspace** token, **Expiration: No expiration**. Suggested name: `github-actions-permanent`.
+
+Rationale:
+- `staging-pipeline.yml:50` uses `Authorization: Bearer $RAILWAY_TOKEN` — the workspace contract. Project tokens require the `Project-Access-Token` header and would still fail the `{me{id}}` probe.
+- The recurrence-breaker is **No expiration**. If the dashboard does not offer that option, pick the longest TTL available, record the dropdown options as a comment on this issue, and a follow-up bead will amend `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**Why**: prior rotations were finite-TTL — that is what causes this exact issue every few hours/days.
+
+---
+
+### Step 2 (Human) — Update the GitHub Actions secret
+
+```bash
+gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+# Paste the new token value when prompted.
+```
+
+---
+
+### Step 3 (Either) — Verify the new token
+
+```bash
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run list --workflow railway-token-health.yml --repo alexsiri7/reli --limit 1
+# Expect: conclusion: success
+```
+
+---
+
+### Step 4 (Either) — Unblock the failed deploys
+
+```bash
+# Re-run the issue-cited failure plus the sibling on the same SHA:
+gh run rerun 25161929515 --repo alexsiri7/reli --failed
+gh run rerun 25161923407 --repo alexsiri7/reli --failed
+gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 3
+# Expect: conclusion: success on all
+```
+
+---
+
+### Step 5 (Either) — Close the issue and clear the label
+
+Close #786 with a comment linking the green run, then remove the `archon:in-progress` label so the auto-pickup cron stops re-firing.
+
+---
+
+## Patterns to Follow
+
+**This investigation mirrors PR #782 (issue #781), PR #784 (issue #783), and PR #780 (issue #779) exactly** — same lineage table format, same human-action checklist, same scope-boundary discipline. No code or workflow changes; the canonical runbook is reused.
+
+```yaml
+# SOURCE: .github/workflows/staging-pipeline.yml:32-58
+# This step is correct — it fails closed when the secret is bad.
+# DO NOT EDIT it to "fix" the deploy; that would mask the real defect.
+- name: Validate Railway secrets
+  env:
+    RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+    ...
+  run: |
+    ...
+    RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+      -H "Authorization: Bearer $RAILWAY_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{me{id}}"}')
+    if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+      MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+      echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+      ...
+      exit 1
+    fi
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge case | Mitigation |
+|------------------|------------|
+| Dashboard no longer offers "No expiration" | Pick the longest TTL, record options on issue, file a follow-up bead to amend `docs/RAILWAY_TOKEN_ROTATION_742.md`. |
+| Fresh Workspace token still returns `Not Authorized` | Per prior runs' `web-research.md` § Finding 2, the `{me{id}}` probe specifically requires an *account* (personal) token; a workspace token will be rejected by validation even if it would deploy successfully. If rotation lands and the probe still fails, switch the dashboard creation to "no workspace selected" (account token) or change the validation query in a separate bead. |
+| Sibling "Main CI red" issue filed in the next cron window | Close it alongside #786 and remove `archon:in-progress` on both. |
+| New deploys file additional sister issues before rotation lands | Expected; the auto-pickup cron will keep firing until `RAILWAY_TOKEN` is rotated. The 4m40s gap between #781/#783 closing and #786 filing is itself an instance of this — the loop-stopper is a deferred follow-up (below). |
+| Agents create a `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming success | Category 1 error per `CLAUDE.md` — explicitly forbidden. This investigation does not do that. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# Health-check the new secret (after human rotation):
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run list --workflow railway-token-health.yml --repo alexsiri7/reli --limit 1   # expect: success
+
+# Re-run the failed deploys:
+gh run rerun 25161929515 --repo alexsiri7/reli --failed
+gh run rerun 25161923407 --repo alexsiri7/reli --failed
+gh run list --workflow staging-pipeline.yml --repo alexsiri7/reli --limit 3       # expect: success on all
+```
+
+### Manual Verification
+
+1. Confirm the new token shows **No expiration** in https://railway.com/account/tokens.
+2. Confirm `https://reli.interstellarai.net` returns 200 after the deploy.
+3. Confirm #786 is closed and the `archon:in-progress` label is removed.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE**:
+- This investigation artifact + the GitHub comment posted to #786.
+- Updating the lineage table to reflect the 16th recurrence (now including #783 as the 15th).
+
+**OUT OF SCOPE (do not touch)**:
+- `.github/workflows/staging-pipeline.yml` — the `Validate Railway secrets` step is correct (failing closed); editing it would mask the real defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is already correct.
+- Any `.github/RAILWAY_TOKEN_ROTATION_*.md` file — Category 1 error per `CLAUDE.md`.
+- The actual token rotation — agent-out-of-scope per `CLAUDE.md`.
+
+**Deferred follow-ups** (file by a human after #786 closes and rotation is verified):
+
+1. **Investigation-only loop-stopper for `archon:in-progress`** (P0, escalated again) — the auto-pickup cron has now produced 16 occurrences across 15 unique issues on the same expired secret because no PR ever lands on no-op investigations. Issue #786 was filed *4m40s after* both #781 and #783 closed cleanly, proving the cron is still firing on every red `staging-pipeline` run regardless of recent rotation-pending state. The cron should suppress re-firing while *any* `Prod deploy failed on main` issue exists for an unrotated secret (e.g. gate on a successful `railway-token-health` run rather than just on the absence of an open `archon:in-progress` sibling).
+2. **Migrate away from long-lived `RAILWAY_TOKEN` PAT** (P2) — service-account token or scheduled-rotation automation. Railway has no OIDC trust feature as of April 2026.
+3. **Standardise on `backboard.railway.com` across all `curl` sites** (P3) — defensive against future `.app` retirement.
+4. **Rename secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN`** (P3) — Railway CLI conventions now treat `RAILWAY_TOKEN` as project-only; renaming the secret avoids the ambiguity that triggered finding 1 in PR #768's `web-research.md`.
+5. **Reconcile validation-query token-type mismatch** (P2, follow-up only) — if the operator opts to migrate from account-scoped to workspace tokens, the validation query in `.github/workflows/staging-pipeline.yml:42` will need to change from `{me{id}}` (account-only) to `{__typename}` (works for both). This is **explicitly out of scope for this bead** — it must wait until rotation has landed and the operator decides token-type migration is desired; doing it while the current secret is expired would mask the real failure signal.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7, 1M context)
+- **Timestamp**: 2026-04-30T11:36:00Z
+- **Artifact**: `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md`
+- **Workflow run id**: `36bb722fce00aeff22f868dd098928fa`

--- a/artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md
+++ b/artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md
@@ -31,8 +31,10 @@ None. No fixes were required.
 | File | Purpose |
 |------|---------|
 | `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md` | Investigation artifact for issue #786 (16th recurrence). |
+| `artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md` | This validation artifact (negative-check evidence). |
+| `artifacts/runs/36bb722fce00aeff22f868dd098928fa/web-research.md` | Railway token-type research, retained for human follow-up after rotation. |
 
-`git status` confirms the only change is the new `artifacts/runs/36bb722fce00aeff22f868dd098928fa/` directory; the working tree is otherwise clean against `origin/main`.
+`git status` confirms the only changes are the three new files under `artifacts/runs/36bb722fce00aeff22f868dd098928fa/`; the working tree is otherwise clean against `origin/main`.
 
 ---
 

--- a/artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md
+++ b/artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md
@@ -1,0 +1,52 @@
+# Validation Results
+
+**Generated**: 2026-04-30 11:42
+**Workflow ID**: 36bb722fce00aeff22f868dd098928fa
+**Status**: ALL_PASS (N/A — docs-only)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No source code changed |
+| Lint | N/A | No source code changed |
+| Format | N/A | No source code changed |
+| Tests | N/A | No source code changed |
+| Build | N/A | No source code changed |
+
+This is a **documentation-only investigation PR** for issue #786 (16th `RAILWAY_TOKEN` expiration). The only change is a new artifact file under `artifacts/runs/36bb722fce00aeff22f868dd098928fa/`. No backend, frontend, workflow, or runtime code is touched (deliberately — see `investigation.md` § "Scope Boundaries" and `CLAUDE.md` § "Railway Token Rotation"). The standard validation suite (type-check, lint, format, tests, build) therefore has nothing to validate and is not run.
+
+---
+
+## Files Modified During Validation
+
+None. No fixes were required.
+
+---
+
+## Files Added in This Branch
+
+| File | Purpose |
+|------|---------|
+| `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md` | Investigation artifact for issue #786 (16th recurrence). |
+
+`git status` confirms the only change is the new `artifacts/runs/36bb722fce00aeff22f868dd098928fa/` directory; the working tree is otherwise clean against `origin/main`.
+
+---
+
+## Artifact Sanity Check
+
+- Investigation file exists at `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md`.
+- Frontmatter / required sections present: Assessment, Problem Statement, Analysis (Root Cause, Evidence Chain, Affected Files, Integration Points, Git History), Implementation Plan, Patterns to Follow, Edge Cases & Risks, Validation, Scope Boundaries, Metadata.
+- Lineage table updated to row 16 (`#786`).
+- No `.github/RAILWAY_TOKEN_ROTATION_*.md` file created (Category 1 error — explicitly avoided per `CLAUDE.md`).
+- No edits to `.github/workflows/staging-pipeline.yml` (out of scope — failing closed correctly).
+- No edits to `docs/RAILWAY_TOKEN_ROTATION_742.md` (canonical runbook unchanged).
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update PR and mark ready for review.

--- a/artifacts/runs/36bb722fce00aeff22f868dd098928fa/web-research.md
+++ b/artifacts/runs/36bb722fce00aeff22f868dd098928fa/web-research.md
@@ -1,0 +1,195 @@
+# Web Research: fix #786 (Prod deploy failed — RAILWAY_TOKEN expired, 16th occurrence)
+
+**Researched**: 2026-04-30T11:30:00Z
+**Workflow ID**: 36bb722fce00aeff22f868dd098928fa
+**Issue**: https://github.com/alexsiri7/reli/issues/786
+**Failed run**: https://github.com/alexsiri7/reli/actions/runs/25161929515
+**Failure mode**: `Validate Railway secrets` step → `RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+---
+
+## Summary
+
+Reli has rotated the Railway token 15+ times (issues #733, #739, #742, #774, #777, #779, #781, #783, now #786). Each rotation follows `docs/RAILWAY_TOKEN_ROTATION_742.md`, yet the failure recurs. Web research reveals the recurrence is **not actually about expiration** — it is almost certainly a **token-type/scope mismatch**. Railway has three token types (account, workspace, project) with subtly different headers, validation rules, and capabilities. The validation query `{me{id}}` used in `staging-pipeline.yml` only succeeds with a **personal account token** — workspace-scoped or project-scoped tokens return `Not Authorized` even when freshly created with no expiration. Authoritative Railway docs and Help-Station threads confirm this. The fix is twofold: (1) make the runbook unambiguous about creating an account-scoped (workspace-blank) token, and (2) consider replacing the `{me{id}}` validation probe with a query that works across token types so a wrong-type rotation fails loudly during creation rather than at the next deploy.
+
+---
+
+## Findings
+
+### 1. Railway has three distinct token types — they are NOT interchangeable
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Root cause of recurring "invalid or expired" errors
+
+**Key Information**:
+
+- **Account Token** — broadest scope, can call any API the user is authorized for, across all workspaces/resources. Created at `railway.com/account/tokens` with workspace dropdown left **blank**.
+- **Workspace Token** — scoped to one workspace, sharable with teammates. Created at the same page by **selecting** a workspace.
+- **Project Token** — scoped to a single environment within a project. Created from project settings → tokens, NOT the account page.
+- The three token types use **different HTTP authentication headers**:
+  - Account / Workspace tokens → `Authorization: Bearer <token>`
+  - Project tokens → `Project-Access-Token: <token>` (NOT `Authorization: Bearer`)
+
+---
+
+### 2. The `{me{id}}` GraphQL query only works with **personal account tokens**
+
+**Source**: [Railway Help Station — RAILWAY_TOKEN invalid or expired](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20) and [Postman — Railway GraphQL API](https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api)
+**Authority**: Community thread with confirmed answers from Railway staff/long-time users; Postman API reference
+**Relevant to**: Why `staging-pipeline.yml`'s validation step fails
+
+**Key Information**:
+
+- Quote from search results: *"For the `me` and `teams` query you need to use the person token, a team scoped token will not work for those because the data returned is specific to your personal account, not the team workspace."*
+- The current workflow validation step (`staging-pipeline.yml:49-58`) calls `{me{id}}` with `Authorization: Bearer $RAILWAY_TOKEN`. If the human creates a **workspace-scoped** token (which happens by default in the Railway UI when a workspace is selected), `{me{id}}` returns `Not Authorized` and the workflow falsely reports the token is "invalid or expired."
+- Community quote: *"RAILWAY_TOKEN now only accepts project token. If you put the normal account token, it literally says 'invalid or expired' even if you just made it 2 seconds ago."* — note: this conflict applies when using the **Railway CLI** `RAILWAY_TOKEN` env var, not the raw GraphQL endpoint, but it shows the platform's habit of returning the same opaque error for any token-type mismatch.
+
+---
+
+### 3. Recommended token type for GitHub Actions CI/CD: **account-scoped**
+
+**Source**: [Token for GitHub Action — Railway Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Railway employee response in support thread
+**Relevant to**: Choosing a stable rotation strategy
+
+**Key Information**:
+
+- Railway employee recommends an **account-scoped token** for GitHub Actions, NOT project-scoped, because project tokens are limited to specific environments and cannot perform workspace-level operations.
+- The recommended environment-variable name is `RAILWAY_API_TOKEN`. `RAILWAY_TOKEN` was a historical workaround that was patched in Railway CLI PR #668. **For raw GraphQL calls (which Reli uses), the env var name does not matter** — only the header (`Authorization: Bearer`) and the token type stored.
+- Recommended creation flow: visit `https://railway.com/account/tokens`, **leave Workspace blank**, set name, select expiration.
+
+---
+
+### 4. Token expiration: tokens DO have a TTL chosen at creation time
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens) and [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Whether genuine expiration is also a contributor
+
+**Key Information**:
+
+- Railway's account/workspace token creation UI offers expiration options — community references mention defaults of 7d, 30d, 90d, plus a "No expiration" option. **The user must explicitly choose "No expiration"** — defaults are short.
+- OAuth access tokens are separate (1-hour TTL, refresh tokens 1 year), but the GitHub Actions secret is a long-lived API token, not an OAuth access token.
+- The current runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) already calls this out, but evidence (16 rotations) suggests the instruction is being missed or that the operator is also creating a wrong-typed token.
+
+---
+
+### 5. Project tokens never expire in practice (community report)
+
+**Source**: [Generate project-wide tokens within the CLI · Issue #122 · railwayapp/cli](https://github.com/railwayapp/cli/issues/122) (referenced in search results) and Railway CLI guide
+**Authority**: Railway CLI repo and docs
+**Relevant to**: Alternative approach that eliminates rotation entirely
+
+**Key Information**:
+
+- Project tokens are intended for deployment automation. They do not appear to expire (community reports — not officially documented).
+- A project token authenticates as a project (not a user), so the `{me{id}}` query is invalid; validation must use a project-scoped query instead.
+- Drawbacks: one token per environment (staging + production = 2 tokens); the deploy code must switch from `Authorization: Bearer` to the `Project-Access-Token` header.
+
+---
+
+### 6. Validation probe must match the token type — current probe is fragile
+
+**Source**: Synthesis of [Railway Public API docs](https://docs.railway.com/integrations/api), [GraphQL Overview](https://docs.railway.com/integrations/api/graphql-overview), and the staging-pipeline workflow at lines 49–58 / 166–175.
+**Authority**: Direct mapping of repo code against Railway's documented GraphQL surface.
+**Relevant to**: How to detect a bad token at rotation time, not at deploy time
+
+**Key Information**:
+
+- A robust validation probe should query something the deploy step actually needs — e.g., `service(id: $SERVICE_ID) { id name }` or `project(id: $PROJECT_ID) { id }`. This succeeds for any token type that is permitted to deploy and fails clearly otherwise.
+- Reli's daily `railway-token-health.yml` uses the same `{me{id}}` probe — it shares the same false-positive risk.
+
+---
+
+## Code Examples
+
+### Replacement validation probe (works for account, workspace, and project tokens)
+
+```bash
+# From synthesis of https://docs.railway.com/integrations/api and Reli's existing service IDs
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg svc "$SERVICE_ID" --arg env "$ENV_ID" \
+    '{query: "query($svc:String!,$env:String!){deployments(input:{serviceId:$svc,environmentId:$env},first:1){edges{node{id status}}}}",
+      variables:{svc:$svc,env:$env}}')")
+if ! echo "$RESP" | jq -e '.data.deployments' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid, expired, or wrong-scoped: $MSG"
+  exit 1
+fi
+```
+
+This probe asks for what the next step (`serviceInstanceUpdate` / `serviceInstanceDeploy`) needs — service-level permissions on the configured environment — so a passing probe guarantees the deploy step will not fail due to scoping.
+
+### Project-token alternative (one secret per environment)
+
+```bash
+# Header changes; mutation body is the same
+curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Project-Access-Token: $RAILWAY_STAGING_PROJECT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"..."}'
+```
+
+Project tokens skip rotation but require structural changes (two new secrets, header swap, new validation query).
+
+---
+
+## Gaps and Conflicts
+
+- **Gap**: Railway does not publicly document the exact default TTL for account/workspace tokens. References vary (7d / 30d / 90d). Whatever it is, it is non-zero, and "No expiration" is not the default selection.
+- **Gap**: The exact failure cause for #786 cannot be determined from logs alone — the API returned only `Not Authorized`. Could be (a) workspace-scoped token mismatched with `{me{id}}`, (b) genuine expiration of an account-scoped token whose TTL was not set to "No expiration", or (c) the Railway-side bug occasionally reported in CLI issue #699. The recurrence pattern (~weekly) leans toward (b) with a default TTL of 7 days OR (a) if the operator is repeatedly creating workspace tokens.
+- **Conflict**: One Help-Station thread says `RAILWAY_TOKEN` accepts only project tokens; another thread says `RAILWAY_TOKEN` worked as a workaround for account tokens before CLI PR #668. Both can be true: the constraint applies to the **Railway CLI**, not raw GraphQL via curl. Reli uses curl directly, so the env var name does not constrain the token type — the token-type-vs-query mismatch is what breaks things.
+- **Cannot be found**: Whether a daily `railway-token-health.yml` cron query against `{me{id}}` itself contributes to rate-limiting or token invalidation. Almost certainly not, but no source confirms.
+
+---
+
+## Recommendations
+
+Based on the research, ordered by confidence and impact:
+
+1. **Make the rotation runbook idiot-proof and verifiable** (`docs/RAILWAY_TOKEN_ROTATION_742.md`):
+   - Add an explicit screenshot-or-bullet step: "**Workspace dropdown MUST be blank**" before name/expiration.
+   - Add an explicit step: "**Expiration: select 'No expiration'**" — the default is short.
+   - Add a **post-rotation self-check** the operator must paste the new token into and run locally before saving the GitHub secret:
+     ```bash
+     curl -sf -X POST https://backboard.railway.app/graphql/v2 \
+       -H "Authorization: Bearer NEW_TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"query":"{me{id}}"}' | jq
+     ```
+     If this returns `data.me.id`, the token is good for the current workflow.
+
+2. **Strengthen the validation probe** in both `staging-pipeline.yml` (lines 49–58 and 166–175) and `railway-token-health.yml`:
+   - Replace `{me{id}}` with a service-scoped query (see code example above) so a workspace-scoped token still validates if it can actually deploy. This eliminates the most likely cause of the false-expiration failure mode.
+   - Update the error message: *"RAILWAY_TOKEN is rejected by the Railway API. Likely causes: (1) wrong token type — must be account-scoped (workspace blank); (2) actual expiration — re-create with 'No expiration'. See docs/RAILWAY_TOKEN_ROTATION_742.md."*
+
+3. **(Optional, larger change) Migrate to project tokens**:
+   - Eliminates rotation entirely (project tokens are reportedly stable).
+   - Cost: rename secrets (`RAILWAY_STAGING_PROJECT_TOKEN`, `RAILWAY_PROD_PROJECT_TOKEN`), swap `Authorization: Bearer` for `Project-Access-Token` in ~6 curl invocations, swap validation query.
+   - Trade-off: mostly isolation upgrade — a leaked project token affects only one environment, not the whole account.
+
+4. **Do NOT** create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming agent rotation is done — CLAUDE.md explicitly forbids this (Category 1 error). The agent's contribution to this issue is the investigation/recommendations above; the actual rotation must be done by the human operator following the runbook.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Public API — Railway Docs | https://docs.railway.com/integrations/api | Canonical token-type definitions and headers |
+| 2 | Using the CLI — Railway Docs | https://docs.railway.com/guides/cli | RAILWAY_TOKEN vs RAILWAY_API_TOKEN distinction |
+| 3 | Login & Tokens — Railway Docs | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth vs API-token expiration model |
+| 4 | Token for GitHub Action — Help Station | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Railway-staff recommendation for GitHub Actions |
+| 5 | RAILWAY_TOKEN invalid or expired — Help Station | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Token-type mismatch produces "invalid or expired" error |
+| 6 | CLI throwing Unauthorized with RAILWAY_TOKEN — Help Station | https://station.railway.com/questions/cli-throwing-unauthorized-with-railway-24883ba1 | Same recurring symptom across users |
+| 7 | Authentication not working with RAILWAY_TOKEN — Help Station | https://station.railway.com/questions/authentication-not-working-with-railway-b3f522c7 | Confirms persistent confusion across community |
+| 8 | RAILWAY_API_TOKEN not being respected — Help Station | https://station.railway.com/questions/railway-api-token-not-being-respected-364b3135 | Env-var name pitfalls |
+| 9 | GraphQL requests returning "Not Authorized" for PAT — Help Station | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | `me`/`teams` queries require personal account tokens |
+| 10 | Generate project-wide tokens within the CLI — railwayapp/cli #122 | https://github.com/railwayapp/cli/issues/122 | Project-token use case for CI/CD automation |
+| 11 | CLI authentication fails with valid API token on Linux — railwayapp/cli #699 | https://github.com/railwayapp/cli/issues/699 | Known platform-side authentication bugs |
+| 12 | Railway GraphQL API — Postman | https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api | GraphQL schema reference for service/deployment queries |
+| 13 | GraphQL Overview — Railway Docs | https://docs.railway.com/integrations/api/graphql-overview | Endpoint, headers, and query patterns |
+| 14 | Troubleshooting — Railway Docs | https://docs.railway.com/integrations/oauth/troubleshooting | Official troubleshooting for auth failures |


### PR DESCRIPTION
## Summary

- 16th consecutive recurrence of `RAILWAY_TOKEN is invalid or expired: Not Authorized` aborting the `Validate Railway secrets` step in `.github/workflows/staging-pipeline.yml` on `main`.
- Docs-only artifact under `artifacts/runs/36bb722fce00aeff22f868dd098928fa/` — no code, workflow, or runbook edits per `CLAUDE.md` § "Railway Token Rotation".
- Action required is human-only: rotate the secret per `docs/RAILWAY_TOKEN_ROTATION_742.md`. Agents cannot perform this step.

## Failure cited by #786

- Run: `25161929515` @ 2026-04-30T11:04:46Z on SHA `d21b401d` (merge of PR #782 for issue #781).
- Error: `2026-04-30T11:04:52.3402629Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
- Sibling failure on the same SHA: run `25161923407` @ 11:04:37Z — failed identically.
- Timing proof: #781 (14th) closed at 11:00:15Z and #783 (15th) closed at 11:00:14Z; the failing deploy (run `25161929515`) ran 4m40s later at 11:04:55Z (per the issue body's `Deployed at:`), and the auto-pickup cron then filed #786 at 11:30:32Z (`createdAt`) — 25m37s after the deploy completed and 30m17s after the prior issues closed, on the merge commit of #782. The auto-pickup cron is still firing on every red `staging-pipeline` run because no rotation has landed.

## Lineage

`#733 → #739 → #742 → #755 → #762 → #751 → #766 → #762 (re-fire) → #769 → #771 → #773 / #774 → #777 → #779 → #781 → #783 → #786`

This is the 16th occurrence across 15 unique issues — same expired secret, same `{me{id}}` probe rejection, same canonical error string.

## Changes

- `artifacts/runs/36bb722fce00aeff22f868dd098928fa/investigation.md` — assessment, evidence chain, lineage table updated to row 16, scope boundaries, operator runbook pointer, deferred follow-ups (loop-stopper for `archon:in-progress` re-firing escalated again).
- `artifacts/runs/36bb722fce00aeff22f868dd098928fa/validation.md` — negative-check evidence (workflow / runbook untouched, no `.github/RAILWAY_TOKEN_ROTATION_*.md` created).
- `artifacts/runs/36bb722fce00aeff22f868dd098928fa/web-research.md` — Railway token-type guidance retained for the human follow-up after rotation.

## Deliberately NOT changed

- `.github/workflows/staging-pipeline.yml` — failing closed correctly; editing it would mask the real defect.
- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is correct.
- No `.github/RAILWAY_TOKEN_ROTATION_*.md` is created — Category 1 error per `CLAUDE.md`.

## Validation

Docs-only — generic type-check / lint / test / build suite is N/A (no code touched). Negative checks (from `validation.md`):

- [x] `git diff --stat HEAD -- .github/workflows/staging-pipeline.yml` → empty
- [x] `git diff --stat HEAD -- docs/RAILWAY_TOKEN_ROTATION_742.md` → empty
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` file created
- [x] Investigation, validation, and web-research artifacts committed under `artifacts/runs/36bb722fce00aeff22f868dd098928fa/`

## Test plan

- [ ] CI on this PR runs only docs-affecting checks; the failing `staging-pipeline` deploy is expected to remain red until a human rotates the token.
- [ ] After merge, the human operator follows `docs/RAILWAY_TOKEN_ROTATION_742.md`:
  - [ ] Revoke the expired token at railway.com → Account Settings → Tokens.
  - [ ] Create a new **personal account token** (not workspace) with **No expiration**.
  - [ ] `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli --body "<new-token>"`
  - [ ] Trigger `.github/workflows/railway-token-health.yml` via `workflow_dispatch` to verify `{me{id}}` succeeds.
  - [ ] Re-run `staging-pipeline` runs `25161929515` and `25161923407` to confirm deploys flow.
  - [ ] Close #786 with a comment referencing the rotation timestamp and remove the `archon:in-progress` label.

Fixes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
