### PR TITLE
docs: investigation for issue #758 (deploy-down stale duplicate of #836)

### DIFF
--- a/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md
+++ b/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md
@@ -8,7 +8,7 @@
 
 | Metric | Value | Reasoning |
 |--------|-------|-----------|
-| Severity | LOW | Original symptom (HTTP 000000) has cleared; production currently returns HTTP 200 on `/`, `/healthz`, `/api/health`. The active deploy-pipeline failure is already tracked under issue #836 (34th RAILWAY_TOKEN expiration). |
+| Severity | LOW | Original symptom (HTTP 000000) has cleared; production currently returns HTTP 200 on `/`, `/healthz`, `/api/health`. The active deploy-pipeline failure is already tracked under issue #836 (33rd RAILWAY_TOKEN expiration). |
 | Complexity | LOW | No source-code change is appropriate. The actionable step is human-only token rotation; this investigation is docs-only and the issue is a duplicate that should be closed. |
 | Confidence | HIGH | Live probes confirm the site is up; CI logs (run `25207459124`) confirm the underlying CI failure mode is `RAILWAY_TOKEN is invalid or expired: Not Authorized`, matching the established 33-cycle pattern documented in PRs #831–#838. |
 
@@ -28,7 +28,7 @@ Issue #758 reports a transient health-check failure (`HTTP 000000`) observed on 
 |-----------|-----------|--------|-------|
 | Production app process (FastAPI / uvicorn) | `backend/main.py` | Yes | Live probe `GET /healthz` returns `{"status":"ok"}` — the running container is healthy. |
 | CI deploy validator (Railway preflight) | `.github/workflows/staging-pipeline.yml:32-58` | Yes | The validator correctly fails fast on an expired token; the failure is the *signal*, not the *defect*. |
-| `RAILWAY_TOKEN` GitHub Actions secret | external (Railway dashboard) | **No — operationally fragile** | Token has expired again (34th occurrence). Structural improvement (Workspace=No workspace, Expiration=No expiration at creation) is tracked in #836's investigation; not in scope for #758. |
+| `RAILWAY_TOKEN` GitHub Actions secret | external (Railway dashboard) | **No — operationally fragile** | Token has expired again (33rd occurrence). Structural improvement (Workspace=No workspace, Expiration=No expiration at creation) is tracked in #836's investigation; not in scope for #758. |
 | Issue lifecycle (archon `in-progress` → re-queue) | issue label state | **Partial** | An open `archon:in-progress` issue with no PR is re-fired every few hours. Once the symptom resolves, the issue should be closed manually since no agent action will produce a PR. |
 
 ### Root Cause / Change Rationale
@@ -47,11 +47,11 @@ WHY: Issue #758 keeps being re-queued.
 ↓ BECAUSE: The symptom that triggered #758 (`HTTP 000000` at 2026-04-28 03:00:32 UTC) was a transient outage during a Railway deploy window. The production process recovered, but CI deploy attempts continue to fail with an expired token.
   Evidence:
   - Live probe 2026-05-01 08:30 UTC: `curl https://reli.interstellarai.net/healthz` → `HTTP 200 {"status":"ok","service":"reli"}`.
-  - Most recent `Staging → Production Pipeline` run `25207459124` (2026-05-01 08:04 UTC) failed at the *Validate Railway secrets* step: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` (`.github/workflows/staging-pipeline.yml:54`).
+  - Most recent `Staging → Production Pipeline` run `25207459124` (2026-05-01 08:04 UTC) failed at the *Validate Railway secrets* step: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` (`.github/workflows/staging-pipeline.yml:55`).
 
-↓ ROOT CAUSE: The active operational issue is the **34th `RAILWAY_TOKEN` expiration**, already tracked under issue **#836** (and adjacent #833). Issue #758 itself describes a now-resolved transient symptom and is duplicate work. Per `CLAUDE.md > Railway Token Rotation`, agents cannot rotate the token; the only fix is a human action against railway.com.
+↓ ROOT CAUSE: The active operational issue is the **33rd `RAILWAY_TOKEN` expiration**, already tracked under issue **#836** (and adjacent #833). Issue #758 itself describes a now-resolved transient symptom and is duplicate work. Per `CLAUDE.md > Railway Token Rotation`, agents cannot rotate the token; the only fix is a human action against railway.com.
   Evidence:
-  - `gh run view 25207459124 --log-failed` → `RAILWAY_TOKEN is invalid or expired: Not Authorized` at `staging-pipeline.yml:54`.
+  - `gh run view 25207459124 --log-failed` → `RAILWAY_TOKEN is invalid or expired: Not Authorized` at `staging-pipeline.yml:55`.
   - `git log --oneline -20` shows 14+ recent commits that are investigation receipts for the same expiration pattern (`8a3f93a` → `ee9d0fb`, issues #800–#836).
   - `CLAUDE.md` (project root): *"Agents cannot rotate the Railway API token. … Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. … Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook."*
 
@@ -65,7 +65,7 @@ WHY: Issue #758 keeps being re-queued.
 
 - `.github/workflows/staging-pipeline.yml:32-58` — *Validate Railway secrets* step is the **detector**, not the defect.
 - `docs/RAILWAY_TOKEN_ROTATION_742.md` — runbook for the human rotation step.
-- Issue #836 — currently-open active tracking bead for the 34th expiration; carries the latest PR receipt (#838) and the surfaced "No workspace" structural recommendation.
+- Issue #836 — currently-open active tracking bead for the 33rd expiration; carries the latest PR receipt (#838) and the surfaced "No workspace" structural recommendation.
 - Issue #833 — adjacent open tracking bead ("Prod deploy failed on main") for the same root cause.
 
 ### Git History
@@ -116,7 +116,7 @@ gh run rerun 25207459124 --repo alexsiri7/reli --failed
 ```bash
 gh issue close 758 --repo alexsiri7/reli \
   --reason "not planned" \
-  --comment "Symptom (HTTP 000000) has cleared; production is HTTP 200 as of 2026-05-01 08:30 UTC. The underlying recurring driver is the RAILWAY_TOKEN expiration cycle, currently tracked under #836 (34th occurrence). Closing as duplicate to stop the archon requeue loop. See artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md."
+  --comment "Symptom (HTTP 000000) has cleared; production is HTTP 200 as of 2026-05-01 08:30 UTC. The underlying recurring driver is the RAILWAY_TOKEN expiration cycle, currently tracked under #836 (33rd occurrence). Closing as duplicate to stop the archon requeue loop. See artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md."
 ```
 
 **Why**: Without closing, the `archon:in-progress` label on an issue with no possible PR will keep firing the poller every ~2.5 hours, generating noise comments without progress.
@@ -216,6 +216,6 @@ git grep -n "RAILWAY_TOKEN" -- .github docs
 - **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md`
 - **Workflow run-id**: `a5e81891df69badbc37d19cacc1c057a`
 - **Production probe** (at investigation time): `GET https://reli.interstellarai.net/healthz` → `HTTP 200 {"status":"ok","service":"reli"}`
-- **Active CI failure** (at investigation time): pipeline run `25207459124` red at `staging-pipeline.yml:54` — `RAILWAY_TOKEN is invalid or expired: Not Authorized`
-- **Tracking issues**: #836 (34th `RAILWAY_TOKEN` expiration — primary), #833 (adjacent — same cause)
+- **Active CI failure** (at investigation time): pipeline run `25207459124` red at `staging-pipeline.yml:55` — `RAILWAY_TOKEN is invalid or expired: Not Authorized`
+- **Tracking issues**: #836 (33rd `RAILWAY_TOKEN` expiration — primary), #833 (adjacent — same cause)
 - **Supersedes**: 2026-04-29 investigation comment on #758 (incorrectly attributed cause to MCP `lifespan` hang)

--- a/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md
+++ b/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md
@@ -1,0 +1,221 @@
+# Investigation: Deploy down: https://reli.interstellarai.net returning HTTP 000000
+
+**Issue**: #758 (https://github.com/alexsiri7/reli/issues/758)
+**Type**: BUG
+**Investigated**: 2026-05-01T08:30:00Z
+
+## Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | LOW | Original symptom (HTTP 000000) has cleared; production currently returns HTTP 200 on `/`, `/healthz`, `/api/health`. The active deploy-pipeline failure is already tracked under issue #836 (34th RAILWAY_TOKEN expiration). |
+| Complexity | LOW | No source-code change is appropriate. The actionable step is human-only token rotation; this investigation is docs-only and the issue is a duplicate that should be closed. |
+| Confidence | HIGH | Live probes confirm the site is up; CI logs (run `25207459124`) confirm the underlying CI failure mode is `RAILWAY_TOKEN is invalid or expired: Not Authorized`, matching the established 33-cycle pattern documented in PRs #831–#838. |
+
+---
+
+## Problem Statement
+
+Issue #758 reports a transient health-check failure (`HTTP 000000`) observed on **2026-04-28 03:00:32 UTC**. As of **2026-05-01 08:30 UTC** the production endpoint is healthy (HTTP 200, `{"status":"ok","service":"reli"}`). The issue has remained `archon:in-progress` and been re-queued repeatedly because no PR closes it; the prior investigation comment (2026-04-29) misdiagnosed the cause as an MCP `lifespan` hang. The actual recurring driver — expired `RAILWAY_TOKEN` — is already being tracked under separate issues (#833, #836) and is human-action-only per `CLAUDE.md`.
+
+---
+
+## Analysis
+
+### Primitive Check
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| Production app process (FastAPI / uvicorn) | `backend/main.py` | Yes | Live probe `GET /healthz` returns `{"status":"ok"}` — the running container is healthy. |
+| CI deploy validator (Railway preflight) | `.github/workflows/staging-pipeline.yml:32-58` | Yes | The validator correctly fails fast on an expired token; the failure is the *signal*, not the *defect*. |
+| `RAILWAY_TOKEN` GitHub Actions secret | external (Railway dashboard) | **No — operationally fragile** | Token has expired again (34th occurrence). Structural improvement (Workspace=No workspace, Expiration=No expiration at creation) is tracked in #836's investigation; not in scope for #758. |
+| Issue lifecycle (archon `in-progress` → re-queue) | issue label state | **Partial** | An open `archon:in-progress` issue with no PR is re-fired every few hours. Once the symptom resolves, the issue should be closed manually since no agent action will produce a PR. |
+
+### Root Cause / Change Rationale
+
+This issue is a **stale duplicate of an active tracking issue**, not a code defect.
+
+### Evidence Chain
+
+WHY: Issue #758 keeps being re-queued.
+↓ BECAUSE: It is labeled `archon:in-progress` with no linked PR.
+  Evidence: 12 auto-comments in `gh issue view 758` of the form *"archon was labeled in-progress Ns ago but no live run and no linked PR were found. Re-queued for another attempt."*
+
+↓ BECAUSE: Prior investigation (2026-04-29 comment by Claude) proposed an MCP-lifespan code change but no implementation was produced; meanwhile the actual operational defect was a Railway-token expiration, which agents cannot rotate.
+  Evidence: Prior comment text — *"ROOT CAUSE: The MCP session manager initialization added in commit `8d621893` may be deadlocking…"* — does not align with current production state (HTTP 200) nor with the recurring CI failure mode below.
+
+↓ BECAUSE: The symptom that triggered #758 (`HTTP 000000` at 2026-04-28 03:00:32 UTC) was a transient outage during a Railway deploy window. The production process recovered, but CI deploy attempts continue to fail with an expired token.
+  Evidence:
+  - Live probe 2026-05-01 08:30 UTC: `curl https://reli.interstellarai.net/healthz` → `HTTP 200 {"status":"ok","service":"reli"}`.
+  - Most recent `Staging → Production Pipeline` run `25207459124` (2026-05-01 08:04 UTC) failed at the *Validate Railway secrets* step: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` (`.github/workflows/staging-pipeline.yml:54`).
+
+↓ ROOT CAUSE: The active operational issue is the **34th `RAILWAY_TOKEN` expiration**, already tracked under issue **#836** (and adjacent #833). Issue #758 itself describes a now-resolved transient symptom and is duplicate work. Per `CLAUDE.md > Railway Token Rotation`, agents cannot rotate the token; the only fix is a human action against railway.com.
+  Evidence:
+  - `gh run view 25207459124 --log-failed` → `RAILWAY_TOKEN is invalid or expired: Not Authorized` at `staging-pipeline.yml:54`.
+  - `git log --oneline -20` shows 14+ recent commits that are investigation receipts for the same expiration pattern (`8a3f93a` → `ee9d0fb`, issues #800–#836).
+  - `CLAUDE.md` (project root): *"Agents cannot rotate the Railway API token. … Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. … Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook."*
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none) | — | NONE | No source code, workflow, config, runbook, or test should be modified by this investigation. The only change is producing this artifact and posting a status comment that recommends closing #758 as duplicate of #836. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — *Validate Railway secrets* step is the **detector**, not the defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — runbook for the human rotation step.
+- Issue #836 — currently-open active tracking bead for the 34th expiration; carries the latest PR receipt (#838) and the surfaced "No workspace" structural recommendation.
+- Issue #833 — adjacent open tracking bead ("Prod deploy failed on main") for the same root cause.
+
+### Git History
+
+- **First filed**: #758 on 2026-04-28 (transient `HTTP 000000`).
+- **Last comment activity on this issue**: 2026-05-01 07:31:25Z — auto-requeue from archon poller.
+- **Adjacent activity**:
+  - `ee9d0fb` (2026-05-01) — *docs: investigation for issue #836 (33rd RAILWAY_TOKEN expiration, 2nd pickup) (#838)*
+  - `392291c` (2026-05-01) — *docs: investigation for issue #836 (33rd RAILWAY_TOKEN expiration) (#837)*
+  - `3db8f1b` / `feb6609` (2026-05-01) — investigations for #832/#833.
+- **Implication**: This is an established recurring pattern, not a regression in #758 itself. The cluster of investigations around the same root cause indicates that #758 should be **closed as duplicate of #836** to stop the requeue loop.
+
+---
+
+## Implementation Plan
+
+There is **no code change** in scope. The plan has two human-only steps and one optional bookkeeping step.
+
+### Step 1 (Human-only): Rotate `RAILWAY_TOKEN`
+
+**Where**: https://railway.com/account/tokens
+**Action**: Create a new account-level token.
+
+**Settings to use** (per `docs/RAILWAY_TOKEN_ROTATION_742.md` and the structural finding from #836's investigation):
+- **Workspace**: `No workspace` ← critical; suspected primary driver of the 33-cycle pattern.
+- **Expiration**: `No expiration`.
+- Name: `gh-actions-deploy-<YYYYMMDD>`.
+
+Then update the GitHub Actions secret:
+
+```bash
+gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+# Paste the new token at the prompt.
+```
+
+Re-run the most recent failed deploy:
+
+```bash
+gh run rerun 25207459124 --repo alexsiri7/reli --failed
+```
+
+**Why**: This is the only action that unblocks CI deploy. It cannot be done by an agent — it requires interactive access to railway.com.
+
+---
+
+### Step 2 (Human-only): Close issue #758 as duplicate of #836
+
+```bash
+gh issue close 758 --repo alexsiri7/reli \
+  --reason "not planned" \
+  --comment "Symptom (HTTP 000000) has cleared; production is HTTP 200 as of 2026-05-01 08:30 UTC. The underlying recurring driver is the RAILWAY_TOKEN expiration cycle, currently tracked under #836 (34th occurrence). Closing as duplicate to stop the archon requeue loop. See artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md."
+```
+
+**Why**: Without closing, the `archon:in-progress` label on an issue with no possible PR will keep firing the poller every ~2.5 hours, generating noise comments without progress.
+
+---
+
+### Step 3 (Optional, agent-safe): Land this investigation artifact
+
+This artifact (`artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md`) is the only file produced. A docs-only PR following the same convention as #838 / #837 (`docs: investigation for issue #758 (deploy-down stale duplicate)`) is acceptable but optional — its function is purely documentary.
+
+---
+
+## Patterns to Follow
+
+**From codebase — the established docs-only investigation pattern**:
+
+```
+# git log --oneline -10 (excerpt)
+ee9d0fb docs: investigation for issue #836 (33rd RAILWAY_TOKEN expiration, 2nd pickup) (#838)
+392291c docs: investigation for issue #836 (33rd RAILWAY_TOKEN expiration) (#837)
+3db8f1b docs: investigation for issue #833 (32nd RAILWAY_TOKEN expiration) (#834)
+```
+
+Each PR in this pattern lands **only** files under `artifacts/runs/<run-id>/` and touches no source, workflow, config, runbook, or test. This investigation conforms to that pattern.
+
+```python
+# CLAUDE.md > Railway Token Rotation (verbatim policy)
+# Agents cannot rotate the Railway API token. The token lives in GitHub
+# Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+# When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+# 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming
+#    rotation is done.
+# 2. File a GitHub issue or send mail to mayor with the error details.
+# 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the
+#    rotation runbook.
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Production goes down again before the human rotates the token. | Already covered: the running container persists across CI failures (the validator gates *new* deploys, not the live process). If the live process crashes for an unrelated reason, no auto-redeploy will recover it until the token is rotated — file a separate `human-needed` issue if this happens. |
+| Closing #758 obscures the original transient outage. | This artifact captures the original symptom (`HTTP 000000` at 2026-04-28 03:00:32 UTC) and the current healthy state, so the historical record is preserved in `artifacts/runs/`. |
+| The prior (incorrect) MCP-lifespan investigation comment confuses future readers. | Step-2 close comment explicitly supersedes the 2026-04-29 comment by stating the symptom has cleared and pointing to the active tracking issue #836. |
+| Agent attempts to apply the prior investigation's `backend/main.py` patch. | **Out of scope**. This artifact's "Scope Boundaries" section explicitly forbids touching `backend/main.py`. The prior comment's diagnosis is unsubstantiated — `/healthz` returns 200 right now without that change. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# 1. Confirm production is currently healthy.
+curl -sf https://reli.interstellarai.net/healthz
+# Expected: HTTP 200 with {"status":"ok","service":"reli"}
+
+# 2. Confirm the CI failure mode is RAILWAY_TOKEN expiration (not something new).
+gh run view 25207459124 --repo alexsiri7/reli --log-failed | grep -i "railway_token"
+# Expected: ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized
+
+# 3. Confirm there is no agent-rotatable secret in the repo.
+git grep -n "RAILWAY_TOKEN" -- .github docs
+# Expected: only references in workflow/runbook — no plaintext token.
+```
+
+### Manual Verification
+
+1. After human rotates the token (Step 1), re-run the latest failed pipeline (`gh run rerun 25207459124 --failed`) and confirm the *Validate Railway secrets* step turns green.
+2. After closing #758 (Step 2), confirm the archon poller stops emitting requeue comments on it (no new comment within ~3 hours).
+3. Confirm production endpoints remain HTTP 200 across the rotation window.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Producing this investigation artifact under `artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md`.
+- Posting a single GitHub comment on #758 with the assessment and the close-as-duplicate recommendation.
+
+**OUT OF SCOPE (do not touch):**
+- `backend/main.py` (no MCP-lifespan change — the prior investigation's hypothesis is not supported by the current healthy state).
+- `docker-compose.yml` (no `RELI_BASE_URL` change — same reason).
+- `.github/workflows/staging-pipeline.yml` (the validator is working correctly; it is the detector, not the defect).
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` (runbook updates are tracked under #836's follow-up beads; CLAUDE.md says do not create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file).
+- Rotating `RAILWAY_TOKEN` (human-only — agents cannot perform this action).
+- Closing the issue itself via API (close action belongs to the human as part of Step 2 to confirm the duplicate determination).
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (model `claude-opus-4-7[1m]`)
+- **Timestamp**: 2026-05-01T08:30:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md`
+- **Workflow run-id**: `a5e81891df69badbc37d19cacc1c057a`
+- **Production probe** (at investigation time): `GET https://reli.interstellarai.net/healthz` → `HTTP 200 {"status":"ok","service":"reli"}`
+- **Active CI failure** (at investigation time): pipeline run `25207459124` red at `staging-pipeline.yml:54` — `RAILWAY_TOKEN is invalid or expired: Not Authorized`
+- **Tracking issues**: #836 (34th `RAILWAY_TOKEN` expiration — primary), #833 (adjacent — same cause)
+- **Supersedes**: 2026-04-29 investigation comment on #758 (incorrectly attributed cause to MCP `lifespan` hang)

--- a/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/validation.md
+++ b/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/validation.md
@@ -20,7 +20,7 @@
 
 ## Context
 
-Issue #758 ("Deploy down: https://reli.interstellarai.net returning HTTP 000000") was investigated and found to be a **stale duplicate of active issue #836** (34th `RAILWAY_TOKEN` expiration).
+Issue #758 ("Deploy down: https://reli.interstellarai.net returning HTTP 000000") was investigated and found to be a **stale duplicate of active issue #836** (33rd `RAILWAY_TOKEN` expiration).
 
 Per `investigation.md` (this run):
 

--- a/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/validation.md
+++ b/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/validation.md
@@ -1,0 +1,103 @@
+# Validation Results
+
+**Generated**: 2026-05-01 09:15
+**Workflow ID**: a5e81891df69badbc37d19cacc1c057a
+**Status**: ALL_PASS (no-op — docs-only, no code changes)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No code changes |
+| Lint | N/A | No code changes |
+| Format | N/A | No code changes |
+| Tests | N/A | No code changes |
+| Build | N/A | No code changes |
+
+---
+
+## Context
+
+Issue #758 ("Deploy down: https://reli.interstellarai.net returning HTTP 000000") was investigated and found to be a **stale duplicate of active issue #836** (34th `RAILWAY_TOKEN` expiration).
+
+Per `investigation.md` (this run):
+
+> There is **no code change** in scope. The plan has two human-only steps and one optional bookkeeping step.
+
+Per `CLAUDE.md > Railway Token Rotation`:
+
+> Agents cannot rotate the Railway API token. … Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. … Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+
+The production endpoint is currently healthy (HTTP 200 on `/healthz`), and the recurring CI failure (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) is already tracked under #836. No `plan-context.md` was produced because no implementation step was warranted.
+
+---
+
+## Working Tree State
+
+```
+$ git status
+On branch archon/task-archon-fix-github-issue-1777622440981
+Your branch is up to date with 'origin/main'.
+nothing to commit, working tree clean
+
+$ git log origin/main..HEAD --oneline
+(no output — HEAD == origin/main)
+
+$ git diff HEAD --stat
+(no output — no working tree changes)
+```
+
+There are zero file modifications on this branch. Type-check / lint / format / test / build commands have nothing to run against, so they are reported as **N/A** rather than ✅ — running them would only re-validate `origin/main`, which is not the purpose of this step.
+
+---
+
+## Type Check
+
+**Command**: not run
+**Result**: N/A — no source files modified.
+
+---
+
+## Lint
+
+**Command**: not run
+**Result**: N/A — no source files modified.
+
+---
+
+## Format
+
+**Command**: not run
+**Result**: N/A — no source files modified.
+
+---
+
+## Tests
+
+**Command**: not run
+**Result**: N/A — no source files modified.
+
+---
+
+## Build
+
+**Command**: not run
+**Result**: N/A — no source files modified.
+
+---
+
+## Files Modified During Validation
+
+None.
+
+---
+
+## Next Step
+
+Skip `archon-finalize-pr` for code merge — there is no PR to finalize because there is no diff. The follow-up action is bookkeeping on issue #758:
+
+1. Post a comment on #758 noting the production endpoint is healthy and the underlying CI failure is tracked under #836.
+2. Recommend closing #758 as duplicate of #836 to stop the `archon:in-progress` requeue loop.
+3. Human action: rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (Workspace = `No workspace`, Expiration = `No expiration`).

--- a/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/web-research.md
+++ b/artifacts/runs/a5e81891df69badbc37d19cacc1c057a/web-research.md
@@ -1,0 +1,240 @@
+---
+name: Web research for issue #758
+description: External research on the deploy-down failure mode (FastAPI lifespan + MCP streamable HTTP, Cloudflare/curl 000, Railway health checks)
+type: research
+---
+
+# Web Research: fix #758 — "Deploy down: https://reli.interstellarai.net returning HTTP 000000"
+
+**Researched**: 2026-05-01T09:15:00Z
+**Workflow ID**: a5e81891df69badbc37d19cacc1c057a
+
+---
+
+## Summary
+
+Three causes are consistent with the symptom (`HTTP 000000` from the health probe at `https://reli.interstellarai.net`): (1) curl could not establish a TCP/TLS connection at all (DNS / CDN / firewall / origin-down) — `000` is curl's sentinel for "no HTTP response received"; (2) the FastAPI `lifespan` is hanging or crashing inside the MCP `session_manager.run()` block, causing the container to never become ready (Docker `HEALTHCHECK` then keeps it unhealthy and Cloudflare returns nothing to the probe); (3) no recent successful Railway deploy because `RAILWAY_TOKEN` has been expiring repeatedly — the most recent ~20 commits on `main` are RAILWAY_TOKEN expiration investigations, so production may simply not have been re-deployed. The strongest code-level finding is that the existing lifespan at `backend/main.py:113-128` reaches into private MCP SDK state (`_session_manager`, `_has_started`, `_run_lock`) — this is a known fragile pattern caused by mounting the streamable HTTP MCP app as a sub-app of FastAPI; the documented fix is to combine the MCP server's own lifespan with the FastAPI lifespan rather than poke private attributes.
+
+---
+
+## Findings
+
+### 1. `curl` / probe HTTP code `000` means *no HTTP response*, not an HTTP error
+
+**Source**: [curl issue tracker / curl mailing list / IBM IT15643](https://www.ibm.com/support/pages/apar/IT15643)
+**Authority**: Primary — curl maintainers and standard ops references.
+**Relevant to**: Interpreting the issue body (`HTTP status: 000000`).
+
+**Key information**:
+
+- `000` from `curl --write-out '%{http_code}'` means curl never received an HTTP status — *not* a server-side error.
+- Common causes: DNS resolution failure, connection refused, TCP timeout, TLS handshake failure, firewall drop.
+- Recommendation from curl: also check the curl exit code (e.g. 6 = couldn't resolve host, 7 = couldn't connect, 28 = timeout, 35 = SSL connect error) instead of relying on the HTTP code alone.
+- This means the Reli probe is failing *before* it gets a reply — the origin is down, blocked, or unreachable; it is **not** returning a 5xx that the app could log.
+
+**Implication for #758**: The probe message gives no information about *why* the origin is unreachable. The investigation must come from Railway service logs / Cloudflare analytics, not from FastAPI logs alone.
+
+---
+
+### 2. The MCP Python SDK's `StreamableHTTPSessionManager.run()` is one-shot per instance, with a known race condition
+
+**Sources**:
+- [LiteLLM #13651 — `StreamableHTTPSessionManager.run() can only be called once per instance`](https://github.com/BerriAI/litellm/issues/13651)
+- [LiteLLM PR #13666 — fix for the same](https://github.com/BerriAI/litellm/pull/13666)
+- [modelcontextprotocol/python-sdk #1180 — FastMCP + Streamable HTTP session management](https://github.com/modelcontextprotocol/python-sdk/issues/1180)
+- [modelcontextprotocol/python-sdk #2150 — Active Streamable HTTP sessions are not terminated during shutdown](https://github.com/modelcontextprotocol/python-sdk/issues/2150)
+
+**Authority**: Upstream MCP SDK issue tracker (`modelcontextprotocol/python-sdk` is the SDK Reli uses via `from mcp.server.fastmcp import FastMCP`).
+**Relevant to**: The hand-rolled reset code at `backend/main.py:115-128`.
+
+**Key information**:
+
+- `StreamableHTTPSessionManager.run()` raises if called twice on the same instance. The error string is literally `"StreamableHTTPSessionManager .run() can only be called once per instance. Create a new instance if you need to run again"`.
+- A race condition exists: two coroutines that both enter the initialise-session-managers path concurrently can both flip `_has_started` to True and trip the guard. There is no lock around the guard in the SDK.
+- Active sessions are not torn down cleanly during shutdown (issue #2150) — this can cause hangs on container shutdown that look like "lifespan never returns."
+
+**Implication for #758**: The Reli code at `backend/main.py:115-128` resets `sm._has_started = False` and re-creates `sm._run_lock` to allow `run()` to be called again on the *same* SDK instance. This works in single-worker `uvicorn` mode but:
+1. Reaches into private SDK state — any minor SDK upgrade can break it.
+2. Does not protect against the race condition above. If two workers (or a worker + a hot-reload restart) hit the path concurrently, one will hang or crash.
+3. If `run()` raises during startup, the FastAPI lifespan never `yield`s, the app never accepts traffic, the Docker `HEALTHCHECK` keeps the container unhealthy, and Cloudflare/Railway sees the origin as down → `HTTP 000000`.
+
+---
+
+### 3. Recommended pattern: combine the MCP server's lifespan with FastAPI's, don't poke private state
+
+**Sources**:
+- [modelcontextprotocol/python-sdk #713 — multi streamable HTTP server lifespan](https://github.com/modelcontextprotocol/python-sdk/issues/713)
+- [modelcontextprotocol/python-sdk #1367 — Mounting Streamable HTTP MCP on existing FastAPI app](https://github.com/modelcontextprotocol/python-sdk/issues/1367)
+- [FastMCP docs — FastAPI integration](https://gofastmcp.com/integrations/fastapi)
+- [FastMCP docs — HTTP Deployment](https://gofastmcp.com/deployment/http)
+- [jlowin/fastmcp #480 — make session_manager a property](https://github.com/jlowin/fastmcp/issues/480)
+- [jlowin/fastmcp #1026 — provide custom lifespan to http_app()](https://github.com/jlowin/fastmcp/issues/1026)
+
+**Authority**: Upstream SDK and the maintained third-party FastMCP documentation. Reli uses the upstream `mcp.server.fastmcp` package, not `jlowin/fastmcp` — the patterns are conceptually compatible but the API surface differs.
+
+**Relevant to**: Replacing the `_has_started` reset hack in `backend/main.py:115-128` with a supported pattern.
+
+**Key information**:
+
+- Starlette / FastAPI sub-app `lifespan` does **not** propagate when the sub-app is `app.mount()`-ed. This is the root reason `session_manager.run()` has to be called from the parent app's lifespan.
+- The supported pattern is to combine lifespans using `contextlib.AsyncExitStack`:
+
+```python
+from contextlib import AsyncExitStack, asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with AsyncExitStack() as stack:
+        # Existing Reli startup
+        ...
+        # MCP server — entered via its public session_manager.run()
+        await stack.enter_async_context(_mcp_server.session_manager.run())
+        yield
+        # Cleanup runs in reverse order on AsyncExitStack exit
+```
+
+- For `jlowin/fastmcp` v2 the equivalent is `FastAPI(lifespan=mcp_app.lifespan)` or `combine_lifespans(app_lifespan, mcp_app.lifespan)` — Reli is on the upstream SDK, so the `AsyncExitStack` pattern is the correct one.
+- Critically: `session_manager.run()` is one-shot per *instance*. If uvicorn restarts the worker (hot-reload, OOM, signal), a fresh process is created and the FastMCP global is re-imported — so the one-shot is not actually a problem under normal operation. The current reset hack is only needed because tests reuse the same module-level `mcp` object across runs. **Production does not need the reset hack.**
+
+---
+
+### 4. `RELI_BASE_URL` is missing from `docker-compose.yml`, which can cause MCP to reject requests with DNS-rebinding-protection errors
+
+**Sources**:
+- [MCP SDK source — TransportSecuritySettings + DNS rebinding protection](https://pypi.org/project/mcp/) (via the `enable_dns_rebinding_protection=True` flag in `backend/mcp_server.py:71`)
+- Code inspection: `backend/mcp_server.py:42-50`, `docker-compose.yml:9-28`
+
+**Authority**: Direct code inspection; SDK behaviour confirmed by SDK release notes referenced in PyPI listing.
+**Relevant to**: Whether MCP requests would be 421-rejected even after the lifespan starts cleanly.
+
+**Key information**:
+
+- `backend/mcp_server.py:42` reads `RELI_BASE_URL` to derive the production hostname allowed by MCP's DNS-rebinding protection.
+- `docker-compose.yml:22` declares the env var (`RELI_BASE_URL=${RELI_BASE_URL:-}`) but defaults it to empty.
+- If the env var is not exported in production, `_RELI_HOST` falls back to whatever it can parse out of `GOOGLE_AUTH_REDIRECT_URI` — that may or may not match the real production hostname.
+- Note this is **only** an MCP path (`/mcp/...`) issue; it does not explain `/healthz` returning `000`. So this is a side issue worth flagging in the fix, not the root cause of the deploy-down symptom.
+
+---
+
+### 5. Railway / Cloudflare path: `HTTP 000` from a public probe is consistent with origin not listening or CDN error 522/523
+
+**Sources**:
+- [Cloudflare Error 522 docs](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/)
+- [Cloudflare Error 524 docs](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524/)
+- [Railway health-check failure thread (FastAPI)](https://station.railway.com/questions/health-check-failed-cd123ec3)
+- [Railway `$PORT` shell-form CMD discussion](https://medium.com/@tomhag_17/debugging-a-railway-deployment-my-journey-through-port-variables-and-configuration-conflicts-eb49cfb19cb8)
+
+**Authority**: Cloudflare official docs + Railway support / community.
+**Relevant to**: Operational diagnosis of why a deploy can be "up" in CI but "000" externally.
+
+**Key information**:
+
+- A Cloudflare 522 means CF could not establish a TCP connection to origin within ~19s — usually because the origin process crashed, the host is overloaded, or a firewall is dropping CF IPs.
+- A 524 means CF connected but origin took >100s to respond — consistent with a slow/hanging lifespan on a fresh container.
+- If the probe is going through a stack like `domain → Cloudflare → Railway → container` and any link is broken, curl on the prober side reports `000` (because CF returns 522/524, the prober may also timeout before any HTTP response).
+- Railway-specific common cause: shell-form CMD vs exec-form CMD around `${PORT}`. Reli's `Dockerfile:56` uses exec form with hardcoded `--port 8000` — that's fine on Railway only if the service is configured for static port 8000 (which Reli is, via `127.0.0.1:8000:8000` mapping in compose) but Railway typically expects `$PORT`.
+- The Railway-side health probe path is `/healthz`. The Dockerfile `HEALTHCHECK` (line 52) also probes `/healthz` every 30s. If the lifespan never reaches `yield`, both fail and the container is killed/restarted.
+
+---
+
+### 6. Recent context: 20+ recent commits are RAILWAY_TOKEN rotation investigations
+
+**Source**: `git log --oneline -20` on the worktree's `main`.
+**Authority**: Direct repo state.
+**Relevant to**: Whether a deploy has even happened recently.
+
+**Key information**:
+
+- The 20 most recent merged PRs (`#806` through `#838`) are all `docs: investigation for issue #N (Nth RAILWAY_TOKEN expiration)` commits.
+- Per `CLAUDE.md` ("Railway Token Rotation"), agents cannot rotate the token; only the human can do it via railway.com.
+- If `RAILWAY_TOKEN` is currently expired, the staging-pipeline workflow (`.github/workflows/staging-pipeline.yml:32-58`) fails at the validation step and never deploys a new image.
+- Therefore: even if a code-level fix to the MCP lifespan is correct, **production won't pick it up until a human rotates the Railway token**. The runbook is at `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+---
+
+## Code Examples
+
+### Recommended replacement for `backend/main.py:108-130` (from upstream MCP SDK guidance)
+
+From the pattern documented in [modelcontextprotocol/python-sdk #713](https://github.com/modelcontextprotocol/python-sdk/issues/713) and confirmed by [FastMCP integration docs](https://gofastmcp.com/integrations/fastapi):
+
+```python
+# Replace the _has_started / _run_lock reset hack with AsyncExitStack.
+# This is the supported way to compose the MCP server's lifespan with FastAPI's.
+from contextlib import AsyncExitStack
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    init_tracing()
+
+    # ... (alembic migrations, scheduler start — unchanged) ...
+    await start_scheduler()
+
+    from .mcp_server import mcp as _mcp_server
+
+    async with AsyncExitStack() as stack:
+        client = await stack.enter_async_context(httpx.AsyncClient(timeout=15.0))
+        app.state.httpx_client = client
+
+        # Only enter the MCP session manager once per process.
+        # In production each worker is a fresh process so the SDK's one-shot
+        # constraint is not an issue. Tests that reuse the module-level `mcp`
+        # singleton should create a fresh FastMCP instance per test instead.
+        await stack.enter_async_context(_mcp_server.session_manager.run())
+
+        yield
+
+    await stop_scheduler()
+    shutdown_tracing()
+```
+
+Key differences from current code:
+
+1. **No private attribute access** (`_session_manager`, `_has_started`, `_run_lock`) — uses only the public `session_manager` property and `run()` async context manager.
+2. `AsyncExitStack` ensures all entered contexts (httpx client, MCP session) are torn down in reverse order on shutdown, including on the error path.
+3. Removes the implicit reuse of one MCP instance across multiple lifespan starts — that workaround belongs in the test fixture, not in production code.
+
+---
+
+## Gaps and Conflicts
+
+- **No definitive root cause of `HTTP 000000`**: the issue body gives only the curl status, not the curl exit code, not Railway logs, not Cloudflare analytics. We can list candidates but cannot pin one down without operator-side data. Recommend the implementation step include "fetch latest Railway deploy log and most recent Cloudflare error class for the domain" before changing code.
+- **Disagreement between SDKs**: `jlowin/fastmcp` (v2) exposes `.lifespan` directly (`FastAPI(lifespan=mcp_app.lifespan)`), while upstream `mcp.server.fastmcp` requires manual `session_manager.run()` plumbing. The Reli codebase uses upstream — third-party FastMCP docs are *informative* but not directly applicable. `AsyncExitStack` is portable across both.
+- **`session_manager` property visibility**: documented in upstream SDK as a property since the fix in `python-sdk` PR for issue #480-equivalent. Reli currently uses both `mcp.session_manager` (line 127) and the underscore-prefixed `_session_manager` (line 115) — these refer to the same object but the underscore form is private. Worth confirming the SDK version in `backend/requirements.txt` exposes `session_manager` as a property in the version Reli pins.
+- **No data on whether the current production is actually crash-looping vs. simply not deployed**. If `RAILWAY_TOKEN` has been expired across most of the recent commit history, production may be running an *old* image that doesn't even have the MCP code at all. Verify Railway's "currently active deployment" SHA before assuming the bug is in the latest code.
+
+---
+
+## Recommendations
+
+1. **Diagnose before changing code.** Pull the Railway deployment log for the active production image and check (a) the current deployed image SHA vs. `main` HEAD, (b) whether the container reached `Application startup complete.` in uvicorn, (c) whether the Docker `HEALTHCHECK` is passing. Without this you may "fix" code that the prod environment doesn't even run yet.
+2. **Confirm `RAILWAY_TOKEN` validity first.** If it's expired (likely, given the recent commit history), no fix can ship to production until a human rotates it via the runbook in `docs/RAILWAY_TOKEN_ROTATION_742.md`. File a fresh GitHub issue tagged for the human if so — do not create a fake rotation doc (per `CLAUDE.md`).
+3. **Replace the private-attribute reset with `AsyncExitStack`.** The existing `sm._has_started = False; sm._run_lock = anyio.Lock()` workaround is incorrect for production: it papers over a test-fixture concern, leaves a race window unprotected, and breaks on SDK upgrades. The supported pattern is one entry through `await stack.enter_async_context(mcp.session_manager.run())` from the parent lifespan.
+4. **Add `RELI_BASE_URL=https://reli.interstellarai.net` to the production environment** so MCP's DNS-rebinding-protection allows the production host. Document this in `RAILWAY_SECRETS.md` or `DEPLOYMENT_SECRETS.md` so the env var is set on Railway, not just in compose.
+5. **Tighten the Docker `HEALTHCHECK`** to give the lifespan more startup time. The current `--start-period=10s` is short — Alembic migrations + scheduler start + MCP `session_manager.run()` can plausibly exceed 10s on cold start, especially if the DB is also cold. `--start-period=60s` is more realistic for this stack.
+6. **Avoid resurrecting bare `mcp.run()` calls** — they conflict with the mounted streamable-HTTP transport and are a documented source of double-init errors per upstream issues #1367 and #1180.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | curl HTTP code 000 (IBM IT15643) | https://www.ibm.com/support/pages/apar/IT15643 | Definition of HTTP `000` from curl |
+| 2 | curl write-out 000 superuser thread | https://a.osmarks.net/content/superuser.com_en_all_2020-04/A/question/501690.html | Common causes for `000` |
+| 3 | MCP SDK #713 — multi streamable HTTP lifespan | https://github.com/modelcontextprotocol/python-sdk/issues/713 | `AsyncExitStack` pattern for combining lifespans |
+| 4 | MCP SDK #1367 — mounting streamable on FastAPI | https://github.com/modelcontextprotocol/python-sdk/issues/1367 | Sub-app lifespan does not propagate; need parent lifespan |
+| 5 | MCP SDK #1180 — FastMCP + streamable HTTP session management | https://github.com/modelcontextprotocol/python-sdk/issues/1180 | Session manager initialisation issues |
+| 6 | MCP SDK #2150 — sessions not terminated on shutdown | https://github.com/modelcontextprotocol/python-sdk/issues/2150 | Shutdown hang behaviour |
+| 7 | LiteLLM #13651 — `run() can only be called once per instance` | https://github.com/BerriAI/litellm/issues/13651 | Confirms one-shot constraint and race |
+| 8 | LiteLLM PR #13666 — fix for above | https://github.com/BerriAI/litellm/pull/13666 | Reference fix approach |
+| 9 | jlowin/fastmcp #480 — session_manager as property | https://github.com/jlowin/fastmcp/issues/480 | Public API for session_manager |
+| 10 | jlowin/fastmcp #1026 — custom lifespan to http_app | https://github.com/jlowin/fastmcp/issues/1026 | Lifespan composition |
+| 11 | FastMCP docs — FastAPI integration | https://gofastmcp.com/integrations/fastapi | Recommended FastAPI integration patterns |
+| 12 | FastMCP docs — HTTP Deployment | https://gofastmcp.com/deployment/http | Streamable HTTP deployment guidance |
+| 13 | FastAPI docs — Lifespan Events | https://fastapi.tiangolo.com/advanced/events/ | Lifespan async context manager contract |
+| 14 | Cloudflare Error 522 docs | https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/ | Origin-unreachable behaviour |
+| 15 | Cloudflare Error 524 docs | https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524/ | Origin-slow-response behaviour |
+| 16 | Railway health-check failed thread | https://station.railway.com/questions/health-check-failed-cd123ec3 | Railway-specific deploy debugging |
+| 17 | Railway PORT/CMD debugging post (Le, Medium) | https://medium.com/@tomhag_17/debugging-a-railway-deployment-my-journey-through-port-variables-and-configuration-conflicts-eb49cfb19cb8 | `$PORT` and shell-form CMD pitfalls |
+| 18 | mcp PyPI page | https://pypi.org/project/mcp/1.9.1/ | Confirms upstream SDK API |


### PR DESCRIPTION
## Summary

Investigation-only artifact for **issue #758** ("Deploy down: https://reli.interstellarai.net returning HTTP 000000"). The original symptom (`HTTP 000000` observed 2026-04-28 03:00:32 UTC) has cleared — production is currently HTTP 200 on `/`, `/healthz`, and `/api/health` as of 2026-05-01 08:30 UTC. The recurring CI failure is the **33rd `RAILWAY_TOKEN` expiration**, already tracked under issue **#836** (and adjacent #833). Per `CLAUDE.md > Railway Token Rotation`, agents cannot rotate the Railway token; the only fix is a human action against railway.com.

This PR follows the established docs-only investigation pattern (cf. PRs #837, #838) and recommends closing #758 as a duplicate of #836 to stop the `archon:in-progress` requeue loop.

- **Symptom at filing (2026-04-28):** transient `HTTP 000000` from public probe.
- **Current state (2026-05-01):** production HTTP 200; CI red at `Validate Railway secrets` (`staging-pipeline.yml:55`) with `RAILWAY_TOKEN is invalid or expired: Not Authorized` (run `25207459124`).
- **Active tracking issue:** #836 (with adjacent #833).
- **Supersedes:** the 2026-04-29 comment on #758 that incorrectly attributed the cause to an MCP `lifespan` hang in `backend/main.py` — the current healthy state is inconsistent with that hypothesis.

## Changes

Single new commit on top of `main`:

- `15f1ee9 docs: investigation for issue #758 (deploy-down stale duplicate of #836)`

Files:

```
artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md  | 222 +++++++++
artifacts/runs/a5e81891df69badbc37d19cacc1c057a/validation.md     | 104 +++++
artifacts/runs/a5e81891df69badbc37d19cacc1c057a/web-research.md   | 241 ++++++++++
3 files changed, 564 insertions(+)
```

No source, workflow, config, runbook, or test files modified. Specifically **not** edited:

- `backend/main.py` — the prior comment's MCP-lifespan hang hypothesis is not supported by the current HTTP 200 state.
- `docker-compose.yml` — no `RELI_BASE_URL` change (out of scope; only relevant to MCP `/mcp/*` paths, not `/healthz`).
- `.github/workflows/staging-pipeline.yml` — the validator is correct; it is the **detector**, not the defect.
- `docs/RAILWAY_TOKEN_ROTATION_742.md` — runbook updates (e.g., "No workspace" structural recommendation) belong in #836's follow-up beads.
- No `.github/RAILWAY_TOKEN_ROTATION_758.md` receipt was created — that would be a Category 1 error per `CLAUDE.md`.

## Required human action (out-of-tree)

These steps are documented in `artifacts/runs/a5e81891df69badbc37d19cacc1c057a/investigation.md` and the existing runbook at `docs/RAILWAY_TOKEN_ROTATION_742.md`. They cannot be performed by an agent.

1. Sign in at https://railway.com/account/tokens.
2. Create a new account-level token:
   - Name: `gh-actions-deploy-<YYYYMMDD>`
   - **Workspace: `No workspace`** (critical — suspected primary driver of the recurring expiration cycle).
   - **Expiration: `No expiration`**.
3. Update the secret:
   ```bash
   gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
   # Paste the new token when prompted
   ```
4. Re-run the most recent failed deploy:
   ```bash
   gh run rerun 25207459124 --repo alexsiri7/reli --failed
   ```
5. Close issue #758 as duplicate of #836 to stop the requeue loop:
   ```bash
   gh issue close 758 --repo alexsiri7/reli --reason "not planned" \
     --comment "Symptom (HTTP 000000) has cleared; production is HTTP 200 as of 2026-05-01. Underlying recurring driver tracked under #836."
   ```

## Validation

Standard validation suite (type-check, lint, format, tests, build) **does not apply** — this PR adds only markdown artifacts under `artifacts/runs/`, outside every npm/Vitest/ESLint glob and the backend `pytest` scope.

| Check | Result | Notes |
|-------|--------|-------|
| Type check | N/A | No `.ts`/`.tsx`/`.py` changes |
| Lint | N/A | No source files in lint scope changed |
| Format | N/A | No source files changed; no `format:check` script |
| Tests | N/A | No test files or runtime behavior changed |
| Build | N/A | No build inputs changed |
| Markdown well-formed | OK | Headers, tables, fenced code blocks all close |

### Manual verification

- `curl -sf https://reli.interstellarai.net/healthz` → `HTTP 200 {"status":"ok","service":"reli"}` (live probe at investigation time).
- `gh run view 25207459124 --repo alexsiri7/reli --log-failed | grep -i "railway_token"` → `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`.
- `git grep -n "RAILWAY_TOKEN" -- .github docs` → only references in workflow/runbook; no plaintext token.

### Post-rotation (by human)

1. `Validate Railway secrets` step in `Deploy to staging` exits 0.
2. Subsequent `Deploy staging image to Railway` and `Wait for staging health` succeed.
3. `Deploy to production` runs (no longer skipped); `${RAILWAY_PRODUCTION_URL}/healthz` returns `{"status":"ok"}`.
4. Issue #758 closes with no further `archon:in-progress` requeue comments within ~3 hours.

## Scope

**In scope:** investigation artifact for #758, evidence chain confirming current HTTP 200 state, pointer to active tracking issue #836, web-research notes on the MCP lifespan / curl 000 / Cloudflare-Railway path.

**Out of scope (intentionally not touched):** rotating the Railway secret (human-only — `CLAUDE.md`), modifying `backend/main.py` (the prior MCP-lifespan hypothesis is not supported by current state), updating the runbook to require "No workspace" (durable structural fix — separate bead under #836), `.github/workflows/staging-pipeline.yml` changes, closing the issue itself via API (close action belongs to the human as part of the duplicate determination).

Part of #758 — investigation only; close as duplicate of #836 by human after token rotation (see "Required human action" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
