### PR TITLE
docs: investigation for issue #801 (20th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md
+++ b/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md
@@ -1,0 +1,210 @@
+# Investigation: Prod deploy failed on main (20th `RAILWAY_TOKEN` expiration)
+
+**Issue**: #801 (https://github.com/alexsiri7/reli/issues/801)
+**Type**: BUG
+**Investigated**: 2026-04-30T18:10:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | The `Validate Railway secrets` pre-flight at `.github/workflows/staging-pipeline.yml:32-58` aborted run `25180002128` with `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` on SHA `7b8fcc9` (the merge commit of PR #799 — the 19th-occurrence investigation). No prod deploy can land on `main` until a human rotates the secret. |
+| Complexity | LOW | No code change is permitted (per `CLAUDE.md` § "Railway Token Rotation"); the canonical runbook already exists at `docs/RAILWAY_TOKEN_ROTATION_742.md`. The artifact-only output mirrors PRs #780 / #782 / #784 / #787 / #788 / #791 / #792 / #795 / #796 / #799. |
+| Confidence | HIGH | The CI summary emits the canonical error string verbatim: `RAILWAY_TOKEN is invalid or expired: Not Authorized`. Sibling CI-pipeline issue #800 ("Main CI red: Deploy to staging") was filed at 18:00:26Z against the same SHA `7b8fcc9`, 4 seconds before #801 (18:00:30Z), proving both pipeline filings saw the identical secret-rejection. PR #799 (19th-occurrence investigation) merged into `main` ~30 minutes earlier; the post-merge `workflow_run` triggered on `7b8fcc9` failed at 17:34:56Z — the rotation was not performed in that window. |
+
+---
+
+## Problem Statement
+
+The `RAILWAY_TOKEN` GitHub Actions secret is still expired. The `Validate Railway secrets` pre-flight in `.github/workflows/staging-pipeline.yml:32-58` calls Railway's `{me{id}}` GraphQL probe over `Authorization: Bearer`, receives `Not Authorized`, and aborts the deploy.
+
+This is the **20th identical recurrence**. Per `CLAUDE.md`, **agents cannot rotate the Railway API token**. This issue requires a human with access to https://railway.com/account/tokens.
+
+---
+
+## Analysis
+
+### First-Principles Analysis
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| `Validate Railway secrets` pre-flight | `.github/workflows/staging-pipeline.yml:32-58` | Yes | Failing closed correctly — surfaces the expired-token state before the actual deploy step would have failed silently mid-push. Do not edit. |
+| Token rotation runbook | `docs/RAILWAY_TOKEN_ROTATION_742.md` | Partial | Canonical, referenced by `CLAUDE.md`. Per `web-research.md` Findings 1–4 in this run, the runbook's "No expiration" guidance and TTL claims are not corroborated by Railway's public docs and may steer operators toward the wrong token type — possibly explaining the 20-times-and-counting recurrence cadence. Recommend a follow-up issue to update the runbook (out of scope for this docs-only artifact). |
+| `RAILWAY_TOKEN` secret itself | GitHub Actions secret store | **No** | Recurring expiry/rejection is the load-bearing root cause. The fix is exclusively human (mint a workspace-scoped token per Railway's "Team CI/CD" guidance; replace the secret). |
+| `archon:in-progress` cron gate | `pipeline-health-cron.sh` (external) | Partial | Prevents *concurrent* duplicate filings, but does not prevent serial re-fires after each merge to `main`. Each investigation PR that merges re-triggers the staging-pipeline `workflow_run`, which fires another issue. See P0 follow-up. |
+
+The primitive that is unsound is the secret itself, not any code in this repo. No code change resolves the failure; only secret rotation does.
+
+### Root Cause
+
+WHY: run `25180002128` failed at the `Deploy to staging / Validate Railway secrets` step
+↓ BECAUSE: Railway returned `Not Authorized` to the `{me{id}}` GraphQL probe (`.github/workflows/staging-pipeline.yml:49-58`)
+↓ BECAUSE: `secrets.RAILWAY_TOKEN` is still expired/invalid even after the merge of investigation PR #799 (for #798) ~30 minutes earlier
+↓ ROOT CAUSE: prior rotations have used finite-TTL or wrong-type tokens, producing the recurring failure mode. **No human has yet performed the rotation that resolves the current expiry window.** See companion `web-research.md` Findings 1–6 for the token-type rationale (workspace-scoped, Bearer-compatible, "best for Team CI/CD" per Railway docs).
+
+### Evidence Chain
+
+WHY: run `25180002128` failed
+↓ BECAUSE: `Validate Railway secrets` step exited 1
+  Evidence: `.github/workflows/staging-pipeline.yml:53-58` — `if ! echo "$RESP" | jq -e '.data.me.id' …; then echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"; exit 1; fi`
+
+↓ BECAUSE: Railway responded `Not Authorized`
+  Evidence: CI summary annotation `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` on Deploy-to-staging job of run `25180002128` at 2026-04-30T17:34:56Z.
+
+↓ BECAUSE: the GraphQL probe was rejected
+  Evidence: `.github/workflows/staging-pipeline.yml:49-52` — `curl -sf -X POST "https://backboard.railway.app/graphql/v2" -H "Authorization: Bearer $RAILWAY_TOKEN" … -d '{"query":"{me{id}}"}'`
+
+↓ ROOT CAUSE: `secrets.RAILWAY_TOKEN` is expired/invalid
+  Evidence: identical failure on the sibling CI-pipeline issue #800 (filed 18:00:26Z against the same SHA `7b8fcc9`, 4 seconds before #801 at 18:00:30Z); identical lineage across #798/#797/#794/#793/#790/#789/#786/#785/#783/#781/#779/#777/#774/#773/#771/#769/#766/#762/#755/#751/#742/#739/#733.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md` | NEW | CREATE | This investigation artifact |
+| `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md` | (already present) | KEEP | Token-type research already produced earlier in this run; referenced from this artifact |
+| (no source files) | — | — | Per `CLAUDE.md`, do not edit `.github/workflows/staging-pipeline.yml`; it is failing closed correctly. Do not create `.github/RAILWAY_TOKEN_ROTATION_*.md` (Category 1 error). |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — pre-flight that surfaces the failure
+- `.github/workflows/staging-pipeline.yml:60-90` — `Deploy staging image to Railway` step (gated by the pre-flight)
+- `.github/workflows/railway-token-health.yml` — manual health probe to verify a fresh secret
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical rotation runbook (referenced by `CLAUDE.md`)
+- `pipeline-health-cron.sh` (external mayor cron) — auto-files this issue on every red prod deploy
+
+### Git History
+
+- `7b8fcc9 docs: investigation for issue #798 (19th RAILWAY_TOKEN expiration) (#799)` — the merge commit on which run `25180002128` was triggered (via `workflow_run`).
+- `8dbd379 docs: investigation for issue #793 (18th RAILWAY_TOKEN expiration) (#795)` — prior 18th-occurrence investigation.
+- `66f717a docs: investigation for issue #794 (18th RAILWAY_TOKEN expiration) (#796)` — sibling 18th-occurrence investigation PR.
+- The pattern is well-established: each merge to `main` re-fires `staging-pipeline.yml` → `Validate Railway secrets` → fail → cron files a new issue (and its CI twin).
+
+---
+
+## Lineage (20 occurrences across 20+ unique issues)
+
+| # | Issue (CI / Prod) | Investigation PR |
+|---|-------------------|------------------|
+| 1–13 | #733 → #739 → #742 → #755 → #762 → #751 → #766 → #762 (re-fire) → #769 → #771 → #773 / #774 → #777 → #779 | (see prior PRs) |
+| 14 | #781 | #782 |
+| 15 | #783 | #784 |
+| 16 (CI) | #785 | #788 |
+| 16 (prod) | #786 | #787 |
+| 17 (CI) | #789 | #792 |
+| 17 (prod) | #790 | #791 |
+| 18 (prod) | #793 | #795 |
+| 18 (CI) | #794 | #796 |
+| 19 (CI / prod) | #797 / #798 | #799 (covers #798; #797 reused or auto-closed) |
+| **20 (CI)** | **#800** | (sibling — separate investigation if cron re-fires) |
+| **20 (prod)** | **#801 (this issue)** | **(this PR)** |
+
+---
+
+## Implementation Plan
+
+This is a docs-only artifact. The implementation steps below describe what the **investigation PR** does, not a code fix. The actual fix (token rotation) must be performed by a human per `CLAUDE.md`.
+
+### Step 1: Land this investigation artifact
+
+**File**: `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md`
+**Action**: CREATE
+
+Mirror the prior investigation pattern (PR #799 for #798) — docs-only, no source-file edits, references the canonical rotation runbook.
+
+**Why**: per `CLAUDE.md` § "Railway Token Rotation" (Category 1 error) — agents cannot rotate the secret, must not create rotation-claim files, must escalate via issue/mail and direct the human to the runbook.
+
+---
+
+### Step 2: Open PR titled `docs: investigation for issue #801 (20th RAILWAY_TOKEN expiration)`
+
+**Body** must include:
+
+- `Fixes #801`
+- 1-paragraph summary: 20th consecutive recurrence; PR #799 merged ~30 minutes earlier and the post-merge `workflow_run` on SHA `7b8fcc9` failed; sibling CI-pipeline issue #800 was filed 4 seconds before #801; per `CLAUDE.md` agents cannot rotate the secret, escalating to human.
+- Pointer to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**Why**: matches the established lineage of PRs #780 / #782 / #784 / #787 / #788 / #791 / #792 / #795 / #796 / #799.
+
+---
+
+### Step 3 (optional, deferred): File a follow-up issue against the runbook
+
+Consider filing a *separate* GH issue (NOT addressed in this PR) to update `docs/RAILWAY_TOKEN_ROTATION_742.md` per `web-research.md` recommendations:
+
+- Specify *workspace token* (Railway's documented "Team CI/CD" recommendation) instead of unspecified token type.
+- Drop the unverified "No expiration" instruction unless an operator can confirm that UI option exists.
+- Add a verification step: run the same `curl … {me{id}}` validation locally before pasting into GitHub secrets.
+
+This is a docs follow-up, not a fix for #801. Out of scope here per Polecat Scope Discipline (`CLAUDE.md`).
+
+---
+
+## Patterns to Follow
+
+**From codebase — mirror the established investigation pattern (PR #799 for #798):**
+
+```
+artifacts/runs/<run-hash>/investigation.md   # this file
+```
+
+Single-file, docs-only, no source edits. Same heading structure, same Assessment/Problem/Analysis/Lineage/Implementation/Validation/Scope sections. The PR description references the GitHub issue (`Fixes #801`) per `CLAUDE.md` § "GitHub Issue Linking".
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Reviewer asks why no code change | The `Validate Railway secrets` step is failing closed correctly. Editing it would mask the error. The bug is the secret value, not the workflow. Per `CLAUDE.md`, agents cannot rotate the secret. |
+| Cron re-fires another `Prod deploy failed` issue when this PR merges | Expected. Each merge to `main` triggers `staging-pipeline.yml` via `workflow_run`. Until the human rotates the token, this loop continues. The investigation-only PRs at least produce a paper trail. |
+| Tempting to "fix" this by switching validation to `{ projectToken { projectId } }` | Out of scope here. Would change the token-type contract for the entire deploy step. File as a separate issue (see `web-research.md` § Recommendations). |
+| Tempting to create `.github/RAILWAY_TOKEN_ROTATION_801.md` claiming rotation done | **DO NOT.** This is an explicit Category 1 error per `CLAUDE.md`. Agents have no access to https://railway.com/account/tokens. |
+| Risk of merging this PR while a human is mid-rotation | Low. Merging this docs-only file does not interact with the secret. A successful rotation will simply make the next `workflow_run` go green. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# This PR contains no code; CI checks are docs-only.
+# The deploy-pipeline failure that filed this issue will continue until a human rotates the token.
+# After rotation, manually trigger to verify:
+gh workflow run railway-token-health.yml
+```
+
+### Manual Verification
+
+1. Confirm `gh issue view 801` shows the canonical error: `RAILWAY_TOKEN is invalid or expired: Not Authorized`.
+2. Confirm `docs/RAILWAY_TOKEN_ROTATION_742.md` exists and is the runbook the human will follow.
+3. After this PR merges and a human rotates the token, the next `staging-pipeline.yml` run on `main` should pass `Validate Railway secrets` and proceed to the actual deploy.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Create `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md` (this file).
+- Reference companion `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md` (already produced).
+- Post a GH issue comment summarizing the investigation.
+- Open the investigation PR with `Fixes #801`.
+
+**OUT OF SCOPE (do not touch):**
+- `.github/workflows/staging-pipeline.yml` — failing closed correctly; do not edit.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook; updates belong in a separate follow-up issue.
+- `secrets.RAILWAY_TOKEN` — agents have no access; Category 1 error to claim rotation.
+- Switching validation from `{me{id}}` to `{ projectToken { … } }` — separate design decision, separate issue.
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation done — explicit `CLAUDE.md` prohibition.
+- Cron-loop mitigation in `pipeline-health-cron.sh` — external repo, separate issue.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7, 1M context)
+- **Timestamp**: 2026-04-30T18:10:00Z
+- **Run hash**: `c5c09daa8f33d8ef367c9b0d529c075c`
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md`
+- **Companion**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md`

--- a/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/validation.md
+++ b/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/validation.md
@@ -1,0 +1,88 @@
+# Validation Results
+
+**Generated**: 2026-04-30 19:10
+**Workflow ID**: c5c09daa8f33d8ef367c9b0d529c075c
+**Status**: ALL_PASS (docs-only)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No source files modified |
+| Lint | N/A | No source files modified |
+| Format | N/A | No source files modified |
+| Tests | N/A | No source files modified |
+| Build | N/A | No source files modified |
+| Diff scope | ✅ | Only `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md` added |
+
+---
+
+## Context
+
+This is a **docs-only investigation artifact** for issue #801 (the 20th
+consecutive `RAILWAY_TOKEN` expiration recurrence). The investigation itself
+states:
+
+> This PR contains no code; CI checks are docs-only.
+> The deploy-pipeline failure that filed this issue will continue until a
+> human rotates the token.
+
+Per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate the Railway
+secret. The investigation artifact is the only deliverable; the actual fix
+(secret rotation) requires human access to https://railway.com/account/tokens.
+
+The validation suite (type-check / lint / format / tests / build) is N/A because
+no source files were modified — running it would only re-confirm the unchanged
+state of `main` (SHA `7b8fcc9`).
+
+---
+
+## Diff Scope Verification
+
+**Command**: `git diff origin/main -- ':!artifacts/runs/' --stat`
+**Result**: ✅ Empty output — confirms zero changes outside `artifacts/runs/`.
+
+**Command**: `git status`
+**Result**: Single untracked path:
+- `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/` (this run's artifact dir)
+
+No staged or unstaged modifications to tracked files. No `.github/`, `backend/`,
+`frontend/`, `scripts/`, `docs/`, or other source-tree files touched.
+
+---
+
+## Files Modified During Validation
+
+None.
+
+---
+
+## Lineage Confirmation
+
+This validation matches the docs-only-PR precedent established by prior
+`RAILWAY_TOKEN` investigation PRs in the same lineage:
+
+- #780, #782, #784, #787, #788, #791, #792, #795, #796, #799 — all docs-only,
+  all merged with no code changes, all required human-only secret rotation.
+
+For the prior credential-rotation task #748 (workflow `00079b75…`), validation
+ran the full test suite (373 frontend tests passed). That precedent is **not**
+followed here because:
+
+1. #748's run included some operational verification steps; this run is purely
+   the investigation artifact.
+2. With zero source-file diff against `origin/main`, every check would
+   trivially pass — re-verifying the upstream `main` state, not this PR.
+3. Per Polecat Scope Discipline (`CLAUDE.md`), running unrelated test suites
+   on a docs-only PR risks surfacing pre-existing flakes that must not be
+   "fixed" in this PR.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update PR description with `Fixes #801`,
+reference the canonical runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`), and
+mark ready for review.

--- a/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md
+++ b/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md
@@ -35,6 +35,8 @@ Issue #801 is the **20th** occurrence of the same `RAILWAY_TOKEN is invalid or e
 **Authority**: Railway community help station thread with user-confirmed resolution
 **Relevant to**: Why the same failure keeps recurring after rotation
 
+**Confidence**: Medium — primary claim rests on a single community quote (`bytekeim`); see § "Gaps and Conflicts" below for what the official docs do and don't confirm.
+
 **Key Information**:
 
 - User `bytekeim` (post quoted in the thread): *"RAILWAY_TOKEN now only accepts project token, if u put the normal account token...it literally says 'invalid or expired' even if u just made it 2 seconds ago."*

--- a/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md
+++ b/artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md
@@ -1,0 +1,166 @@
+# Web Research: fix #801 — Prod deploy failed (RAILWAY_TOKEN expired, 20th occurrence)
+
+**Researched**: 2026-04-30T18:00:00Z
+**Workflow ID**: c5c09daa8f33d8ef367c9b0d529c075c
+
+---
+
+## Summary
+
+Issue #801 is the **20th** occurrence of the same `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure. The existing runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) tells operators to create the token with **"No expiration"**, but the failure has recurred 17 times since that runbook was written — strong evidence that either (a) the "No expiration" option is not being applied, or (b) the wrong token *type* is being created. Research suggests the root cause is most likely **token-type mismatch**: the workflow's validation step calls the GraphQL `{me{id}}` query, which only succeeds with an **account-scoped or workspace-scoped token**, not a project token, and Railway's own help-station threads confirm that "RAILWAY_TOKEN" labelled as "invalid or expired" frequently means *wrong type*, not *expired*.
+
+---
+
+## Findings
+
+### 1. Railway has three token types with very different semantics
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens) and [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Choosing the right token for `staging-pipeline.yml`
+
+**Key Information**:
+
+- **Account token** — broadest scope, covers all your resources and workspaces
+- **Workspace (team) token** — scoped to a workspace; "best for Team CI/CD, shared automation" per Railway docs; can be shared with teammates
+- **Project token** — scoped to a single environment within one project; created from the project's Settings → Tokens page
+- All three are sent via `Authorization: Bearer <token>` against the GraphQL endpoint
+- Railway explicitly recommends **workspace tokens** for team CI/CD pipelines
+
+---
+
+### 2. "RAILWAY_TOKEN invalid or expired" is often a wrong-type error, not an expiration
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)
+**Authority**: Railway community help station thread with user-confirmed resolution
+**Relevant to**: Why the same failure keeps recurring after rotation
+
+**Key Information**:
+
+- User `bytekeim` (post quoted in the thread): *"RAILWAY_TOKEN now only accepts project token, if u put the normal account token...it literally says 'invalid or expired' even if u just made it 2 seconds ago."*
+- This is the **opposite** of what the [Token for GitHub Action thread](https://station.railway.com/questions/token-for-git-hub-action-53342720) says, where a Railway employee writes: *"use a Railway API token scoped to the user account, not a project token, for the GitHub Action."*
+- The contradiction resolves once you separate **CLI-based** workflows (use project token via `RAILWAY_TOKEN`) from **direct GraphQL API** workflows (use account/workspace token, header still `Authorization: Bearer`).
+- The `staging-pipeline.yml` in this repo calls the GraphQL API directly with `curl` (not the CLI), so it needs an **account or workspace token**, not a project token.
+
+---
+
+### 3. The `{me{id}}` validation query will only succeed with an account/workspace token
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api) and [Introduction to GraphQL | Railway Docs](https://docs.railway.com/integrations/api/graphql-overview)
+**Authority**: Official Railway documentation
+**Relevant to**: `.github/workflows/staging-pipeline.yml` lines 49-55 (the validation step that fails)
+
+**Key Information**:
+
+- Project tokens have no associated user identity — they authenticate as the project, not as a user
+- `{me{id}}` returns the authenticated user, which only exists for account and workspace tokens
+- If someone rotates the secret with a **project token**, the validation step will fail with `Not Authorized` even though the token is brand-new and otherwise valid
+- This means the current error message ("invalid or expired") is misleading when the underlying problem is wrong-type
+
+---
+
+### 4. Documented Railway token-expiration semantics (and an important silent-revocation case)
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens) and [Troubleshooting | Railway Docs](https://docs.railway.com/integrations/oauth/troubleshooting)
+**Authority**: Official Railway documentation
+**Relevant to**: Whether tokens *can* genuinely expire after rotation
+
+**Key Information**:
+
+- OAuth **access tokens** expire after 1 hour (irrelevant — these are not what's stored in `RAILWAY_TOKEN`)
+- OAuth **refresh tokens** have a 1-year lifetime, are rotated on use, and using a stale rotated token *immediately revokes the entire authorization*
+- Account/workspace/project tokens: the public docs **do not document an expiration TTL** for these tokens. They also do not document a "No expiration" toggle (contradicting the claim in the existing rotation runbook).
+- Silent-revocation footgun: requesting more than 100 refresh tokens for the same user causes the oldest to be revoked without notice
+- No public docs confirm or deny whether long-lived account/workspace tokens are silently expired by Railway after some interval
+
+---
+
+### 5. Railway CI/CD ecosystem signal
+
+**Source**: [Using Github Actions with Railway — Railway Blog](https://blog.railway.com/p/github-actions) and [Token for GitHub Action — Railway Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Official Railway blog + Railway employee response
+**Relevant to**: What the established pattern looks like
+
+**Key Information**:
+
+- Railway's own GitHub Actions blog example uses the `ghcr.io/railwayapp/cli:latest` container with a **project token** in `RAILWAY_TOKEN` and runs `railway up --service=...`
+- The reli pipeline does NOT follow this pattern — it shells out to the GraphQL API directly with `curl`
+- A Railway employee in the help-station thread said RAILWAY_API_TOKEN had pickup issues historically that have since been fixed; the env-var name distinction matters for the **CLI**, not for direct curl-to-GraphQL calls (where the variable is just a shell variable)
+
+---
+
+### 6. Existing reli docs that are likely incorrect
+
+**Source**: `docs/RAILWAY_TOKEN_ROTATION_742.md` (this repo)
+**Authority**: Internal runbook, written at occurrence #3
+**Relevant to**: Direct contradiction with public Railway docs
+
+**Key Information**:
+
+- Says: *"The new token must be created with 'No expiration'."*
+- Says: *"When creating tokens on Railway, the default TTL may be short (e.g., 1 day or 7 days)."*
+- Public Railway documentation does not describe either a per-token TTL selector or a "No expiration" option for account/workspace/project tokens. It is plausible this advice was never accurate, which would explain why the issue keeps recurring after rotation.
+
+---
+
+## Code Examples
+
+### Token-type-correct validation query (account/workspace token)
+
+```graphql
+# From https://docs.railway.com/integrations/api
+# Works with: account token, workspace token
+# Header: Authorization: Bearer <token>
+query { me { id } }
+```
+
+### Project-token-compatible validation query
+
+```graphql
+# From https://docs.railway.com/integrations/api/graphql-overview
+# Works with: project token (no `me` resolver available)
+# Header: Authorization: Bearer <project_token> (or Project-Access-Token in some flows)
+query { projectToken { projectId environmentId } }
+```
+
+Switching the validation step to `{ projectToken { projectId } }` would let the workflow accept project tokens too, but is **not** recommended here because subsequent deploy/health steps in `staging-pipeline.yml` may need workspace-scoped operations.
+
+---
+
+## Gaps and Conflicts
+
+- **Conflict**: One Railway help-station thread says `RAILWAY_TOKEN` only accepts project tokens; another (with a Railway employee) says use an account-scoped token. Resolved by distinguishing CLI vs direct-GraphQL paths — the reli workflow is direct-GraphQL, so account/workspace token is correct.
+- **Gap**: Public docs do not confirm whether long-lived account/workspace tokens silently expire on a schedule, or whether there's a UI option to set "No expiration" at creation. The internal runbook claims this option exists; this could not be corroborated against official docs.
+- **Gap**: No published guidance on whether deleting and recreating a workspace member or session invalidates issued workspace tokens (a possible silent-revocation cause if the human operator's session is rotating).
+- **Gap**: No public Railway changelog entry was found announcing a token-expiration policy change that would explain the recurrence cadence in this repo.
+
+---
+
+## Recommendations
+
+Based on research, the next operator (human) rotating the token should:
+
+1. **Use a workspace token, not a project token, and not an account token tied to a single user session.** Workspace tokens are Railway's documented recommendation for "Team CI/CD, shared automation" and survive an individual user's session changes. The validation `{me{id}}` query works with workspace tokens.
+2. **Verify the token type at creation time**, not just paste-and-pray. Railway's token creation UI labels each token with its scope. If "No expiration" is genuinely not an option for the chosen type, the runbook is wrong and needs updating.
+3. **Update `docs/RAILWAY_TOKEN_ROTATION_742.md`** to: (a) specify *workspace token* explicitly, (b) drop the unverified "No expiration" instruction unless a screenshot of that UI option is in hand, (c) add a verification step that runs the same `curl` validation locally before pasting into GitHub secrets.
+4. **Consider switching from direct-GraphQL `curl` to the official `railwayapp/cli:latest` container pattern** documented on Railway's blog. This is the path Railway tests against, reducing the chance that a behavior change on their side silently breaks reli.
+5. **Do not** create another `docs/RAILWAY_TOKEN_ROTATION_*.md` file claiming the rotation is done — per CLAUDE.md, that is a Category 1 error. The existing investigation-only pattern (issues #789-#799) is correct.
+
+What an agent **cannot** do per repo policy: rotate the token itself. This research artifact is meant to inform the human who can.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Docs — Login & Tokens | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth token semantics, refresh-token rotation, silent revocation |
+| 2 | Railway Docs — Public API | https://docs.railway.com/integrations/api | Three token types and their scopes; workspace token is "best for Team CI/CD" |
+| 3 | Railway Docs — Introduction to GraphQL | https://docs.railway.com/integrations/api/graphql-overview | GraphQL endpoint and `me` query usage |
+| 4 | Railway Docs — Troubleshooting | https://docs.railway.com/integrations/oauth/troubleshooting | 100-token silent revocation rule |
+| 5 | Railway Help Station — RAILWAY_TOKEN invalid or expired | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Wrong-type errors masquerade as "expired" |
+| 6 | Railway Help Station — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Railway employee says use account-scoped token for GH Actions; CLI vs direct-API distinction |
+| 7 | Railway Blog — Using GitHub Actions with Railway | https://blog.railway.com/p/github-actions | Official CLI-container pattern for GH Actions deployments |
+| 8 | Railway Docs — GitHub Actions Self-Hosted Runners | https://docs.railway.com/guides/github-actions-runners | Confirms Railway uses fine-grained PATs for runner registration (different concern, but rules out OIDC) |
+| 9 | Railway CLI Issue #699 — auth fails with valid token on Linux | https://github.com/railwayapp/cli/issues/699 | Known auth-edge-cases on the CLI side |
+| 10 | Railway Help Station — RAILWAY_API_TOKEN not being respected | https://station.railway.com/questions/railway-api-token-not-being-respected-364b3135 | Historical CLI env-var pickup issue (now fixed) |


### PR DESCRIPTION
## Summary

20th consecutive recurrence of the `RAILWAY_TOKEN` expiration aborting `staging-pipeline.yml`. Run `25180002128` failed on SHA `7b8fcc9` (the merge of PR #799, the prior 19th-occurrence investigation) ~30 minutes after that merge. Sibling CI-pipeline issue #800 was filed 4 seconds before #801 against the same SHA. Per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate the secret — escalating to human via this docs-only investigation artifact (matches the established lineage of PRs #780 / #782 / #784 / #787 / #788 / #791 / #792 / #795 / #796 / #799).

## Root Cause

`secrets.RAILWAY_TOKEN` is expired. The `Validate Railway secrets` pre-flight at `.github/workflows/staging-pipeline.yml:32-58` calls Railway's `{me{id}}` GraphQL probe over `Authorization: Bearer`, receives `Not Authorized`, and aborts with `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`. The pre-flight is **failing closed correctly** — do not edit it.

## Changes

- `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/investigation.md` — full investigation
- `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/web-research.md` — Railway token-type research (workspace-scoped recommendation per Railway's "Team CI/CD" docs)
- `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/validation.md` — diff-scope verification (zero source-file changes)

No source files modified. No `.github/RAILWAY_TOKEN_ROTATION_801.md` file (would be a Category 1 error per `CLAUDE.md`).

## Required Human Action

A human with access to https://railway.com/account/tokens must rotate the secret per the canonical runbook at `docs/RAILWAY_TOKEN_ROTATION_742.md`. After rotation, verify with:

```bash
gh workflow run railway-token-health.yml
```

## Validation

| Check | Result | Details |
|-------|--------|---------|
| Type check / Lint / Format / Tests / Build | N/A | No source files modified |
| Diff scope | ✅ | Only `artifacts/runs/c5c09daa8f33d8ef367c9b0d529c075c/` added |

`git diff origin/main -- ':!artifacts/runs/' --stat` is empty — confirms zero changes outside the artifacts dir.

## Test plan

- [ ] Human reviewer confirms no source-tree files touched (`git diff main...HEAD -- ':!artifacts/runs/'` is empty)
- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`
- [ ] Manual `gh workflow run railway-token-health.yml` returns green after rotation
- [ ] Next post-merge `staging-pipeline.yml` run on `main` passes `Validate Railway secrets`

Fixes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)