### PR TITLE
docs: investigation for issue #804 (21st RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md
+++ b/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md
@@ -44,13 +44,13 @@ WHY: `Deploy to staging` job exits 1.
 |------|-------|--------|-------------|
 | GitHub Actions secret `RAILWAY_TOKEN` | n/a | ROTATE (human-only) | Create new Railway API token with **"No expiration"** and update the secret. |
 
-No source files require modification. The validate step at `.github/workflows/staging-pipeline.yml:32-58` (and the prod equivalent at `:149-173`) is functioning correctly.
+No source files require modification. The validate step at `.github/workflows/staging-pipeline.yml:32-58` (and the prod equivalent at `:149-175`) is functioning correctly.
 
 ### Integration Points
 
 - `.github/workflows/staging-pipeline.yml:32-58` — staging validate step that emitted the failure.
 - `.github/workflows/staging-pipeline.yml:60-88` — staging deploy step that uses the same token.
-- `.github/workflows/staging-pipeline.yml:149-173` — prod validate step (will fail next prod deploy with the same error).
+- `.github/workflows/staging-pipeline.yml:149-175` — prod validate step (will fail next prod deploy with the same error).
 - `.github/workflows/railway-token-health.yml` — periodic health check that monitors the token.
 
 ### Git History

--- a/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md
+++ b/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md
@@ -1,0 +1,163 @@
+# Investigation: Main CI red: Deploy to staging
+
+**Issue**: #804 (https://github.com/alexsiri7/reli/issues/804)
+**Type**: BUG
+**Investigated**: 2026-04-30T18:50:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Staging deploy job fails on every main push, blocking the staging→prod promotion pipeline; no production data is at risk and a clear human-only workaround (rotate token) exists. |
+| Complexity | LOW | Resolution is a one-step secret rotation in GitHub Actions; no code change is required and the runbook is already written. |
+| Confidence | HIGH | The job log explicitly says `RAILWAY_TOKEN is invalid or expired: Not Authorized`, the validation step that produced it is deliberately designed to surface exactly this case, and the same failure has now recurred 21 times. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in `.github/workflows/staging-pipeline.yml` fails at the `Validate Railway secrets` step because the `RAILWAY_TOKEN` GitHub Actions secret has expired again. Railway's GraphQL API rejects the token with `Not Authorized`. **Agents cannot fix this** — rotation requires a human with railway.com dashboard access.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+This is the 21st recurrence of the same `RAILWAY_TOKEN` expiration (prior: #742, #747, #752, #762, #769, #774, #777, #783, #793, #794, #798, #801, and others). The validate step is working as designed; it is correctly surfacing an expired credential.
+
+### Evidence Chain
+
+WHY: `Deploy to staging` job exits 1.
+↓ BECAUSE: The `Validate Railway secrets` step fails.
+  Evidence: run log line `2026-04-30T18:35:01.0910395Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: A `{me{id}}` probe to `https://backboard.railway.app/graphql/v2` returns no `data.me.id`.
+  Evidence: `.github/workflows/staging-pipeline.yml:49-58` — the validate step calls Railway's GraphQL `me` query and exits 1 when the response lacks `.data.me.id`.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret is expired. Rotation requires a human with railway.com dashboard access; no agent can perform it.
+  Evidence: `CLAUDE.md` — "Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com."
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| GitHub Actions secret `RAILWAY_TOKEN` | n/a | ROTATE (human-only) | Create new Railway API token with **"No expiration"** and update the secret. |
+
+No source files require modification. The validate step at `.github/workflows/staging-pipeline.yml:32-58` (and the prod equivalent at `:149-173`) is functioning correctly.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — staging validate step that emitted the failure.
+- `.github/workflows/staging-pipeline.yml:60-88` — staging deploy step that uses the same token.
+- `.github/workflows/staging-pipeline.yml:149-173` — prod validate step (will fail next prod deploy with the same error).
+- `.github/workflows/railway-token-health.yml` — periodic health check that monitors the token.
+
+### Git History
+
+- The validate step was introduced by commit `3dfb995` ("fix: add Railway API token auth check to deploy pre-flight (#738)") and refined in `0040535` ("fix: use curl -sf consistently in Railway token validate steps (#744)"). Behavior is correct.
+- **Implication**: This is not a regression. The CI is doing its job; the credential is what expired.
+
+---
+
+## Implementation Plan
+
+> ⚠️ **No code change. This issue requires a human to rotate the Railway API token.**
+> Per `CLAUDE.md > Railway Token Rotation`, agents must NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. Doing so is a Category 1 error.
+
+### Step 1 (HUMAN): Create a new Railway token with no expiration
+
+1. Sign in at https://railway.com/account/tokens.
+2. Create a token named `github-actions-permanent`.
+3. **Set expiration to "No expiration"** — do not accept the default TTL. Several past rotations used short-lived defaults, which is why this keeps recurring.
+
+### Step 2 (HUMAN): Update the GitHub Actions secret
+
+```bash
+gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+# paste the new token when prompted
+```
+
+### Step 3 (HUMAN): Re-run the failed CI
+
+```bash
+gh run rerun 25182725669 --repo alexsiri7/reli --failed
+
+# Fallback if the run is stale:
+gh run list --repo alexsiri7/reli --status failure --limit 1 \
+  --json databaseId --jq '.[0].databaseId' \
+  | xargs -I{} gh run rerun {} --repo alexsiri7/reli --failed
+```
+
+### Step 4 (HUMAN): Close issue #804 once CI is green
+
+The full runbook lives at `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+---
+
+## Patterns to Follow
+
+Mirror prior recurrence handling — file an investigation that points the human at the runbook, do not fabricate a rotation receipt:
+
+```
+SOURCE: recent commits on main
+0275146 docs: investigation for issue #800 (20th RAILWAY_TOKEN expiration) (#803)
+83a2f93 docs: investigation for issue #801 (20th RAILWAY_TOKEN expiration) (#802)
+7b8fcc9 docs: investigation for issue #798 (19th RAILWAY_TOKEN expiration) (#799)
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent fabricates a `.github/RAILWAY_TOKEN_ROTATION_804.md` claiming success. | Explicitly forbidden by `CLAUDE.md`; this artifact does not create such a file. |
+| Human rotates the token but with a default short TTL. | Step 1 emphasizes **"No expiration"** — this is the recurrence root cause. |
+| Prod deploy job will hit the same failure on next deploy. | The rotation fixes both staging and prod since both jobs read the same `RAILWAY_TOKEN` secret. |
+| `gh run rerun 25182725669` returns "run too old" / not rerunnable. | The fallback command in Step 3 reruns the most recent failed run. |
+| Recurrence pattern (21 times) suggests systemic process problem. | Out of scope here; consider a follow-up issue to track Railway-side automation or alternate auth (e.g., service tokens with longer TTLs). |
+
+---
+
+## Validation
+
+### Automated Checks
+
+After human rotates the token:
+
+```bash
+# Re-run the failed staging deploy
+gh run rerun 25182725669 --repo alexsiri7/reli --failed
+
+# Watch the rerun
+gh run watch --repo alexsiri7/reli
+```
+
+### Manual Verification
+
+1. New run of `staging-pipeline.yml` reaches `Deploy staging image to Railway` without the `RAILWAY_TOKEN is invalid or expired` error.
+2. Staging health probe (`/healthz`) returns `{"status":"ok"}` within the 20-attempt loop at `.github/workflows/staging-pipeline.yml:90-104`.
+3. `railway-token-health.yml` next scheduled run reports green.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Documenting the failure, pointing the human at `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+- Posting a GitHub comment on issue #804 with this analysis.
+
+**OUT OF SCOPE (do not touch):**
+- Editing `.github/workflows/staging-pipeline.yml` — the validate step is correct.
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` file (forbidden by CLAUDE.md).
+- Attempting to rotate the token via API (agents lack the credentials and the policy forbids it).
+- Architectural changes to the Railway deploy approach (the recurrence pattern may warrant a separate issue, but that is a future decision).
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-04-30T18:50:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md`

--- a/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/validation.md
+++ b/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/validation.md
@@ -1,0 +1,82 @@
+# Validation Results
+
+**Generated**: 2026-04-30 18:55
+**Workflow ID**: b9863d3691e7e5613a5dc5d396567ce8
+**Status**: ALL_PASS (N/A — docs-only)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No source code changed |
+| Lint | N/A | No source code changed |
+| Format | N/A | No source code changed |
+| Tests | N/A | No source code changed |
+| Build | N/A | No source code changed |
+
+This is a **documentation-only investigation PR** for issue #804 (21st `RAILWAY_TOKEN` expiration). The only change is the new artifact files under `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/`. No backend, frontend, workflow, or runtime code is touched (deliberately — see `investigation.md` § "Scope Boundaries" and `CLAUDE.md` § "Railway Token Rotation"). The standard validation suite (type-check, lint, format, tests, build) therefore has nothing to validate and is not run.
+
+The root cause — an expired `RAILWAY_TOKEN` GitHub Actions secret — cannot be fixed by any agent; rotation requires a human with railway.com dashboard access. The PR's job is to point that human at `docs/RAILWAY_TOKEN_ROTATION_742.md` and document the recurrence.
+
+---
+
+## Files Modified During Validation
+
+None. No fixes were required.
+
+---
+
+## Files Added in This Branch (planned)
+
+| File | Purpose |
+|------|---------|
+| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md` | Investigation artifact for issue #804 (21st recurrence). |
+| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/validation.md` | This validation artifact (negative-check evidence). |
+| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/web-research.md` | Railway token-type research, retained for human follow-up after rotation. |
+
+The artifacts currently live under `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/` and will be copied into the worktree's `artifacts/runs/...` path during the finalize step, mirroring the prior 20 recurrences.
+
+---
+
+## Negative Checks (Scope-Boundary Evidence)
+
+| Command | Expected | Result |
+|---------|----------|--------|
+| `git diff --stat HEAD -- .github/workflows/staging-pipeline.yml` | empty | empty (workflow not edited; failing closed correctly) |
+| `git diff --stat HEAD -- docs/RAILWAY_TOKEN_ROTATION_742.md` | empty | empty (canonical runbook unchanged) |
+| `ls .github/RAILWAY_TOKEN_ROTATION_*.md` | no match | no match (Category 1 error explicitly avoided per `CLAUDE.md`) |
+| `git status --short` | clean | clean (no in-tree edits beyond planned artifacts) |
+
+---
+
+## Artifact Sanity Check
+
+- Investigation file exists at `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md` (7,590 bytes).
+- Web-research file exists at `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/web-research.md` (12,034 bytes).
+- Required investigation sections present: Assessment, Problem Statement, Analysis (Root Cause, Evidence Chain, Affected Files, Integration Points, Git History), Implementation Plan, Patterns to Follow, Edge Cases & Risks, Validation, Scope Boundaries, Metadata.
+- Investigation correctly cites prior lineage (#742, #747, #752, #762, #769, #774, #777, #783, #793, #794, #798, #801, etc.) and labels this as the **21st** recurrence.
+- No `.github/RAILWAY_TOKEN_ROTATION_*.md` file created (Category 1 error — explicitly avoided per `CLAUDE.md`).
+- No edits to `.github/workflows/staging-pipeline.yml` (out of scope — failing closed correctly).
+- No edits to `docs/RAILWAY_TOKEN_ROTATION_742.md` (canonical runbook unchanged).
+
+---
+
+## Why The Standard Suite Was Not Run
+
+`plan-context.md` was not produced for this run because the investigation determined there is no implementation step. The five standard checks each require a target:
+
+- **Type check / Build** — operate on source files; none changed.
+- **Lint / Format** — operate on source files; none changed.
+- **Tests** — would either run the entire suite (irrelevant to a docs-only change and would consume CI budget) or run tests targeting the change (none exist, because the change is prose).
+
+Running them would be theatre, not validation. The negative checks above are the actual scope-boundary evidence that matters for this PR.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update PR (`Fixes #804`) and mark ready for review. The PR should mirror the title pattern of the prior 20 recurrences:
+
+> `docs: investigation for issue #804 (21st RAILWAY_TOKEN expiration)`

--- a/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/web-research.md
+++ b/artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/web-research.md
@@ -1,0 +1,168 @@
+## Web Research: fix #804
+
+**Researched**: 2026-04-30T18:55:00Z
+**Workflow ID**: b9863d3691e7e5613a5dc5d396567ce8
+
+---
+
+## Summary
+
+Issue #804 is the **21st** recurrence of the same failure: `RAILWAY_TOKEN is invalid or expired: Not Authorized` returned by `https://backboard.railway.app/graphql/v2` during the `Validate Railway secrets` step of `Deploy to staging`. Per Reli's `CLAUDE.md` policy, agents cannot rotate the token — a human must visit `railway.com/account/tokens`. Web research confirms the Reli runbook's existing guidance and surfaces two structural options worth flagging to the human: (1) Railway **project (environment-scoped) tokens** authenticate with a different header than account tokens and are the recommended CI/CD primitive; (2) account tokens default to short TTLs, so the new token must be created with **No expiration** to break the rotation cycle.
+
+---
+
+## Findings
+
+### Railway Token Types & Authentication Headers
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Why the current token keeps expiring; whether the workflow uses the right token type.
+
+**Key Information**:
+
+- Railway exposes **three distinct token types**, each with its own auth header:
+  - **Account / personal tokens** → `Authorization: Bearer <token>` (full account access)
+  - **Team / workspace tokens** → `Team-Access-Token: <token>` (team-scoped)
+  - **Project tokens** → `Project-Access-Token: <token>` (environment-scoped; the recommended CI/CD primitive)
+- Endpoint: `https://backboard.railway.com/graphql/v2` (note: `.com`, not `.app` — both appear in the wild but `.com` is the documented one).
+- Rate limit: 1000 requests/hour per token.
+- The current `staging-pipeline.yml` uses `Authorization: ***` (Bearer-style), which means the secret is an **account token**, not a project token.
+
+---
+
+### "Not Authorized" Failure Modes
+
+**Source**: [API Token "Not Authorized" Error for Public API and MCP — Railway Help Station](https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1)
+**Authority**: Railway's official community help station; confirmed by Railway staff responses
+**Relevant to**: Diagnosing why the validation curl returns `Not Authorized`.
+
+**Key Information**:
+
+- `{ me { id } }` returns `Not Authorized` when the supplied token is **not a personal/account token** (e.g., a team or project token sent with the wrong header). For Reli's validation query (`{me{id}}`), only an **account token** with `Authorization: Bearer` works.
+- Tokens silently revoke after expiration — the API responds with `Not Authorized` rather than a dedicated "expired" error code.
+- See also: [GraphQL requests returning "Not Authorized" for PAT](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52) — same root cause; Railway support typically asks for traceIds to confirm revocation vs. permission scoping.
+
+---
+
+### Token Expiration & "No Expiration" Option
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens)
+**Authority**: Official Railway documentation
+**Relevant to**: Why the token has now expired 21 times — and how to stop the bleeding.
+
+**Key Information**:
+
+- When generating an account token in the dashboard, the user picks an expiration. Defaults are short (1 day / 7 days / 30 days). The **"No expiration"** option exists but is opt-in.
+- OAuth-issued access tokens always expire after 1 hour and require `offline_access` for refresh. Dashboard-generated tokens are separate and follow the user-picked TTL.
+- The Reli runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) already calls out **"Expiration: No expiration (critical — do not accept default TTL)"**, but the 21× recurrence suggests this step has not been honored on at least one rotation.
+
+---
+
+### Project Tokens for CI/CD (Long-Lived Alternative)
+
+**Source**: [Using GitHub Actions with Railway — Railway Blog](https://blog.railway.com/p/github-actions) and [Railway Help Station — Token for GitHub Action](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Railway's official blog and help station
+**Relevant to**: A potentially better long-term primitive than rotating an account token.
+
+**Key Information**:
+
+- For GitHub Actions, Railway recommends a **project token** stored as `RAILWAY_TOKEN` and used by the `railway up` CLI: `railway up --service=<id>`.
+- Project tokens **do not expire by default**, are scoped to one environment, and break the validation pattern Reli currently uses (no `me { id }` query — the CLI handles auth opaquely).
+- Trade-off: project tokens cannot satisfy the existing `{me{id}}` validation curl. Switching to project tokens would require changing the workflow's "Validate Railway secrets" step to either (a) drop the `me` check, or (b) call a project-scoped query like `{project(id:"...") { name }}`.
+
+---
+
+### Reusable GitHub Action
+
+**Source**: [bervProject/railway-deploy — GitHub](https://github.com/bervProject/railway-deploy)
+**Authority**: Most-starred third-party action for Railway deploys
+**Relevant to**: Reduces the surface area where `RAILWAY_TOKEN` is consumed.
+
+**Key Information**:
+
+- Drop-in action: `bervProject/railway-deploy@main` with `service:` input and `RAILWAY_TOKEN` env. Wraps `railway up`.
+- Useful as a future simplification, but **does not** address the rotation cadence — same token expiry rules apply.
+
+---
+
+### Secretless / OIDC Alternatives
+
+**Source**: [Secretless Access for GitHub Actions and Workflows — Aembit](https://aembit.io/blog/secretless-access-for-github-actions/) and [GitHub community discussion #168661 — Best Practices for Managing and Rotating Secrets](https://github.com/orgs/community/discussions/168661)
+**Authority**: Vendor blog (Aembit) cross-checked against GitHub's own community-discussion thread
+**Relevant to**: Long-term answer to "how do we stop rotating this token by hand?"
+
+**Key Information**:
+
+- GitHub Actions supports OIDC-based secretless auth for AWS/GCP/Azure/HashiCorp Vault out of the box — but **Railway does not currently expose an OIDC trust relationship for GitHub Actions** (no entry in their docs as of April 2026).
+- Realistic intermediate step: rotate to a project token + use a secrets manager (Doppler, GitHub-native rotation webhooks, or a `railway-token-health.yml` workflow that already exists in this repo) to alert *before* expiry rather than after.
+
+---
+
+## Code Examples
+
+The current validation step in `.github/workflows/staging-pipeline.yml`:
+
+```bash
+# From the failing run log
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: ***" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  exit 1
+fi
+```
+
+If the team chose to migrate to a **project token**, the validation curl would change to (project tokens cannot run `me`):
+
+```bash
+# Hypothetical replacement using project tokens — from
+# https://docs.railway.com/integrations/api
+RESP=$(curl -sf -X POST "https://backboard.railway.com/graphql/v2" \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":\"{ projectToken { projectId environmentId } }\"}")
+```
+
+---
+
+## Gaps and Conflicts
+
+- **Endpoint domain inconsistency**: Railway's docs use `backboard.railway.com` while Reli's workflow hits `backboard.railway.app`. Both currently resolve, but the `.app` domain is undocumented and may be deprecated. Worth flagging to the human, but **not the cause of issue #804** (the curl returns a structured `Not Authorized`, so the endpoint is reachable).
+- **Railway OIDC support**: No public roadmap entry. Could not confirm whether Railway plans to add it.
+- **Token TTL audit**: I cannot determine from outside whether the most recent `RAILWAY_TOKEN` rotation was performed with "No expiration" or accepted a default TTL. The 21× recurrence strongly suggests at least one rotation accepted a default.
+- **Why 21 rotations**: The cadence of the recent issues (#793, #794, #798, #801, #800, #804) suggests roughly weekly recurrence — consistent with a 7-day default TTL. None of the search results confirm Railway's exact default value.
+
+---
+
+## Recommendations
+
+Based on research, in priority order:
+
+1. **Do NOT attempt to fix this in code.** Per `CLAUDE.md`'s "Railway Token Rotation" section, the agent's only legitimate action is to file an investigation note pointing at `docs/RAILWAY_TOKEN_ROTATION_742.md`. Creating a `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming the rotation is done is a Category 1 error.
+2. **Tell the human to verify "No expiration" on rotation.** The recurrence pattern (21 incidents) strongly indicates a default TTL is being accepted. The runbook already says this — the failure mode is human compliance, not documentation.
+3. **Recommend migration to a Railway project token.** Trade-offs: (a) project tokens are environment-scoped and don't expire by default; (b) the `Validate Railway secrets` step must be rewritten because `{me{id}}` requires an account token; (c) auth header changes from `Authorization: Bearer` to `Project-Access-Token`. This would meaningfully break the cycle.
+4. **Fix endpoint to `backboard.railway.com`.** Low-risk hygiene change; the `.app` domain is undocumented.
+5. **Consider an `expires_at` health check.** The repo already has `railway-token-health.yml` — if it doesn't already query token TTL, extending it to alert ~7 days pre-expiry would prevent main-CI-red incidents from being the first signal.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Public API — Railway Docs | https://docs.railway.com/integrations/api | Official token-type reference (account/team/project), correct headers, endpoint |
+| 2 | Login & Tokens — Railway Docs | https://docs.railway.com/integrations/oauth/login-and-tokens | Token expiration semantics, "No expiration" option |
+| 3 | Introduction to GraphQL — Railway Docs | https://docs.railway.com/integrations/api/graphql-overview | GraphQL schema and auth model |
+| 4 | API Token "Not Authorized" Error — Railway Help Station | https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1 | Confirms `me{id}` requires account token; explains the exact error message Reli sees |
+| 5 | GraphQL requests returning "Not Authorized" for PAT — Railway Help Station | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | Cross-reference for the same failure mode |
+| 6 | Using GitHub Actions with Railway — Railway Blog | https://blog.railway.com/p/github-actions | Recommends project tokens for CI/CD |
+| 7 | Token for GitHub Action — Railway Help Station | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Practical project-token setup pattern |
+| 8 | Unable to Generate API Token with Deployment Permissions | https://station.railway.com/questions/unable-to-generate-api-token-with-deploy-4d2ccc12 | Edge cases on token scoping |
+| 9 | bervProject/railway-deploy — GitHub | https://github.com/bervProject/railway-deploy | Reusable Action that wraps `railway up` |
+| 10 | Secretless Access for GitHub Actions — Aembit | https://aembit.io/blog/secretless-access-for-github-actions/ | OIDC trust-relationship background |
+| 11 | Best Practices for Managing and Rotating Secrets — GitHub Community Discussion #168661 | https://github.com/orgs/community/discussions/168661 | GitHub-native rotation guidance |
+| 12 | Automated secrets rotation with Doppler and GitHub Actions | https://www.doppler.com/blog/automated-secrets-rotation-with-doppler-and-github-actions | Optional secrets-manager path |


### PR DESCRIPTION
## Summary

Investigation-only artifact for the **21st recurrence** of the expired `RAILWAY_TOKEN` secret. The `Validate Railway secrets` pre-flight at `.github/workflows/staging-pipeline.yml:32-58` is again aborting every `Deploy to staging` run on `main` with `RAILWAY_TOKEN is invalid or expired: Not Authorized`.

Per `CLAUDE.md` § "Railway Token Rotation", **agents cannot rotate the Railway API token** — this PR is documentation only, mirroring the precedent set by the 20 prior occurrences (PRs #780 / #782 / #784 / #787 / #788 / #791 / #792 / #795 / #796 / #799 / #802 / #803).

Fixes #804

## Failing run

- Failing run id: `25182725669`
- Job: `Deploy to staging` → step `Validate Railway secrets`
- Error: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` (timestamp `2026-04-30T18:35:01Z`)
- Endpoint probed: `https://backboard.railway.app/graphql/v2` query `{me{id}}` returned no `data.me.id`

## Root cause

`secrets.RAILWAY_TOKEN` is expired. The validate step at `.github/workflows/staging-pipeline.yml:49-58` is **functioning correctly** — it is failing closed precisely because Railway's GraphQL API rejects the token. Recurrence cadence (21 incidents) is consistent with rotations being performed with a default short TTL rather than the documented **"No expiration"** option.

## Changes

| File | Status | Purpose |
|------|--------|---------|
| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/investigation.md` | new | Investigation artifact for issue #804 (21st recurrence). |
| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/validation.md` | new | Validation artifact for the docs-only investigation PR. |
| `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/web-research.md` | new | Railway token-type / expiration research, retained for the post-rotation human follow-up. |

**Negative checks (scope-boundary evidence):**

- `.github/workflows/staging-pipeline.yml` — **unchanged** (failing closed correctly per lines 32–58; do not mask)
- `docs/RAILWAY_TOKEN_ROTATION_742.md` — **unchanged** (canonical runbook)
- No `.github/RAILWAY_TOKEN_ROTATION_*.md` created (Category 1 error explicitly avoided per `CLAUDE.md`)

## Validation

| Check | Result | Details |
|-------|--------|---------|
| Type check | N/A | No source code changed |
| Lint | N/A | No source code changed |
| Format | N/A | No source code changed |
| Tests | N/A | No source code changed |
| Build | N/A | No source code changed |

Docs-only PR — the standard validation suite has nothing to validate, mirroring the 20 prior identical investigation PRs. See `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/validation.md` for the negative-check evidence.

## Required human action (out of agent scope)

The fix lives outside this repo. A human with access to https://railway.com/account/tokens must:

1. Mint a new Railway account token with **Expiration: No expiration** (do not accept the default TTL — this is the recurrence root cause).
2. Update the GitHub secret: `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli`.
3. Verify with the health probe: `gh workflow run railway-token-health.yml --repo alexsiri7/reli`.
4. Re-run the failed deploy: `gh run rerun 25182725669 --repo alexsiri7/reli --failed` (fallback: rerun the latest failed run via `gh run list --status failure --limit 1`).
5. Close issue #804 once `staging-pipeline.yml` returns green.

See `docs/RAILWAY_TOKEN_ROTATION_742.md` for the canonical rotation runbook.

## Test plan

- [x] Artifact files committed under `artifacts/runs/b9863d3691e7e5613a5dc5d396567ce8/`
- [x] Investigation cites the failing run (`25182725669`) and the explicit error text
- [x] Lineage updated to **21st recurrence**
- [x] No edits to `.github/workflows/staging-pipeline.yml`
- [x] No edits to `docs/RAILWAY_TOKEN_ROTATION_742.md`
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` created
- [ ] Human rotates `RAILWAY_TOKEN` with **No expiration** (out of scope for this PR)
- [ ] Post-rotation: `staging-pipeline.yml` returns three consecutive `success` conclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)