### PR TITLE
docs: investigation for issue #833 (32nd RAILWAY_TOKEN expiration, 3rd pickup)

### DIFF
--- a/artifacts/runs/75416085b60b3c092951f0974961cd53/investigation.md
+++ b/artifacts/runs/75416085b60b3c092951f0974961cd53/investigation.md
@@ -1,0 +1,179 @@
+# Investigation: Prod deploy failed on main (33rd `RAILWAY_TOKEN` expiration, 3rd pickup of #833)
+
+**Issue**: #833 (https://github.com/alexsiri7/reli/issues/833)
+**Type**: BUG
+**Investigated**: 2026-05-01T09:10:00Z
+**Workflow**: `75416085b60b3c092951f0974961cd53`
+
+## Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Production auto-deploy on every push to `main` is still broken at `Validate Railway secrets`. The latest failing run `25208240731` (08:34Z on SHA `76b58f5`, the merge of PR #839 for sibling-of-sibling #758) confirms the secret has *still* not been rotated since the original incident at 03:35Z. `Deploy to production` is `skipped` on every merge. HIGH (not CRITICAL) because a documented human-only rotation workaround exists. |
+| Complexity | LOW | Single human action — rotate the `RAILWAY_TOKEN` GitHub Actions secret per `docs/RAILWAY_TOKEN_ROTATION_742.md`. No code, workflow, or config edit. Agents are forbidden from rotating per `CLAUDE.md > Railway Token Rotation`. |
+| Confidence | HIGH | Original run `25201008471` and every subsequent run on `main` (`25202385518`, `25202388806`, `25203795132`, `25207459124`, `25208240731`) emit the validator's exact diagnostic — `RAILWAY_TOKEN is invalid or expired: Not Authorized` at `.github/workflows/staging-pipeline.yml:55`. 33rd identical-shape recurrence; 3rd archon pickup of this specific issue. |
+
+---
+
+## Problem Statement
+
+The `RAILWAY_TOKEN` GitHub Actions secret is still expired. The `Validate Railway secrets` pre-flight in `.github/workflows/staging-pipeline.yml:32-58` issues `Authorization: Bearer $RAILWAY_TOKEN` against Railway's `{me{id}}` GraphQL probe, receives `Not Authorized`, exits 1, and `Deploy to production` is skipped.
+
+This is the **3rd archon pickup** of #833 specifically. Issue #833's first investigation merged as PR #834 at 04:30Z; archon's pickup cron then re-fired the issue at 06:30Z stating "no live run and no linked PR were found", producing a second investigation in workflow `09146632082d189318409846f65d7fd6` (no new PR). The cron has now re-fired #833 a third time at 09:00Z with the same observation. Sibling issue **#836** (33rd recurrence on next-day SHA `392291c`) is also open and traces to the same secret. Sibling **#832** (32nd recurrence, staging-side framing on the same original run) is already CLOSED.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+**Process / human-action defect, not a code defect.** The workflow is failing closed exactly as designed (`.github/workflows/staging-pipeline.yml:32-58`); editing it to mask the failure would itself be a defect. Per `CLAUDE.md > Railway Token Rotation`:
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+The structural recurrence is now well-characterized in the companion `web-research.md` for this run: the validator at line 49–58 uses `Authorization: Bearer` against `{me{id}}`, which is **account-token semantics** — project tokens have no `me` user and workspace-scoped account tokens also return `data.me = null`. Both failure modes surface the same misleading "invalid or expired" string. The rotator must produce an **account-scoped token with no workspace selected**.
+
+### Evidence Chain
+
+```
+WHY: Run 25208240731 (latest, 08:34Z on SHA 76b58f5) failed.
+↓ BECAUSE: Deploy to staging → Validate Railway secrets exited 1.
+  Evidence: ##[error]Process completed with exit code 1.
+
+↓ BECAUSE: Railway GraphQL {me{id}} returned no data.me.id.
+  Evidence: ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized
+
+↓ ROOT CAUSE (immediate): RAILWAY_TOKEN GitHub Actions secret has
+  expired/been revoked and has not been rotated since the original
+  03:35Z incident on SHA d01d31c (run 25201008471).
+  Evidence: .github/workflows/staging-pipeline.yml:49-58 — validator
+  issues Authorization: Bearer $RAILWAY_TOKEN against {me{id}} and
+  exits 1 on missing data.me.id.
+
+↓ ROOT CAUSE (structural, recurring): the validator only passes for
+  account-scoped (workspace-blank) Railway tokens. Project tokens and
+  workspace-scoped tokens both produce data.me = null and the same
+  "Not Authorized" message — making rotation mistakes invisible
+  until CI runs again. See web-research.md § Findings 1-2.
+```
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/75416085b60b3c092951f0974961cd53/investigation.md` | NEW | CREATE | This investigation artifact (3rd-pickup re-confirmation + latest-run evidence + pointer to existing PR #834 and #837/#838 lineage). |
+| `artifacts/runs/75416085b60b3c092951f0974961cd53/web-research.md` | (already in canonical workspace) | CARRY-FORWARD | Pre-existing web-research artifact authored earlier in this run that documents the account-vs-project-vs-workspace token failure-mode taxonomy and the pre-save verification curl. |
+
+**Deliberately not changed** (per `CLAUDE.md`):
+- `.github/workflows/staging-pipeline.yml` — failing closed correctly; editing would mask the real defect.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook remains correct.
+- **No `.github/RAILWAY_TOKEN_ROTATION_833.md` will be created** — Category 1 error.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step using `{me{id}}` probe.
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` (`serviceInstanceUpdate` + `serviceInstanceDeploy` mutations), would also fail without rotation.
+- `.github/workflows/railway-token-health.yml` — independent health-check workflow the operator can use to verify the new secret before re-running deploys.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical rotation runbook referenced from `CLAUDE.md`.
+
+### Git History
+
+- **Original failing run cited by #833**: `25201008471` at 2026-05-01T03:35:29Z on SHA `d01d31c`.
+- **Latest failing run** (still red): `25208240731` at 2026-05-01T08:34:57Z on SHA `76b58f5` (the merge commit of PR #839 for sibling-of-sibling #758).
+- **All intervening main runs failed identically**: `25202385518`/`25202388806` (`3db8f1b`, merge of PR #834 — this issue's first investigation); `25203795132` (`392291c`, merge of PR #837 — first investigation for sibling #836); `25207459124` (`ee9d0fb`, merge of PR #838 — second pickup of #836). Six consecutive red runs on `main` since the original incident, all matching the validator's `Not Authorized` shape.
+- **Pickup lineage for #833**: 1st pickup → PR #834 (merged 04:30Z); 2nd pickup → workflow `09146632082d189318409846f65d7fd6` at 06:30Z, no new PR; 3rd pickup (this) → workflow `75416085b60b3c092951f0974961cd53` at 09:00Z.
+- **Sibling issues**: #832 (32nd recurrence, closed); #836 (33rd recurrence, open). One rotation resolves all three.
+
+---
+
+## Implementation Plan (HUMAN-ONLY)
+
+| Step | Where | Action |
+|------|-------|--------|
+| 1 | https://railway.com/account/tokens | Create a new **account-scoped** token. **Leave the workspace selector blank** (do not pick a default workspace). Select **"No expiration"** if available. Project and workspace-scoped tokens both fail the `{me{id}}` validator immediately — see `web-research.md` § Findings 1-2 in this run dir. |
+| 2 | Local terminal (pre-save check) | Verify the new token *before* storing it: `curl -sf -X POST https://backboard.railway.app/graphql/v2 -H "Authorization: Bearer <NEW_TOKEN>" -H "Content-Type: application/json" -d '{"query":"{me{id}}"}' \| jq '.data.me.id'`. Output must be a non-null string. Anything else (null, errors) means wrong class/scope — discard and recreate. |
+| 3 | Local terminal | `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the verified token. |
+| 4 | Local terminal | `gh run rerun 25208240731 --repo alexsiri7/reli --failed` (use the *latest* failing run; older runs may be locked). If rejected, push a no-op commit to `main`. |
+| 5 | GitHub | Close **#833**, **#836**, and confirm **#832** stays closed once `Validate Railway secrets` passes and `Deploy to production` reaches Railway. |
+
+> ⚠️ **Do NOT create `.github/RAILWAY_TOKEN_ROTATION_833.md`** — that is a Category 1 error per `CLAUDE.md`.
+>
+> ⚠️ **Do NOT pick a project or workspace token** — both fail the existing `{me{id}}` validator immediately and produce the same misleading "invalid or expired" message.
+
+---
+
+## Patterns to Follow
+
+The validator that gates this deploy is unchanged from prior recurrences and remains the contract a fresh token must satisfy:
+
+```bash
+# .github/workflows/staging-pipeline.yml:49-58
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
+  exit 1
+fi
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Rotator selects a project token (intuitive given the env-var name `RAILWAY_TOKEN`) | Pre-save verification curl in Step 2 surfaces the mistake before the secret is stored. |
+| Rotator selects a workspace-scoped account token (Railway UI may pre-select a default workspace) | Step 1 explicitly directs the rotator to leave the workspace selector blank; pre-save curl catches it if missed. |
+| Run `25208240731` is too old to rerun by the time the rotator acts | Step 4 fallback: push a no-op commit to `main`, which triggers a fresh `staging-pipeline.yml` run on the new HEAD. |
+| Archon re-fires #833 a fourth time before the human rotates | Expected per the pickup-cron heuristic ("no live run + no linked PR"). The fourth pickup will reach the same conclusion; this artifact already documents it. The structural fix to break this loop is mailed-to-mayor and out-of-scope. |
+| Sibling #836 re-fires concurrently | Resolution is identical (one rotation closes both). Step 5 prompts the human to close them together. |
+
+---
+
+## Validation
+
+### Automated Checks (post-rotation)
+
+```bash
+gh run rerun 25208240731 --repo alexsiri7/reli --failed
+gh run watch --repo alexsiri7/reli
+gh secret list --repo alexsiri7/reli | grep RAILWAY_TOKEN
+```
+
+Expected: `Validate Railway secrets` passes → `Deploy staging image to Railway` reaches Railway → `Wait for staging health` returns ok → `Deploy to production` proceeds → `/healthz` on `RAILWAY_PRODUCTION_URL` returns `{"status":"ok"}` → `railway-token-health.yml` goes green.
+
+### This Re-Fire's Validation (pre-rotation)
+
+N/A across type-check, lint, tests, build — the diff is docs-only (one new investigation artifact in this run's directory). The rotation that would unblock CI is human-only and cannot be performed by this agent.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Authoring this 3rd-pickup investigation artifact at the canonical workflow path.
+- Pointing the human at the existing runbook and the verified, workspace-blank rotation procedure.
+
+**OUT OF SCOPE (do not touch):**
+- The actual `RAILWAY_TOKEN` rotation (human-only per `CLAUDE.md`).
+- `.github/workflows/staging-pipeline.yml` (failing closed correctly).
+- A `.github/RAILWAY_TOKEN_ROTATION_833.md` rotation receipt (Category 1 error).
+- The structural fix (validator that distinguishes wrong-class vs expired tokens, env-var rename, scheduled secret-validation cron, GitHub OIDC federation) — already mailed to mayor in prior cycles; do **not** re-mail.
+- Migration off Railway (tracked separately in #629).
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7)
+- **Timestamp**: 2026-05-01T09:10:00Z
+- **Workflow**: `75416085b60b3c092951f0974961cd53` (3rd pickup of #833)
+- **Predecessor PRs**: #834 (1st pickup of #833, merged), #837 / #838 (sibling #836 1st & 2nd pickups, merged)
+- **Companion artifact**: `artifacts/runs/75416085b60b3c092951f0974961cd53/web-research.md`
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/75416085b60b3c092951f0974961cd53/investigation.md`

--- a/artifacts/runs/75416085b60b3c092951f0974961cd53/web-research.md
+++ b/artifacts/runs/75416085b60b3c092951f0974961cd53/web-research.md
@@ -1,0 +1,225 @@
+# Web Research: fix #833
+
+**Researched**: 2026-05-01T09:05:00Z
+**Workflow ID**: 75416085b60b3c092951f0974961cd53
+**Issue**: [#833 — Prod deploy failed on main](https://github.com/alexsiri7/reli/issues/833)
+**Failing run**: https://github.com/alexsiri7/reli/actions/runs/25201008471
+**Failing step**: `Validate Railway secrets` → `RAILWAY_TOKEN is invalid or expired: Not Authorized`
+**Recurrence**: 33rd identical-shape cycle (this is the 3rd archon re-fire on #833 after PR #834 merged)
+
+---
+
+## Summary
+
+This is the 33rd `RAILWAY_TOKEN is invalid or expired: Not Authorized` recurrence and the third re-fire on the same issue. Per `CLAUDE.md > Railway Token Rotation`, agents cannot rotate the secret — only a human with railway.com dashboard access can. Research surfaces four points the human rotator should act on: (1) **the validator at `.github/workflows/staging-pipeline.yml:49-58` uses `Authorization: Bearer` against `{me{id}}`, which is account-token semantics — a project token cannot pass it** (project tokens have no `me` user); (2) account tokens created with a *workspace selected* become workspace-scoped and **also fail `{me{id}}`** even when freshly minted, producing the same misleading "invalid or expired" message; (3) Railway's recent (Jan 26–29 2026) public incident was about GitHub OAuth installation tokens, not `RAILWAY_TOKEN` — unrelated to this recurrence; (4) Railway still does not support GitHub OIDC federation, so static-token rotation remains the only viable CI auth path until that changes.
+
+---
+
+## Findings
+
+### 1. The validator is account-token-shaped — project tokens cannot pass it
+
+**Source**: Repo file `.github/workflows/staging-pipeline.yml:49-58` (read 2026-05-01)
+**Authority**: Authoritative — this is the actual code that fails
+**Relevant to**: Disambiguating which Railway token class the rotator must produce
+
+**Key Information**:
+
+```yaml
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  ...
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  exit 1
+fi
+```
+
+The validator (and the subsequent `serviceInstanceUpdate` mutation at lines 70–78) uses:
+- Header: `Authorization: Bearer $RAILWAY_TOKEN`
+- Query: `{me{id}}` against `https://backboard.railway.app/graphql/v2`
+
+`{me{id}}` resolves a *user* identity. Project tokens have no associated user — they identify a project, and Railway exposes them via the `Project-Access-Token: <token>` header per the [Railway Public API docs](https://docs.railway.com/integrations/api). Pushing a project token through this validator returns `data.me = null`, which the validator surfaces as `RAILWAY_TOKEN is invalid or expired: Not Authorized` — the same string emitted on a genuinely expired account token. **The validator can only pass with an account token (non-workspace-scoped — see Finding 2).**
+
+The repo runbook [`docs/RAILWAY_TOKEN_ROTATION_742.md`](https://github.com/alexsiri7/reli/blob/main/docs/RAILWAY_TOKEN_ROTATION_742.md) is consistent with this — it directs the rotator to `https://railway.com/account/tokens` (the account/personal token page).
+
+---
+
+### 2. Workspace-scoped account tokens also fail `{me{id}}` — likely root cause of recurrences
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20) and search-result excerpt from the same thread
+**Authority**: Railway-staffed community help; corroborated by multiple user reports
+**Relevant to**: Why a freshly rotated account token can still fail validation immediately — the missing piece in prior cycles
+
+**Key Information** (paraphrased from search-result excerpt of the thread, since the WebFetch summary truncated this detail):
+
+> "When creating the token in the accounts page, if you weren't leaving the workspace blank and were setting it to your default workspace, it makes a workspace-scoped token. To create an account-scoped token, you have to create one in the accounts page, but leave the workspace blank."
+
+**Why this matters for #833**: Railway's UI at `https://railway.com/account/tokens` may pre-select a default workspace. Tokens created with a workspace selected resolve to workspace identity, not user identity, and the GraphQL `{me{id}}` query returns null for them — producing the exact "invalid or expired" failure mode we keep seeing, *even when the rotator just created the token*. After 33 recurrences with the same shape, this is a credible explanation: prior rotators may have left the workspace selector at its default value, producing workspace-scoped tokens that the validator silently treats as expired.
+
+**Action for the rotator**: at the create-token form on https://railway.com/account/tokens, **explicitly clear the workspace field** so the token is account-scoped, *not* workspace-scoped.
+
+---
+
+### 3. Pre-save verification — quote the same probe before storing
+
+**Source**: Synthesis of Findings 1 and 2 plus general API-key rotation hygiene from prior research's [securebin.ai rotation guide](https://securebin.ai/blog/api-key-rotation-best-practices/)
+**Authority**: Combination of the workflow's own contract + standard pre-flight pattern
+**Relevant to**: Eliminating the round-trip cost of "rotate → push → re-run CI → discover wrong token type"
+
+**Key Information**:
+
+Before running `gh secret set RAILWAY_TOKEN`, the rotator can verify in one curl that the new token will pass the workflow's exact validator:
+
+```bash
+curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer <NEW_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}' | jq '.data.me.id'
+```
+
+- Output is a non-null string → token is account-scoped (good, store it).
+- Output is `null` or the response carries an `errors` array → token is project-scoped, workspace-scoped, or expired (bad, do not store).
+
+This makes Finding 2's failure mode visible *before* a red CI run forces a 34th cycle.
+
+---
+
+### 4. Railway's January 26–29, 2026 incident is not the cause of this recurrence
+
+**Source**: [Incident Report: January 28-29, 2026 — Railway Blog](https://blog.railway.com/p/incident-report-january-26-2026)
+**Authority**: Railway's own post-mortem
+**Relevant to**: Ruling out a Railway-side outage as the explanation for `Not Authorized` here
+
+**Key Information**:
+
+- Window: January 26–29, 2026 (well before this incident on 2026-05-01).
+- Affected: GitHub login auth, connecting new GitHub repos, deploys from GitHub repos.
+- Root cause: `installationTokenById` dataloader regenerated GitHub OAuth installation tokens per request, exhausting GitHub's 2,000-tokens-per-hour rate limit (~82 new tokens/sec at peak).
+- Resolution: token caching, migration from user-OAuth to installation tokens, manual repo sync.
+
+**Verdict**: this incident is unrelated to `RAILWAY_TOKEN`. It involved GitHub-issued OAuth tokens that Railway uses internally to fetch repo state. `RAILWAY_TOKEN` is a Railway-issued static API token. They share neither lifecycle nor identity surface. Don't conflate.
+
+---
+
+### 5. Railway still does not support GitHub OIDC federation
+
+**Sources**:
+- [Public API | Railway Docs](https://docs.railway.com/integrations/api) — no OIDC mention
+- [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens) — covers OAuth-for-third-party-apps only
+- [Configuring OpenID Connect in cloud providers — GitHub Docs](https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers) — Railway not listed among supported providers
+- 2026 OIDC search results return guides for GCP/AWS/Azure exclusively; no Railway implementations surfaced
+
+**Authority**: Combined Railway and GitHub primary docs
+**Relevant to**: Whether the rotation pain can be eliminated by adopting short-lived federated credentials
+
+**Key Information**:
+
+GitHub Actions OIDC lets a runner exchange its built-in JWT for a short-lived cloud credential per job — no static secret required. For this to work on Railway, Railway must implement an OIDC trust relationship and accept GitHub's JWTs at its API surface. As of this research (2026-05-01), no such surface exists in Railway's docs, blog, or community. Until Railway ships OIDC federation, **the only available levers are reducing rotation frequency (no-expiration tokens) and detecting expiry early (scheduled validation cron)**.
+
+---
+
+### 6. Existing prior research on this exact recurrence is comprehensive — this re-fire's contribution is incremental
+
+**Source**: [`artifacts/runs/09146632082d189318409846f65d7fd6/web-research.md`](https://github.com/alexsiri7/reli/blob/main/artifacts/runs/09146632082d189318409846f65d7fd6/web-research.md) (merged via PR #834)
+**Authority**: Prior archon re-fire on the same issue, already merged to `main`
+**Relevant to**: Avoiding duplicate documentation while still surfacing what changed
+
+**Key Information**:
+
+The prior re-fire's `web-research.md` already documents:
+- Railway's four token types (account/workspace/project/OAuth) and their respective headers
+- Token TTL configuration and the "No expiration" option
+- Lack of GitHub OIDC support on Railway
+- Industry rotation hygiene (dual-secret rotation, scheduled validation, audit logs)
+
+**What this re-fire adds**:
+- Explicit reconciliation of the prior research's *project-token* recommendation against the workflow's actual *account-token-shaped* validator (Finding 1) — these are not contradictory once the validator code is read.
+- The **workspace-scoped account-token failure mode** (Finding 2) — a credible explanation for why even a freshly rotated token can fail the same way.
+- A **pre-save verification curl** the rotator can run before pushing to GitHub secrets (Finding 3).
+- Confirmation that Railway's recent (Jan 2026) incident is not the cause (Finding 4).
+
+---
+
+## Code Examples
+
+### Pre-save token verification (recommended for the rotator)
+
+```bash
+# Run BEFORE `gh secret set RAILWAY_TOKEN` to catch wrong-class / workspace-scoped tokens.
+NEW_TOKEN="<paste_just-created_railway_token>"
+curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $NEW_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}' | jq '.data.me.id // "FAIL — not account-scoped"'
+# Expected: a non-null string (e.g. "abcd1234-...").
+# Anything else means the token will not pass .github/workflows/staging-pipeline.yml validation.
+```
+
+### Existing validator step (excerpt from the failing workflow, for reference)
+
+```bash
+# .github/workflows/staging-pipeline.yml:49-58
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
+  exit 1
+fi
+```
+
+---
+
+## Gaps and Conflicts
+
+- **Apparent conflict between prior research and current finding** — *resolved*. Prior research cited the Railway help thread saying "`RAILWAY_TOKEN` only accepts project tokens." That guidance is *for the Railway CLI*, which expects the env var named `RAILWAY_TOKEN` to be a project token. **Our workflow does not use the Railway CLI** in the failing step — it directly issues a GraphQL POST with `Authorization: Bearer`, which is account-token semantics regardless of what env var name the secret happens to use. Both statements can be true simultaneously.
+- **Workspace-scoping evidence strength**: the workspace-blank claim comes from a community help thread (bytekeim's reply on station.railway.com), not from official Railway docs. It is consistent with both Railway's GraphQL schema and the recurrence pattern, but a primary-source citation would be stronger. Worth confirming during rotation by running the pre-save curl in Finding 3.
+- **No-expiration tokens**: Railway's public docs still do not formally document a hard upper bound on "No expiration" tokens. Whether the recurrence pattern reflects an undocumented cap, repeated workspace-scoping mistakes, or both cannot be determined from public sources.
+- **OIDC roadmap**: no public Railway statement on OIDC federation plans. No change since prior research.
+
+---
+
+## Recommendations
+
+For the human handling this incident (agents must not rotate per `CLAUDE.md`):
+
+1. **At https://railway.com/account/tokens, create a token with**:
+   - Name: descriptive (e.g. `github-actions-2026-05`)
+   - **Expiration**: `No expiration`
+   - **Workspace**: *leave blank* — explicitly clear any default selection so the token is account-scoped, not workspace-scoped. This is the most likely cause of the 33-cycle recurrence.
+2. **Verify the token before storing it**: run the curl in Finding 3 and confirm a non-null `data.me.id` is returned. If the result is `null` or an error, the token is wrong-class (project) or wrong-scope (workspace) — discard and recreate.
+3. **Push to GitHub**: `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli`.
+4. **Re-run the failed pipeline**: `gh run rerun 25201008471 --repo alexsiri7/reli --failed`. If the run is too old to rerun, push a no-op commit to `main`.
+5. **Close issues #832, #833, and #836** once `Validate Railway secrets` passes and `Deploy to production` reaches Railway.
+6. **Do not** create a `.github/RAILWAY_TOKEN_ROTATION_833.md` "completion" file — `CLAUDE.md` flags this as a Category 1 error because the underlying action cannot be performed by agents. The investigation/web-research artifacts under `artifacts/runs/<workflow-id>/` are the correct place for documentation.
+
+Out-of-scope follow-ups (already mailed to mayor in prior cycles, do **not** re-mail):
+- Replace `{me{id}}` validator with a workspace-and-project-tolerant probe so token-class mistakes fail loudly with class-specific guidance.
+- Add a scheduled (e.g. weekly) validation cron that runs only the secrets validator and opens an issue on failure — catches expiry before the next deploy.
+- Open a Railway feature request for GitHub OIDC federation.
+- Migration off Railway tracked separately in [#629](https://github.com/alexsiri7/reli/issues/629).
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Repo workflow file | `.github/workflows/staging-pipeline.yml:49-58` (in repo) | Authoritative — the validator code that defines what counts as a valid token |
+| 2 | Repo runbook | [`docs/RAILWAY_TOKEN_ROTATION_742.md`](https://github.com/alexsiri7/reli/blob/main/docs/RAILWAY_TOKEN_ROTATION_742.md) | Step-by-step rotation procedure tailored to Reli |
+| 3 | Railway Help — RAILWAY_TOKEN invalid or expired | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Workspace-blank requirement for account-scoped tokens; project-vs-account confusion |
+| 4 | Railway Help — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | CI guidance: `RAILWAY_TOKEN` (project) vs `RAILWAY_API_TOKEN` (account/workspace) for the Railway CLI |
+| 5 | Railway Help — RAILWAY_API_TOKEN not being respected | https://station.railway.com/questions/railway-api-token-not-being-respected-364b3135 | `RAILWAY_TOKEN` precedence over `RAILWAY_API_TOKEN` when both set |
+| 6 | Railway Public API docs | https://docs.railway.com/integrations/api | Token classes and required headers (`Authorization: Bearer` vs `Project-Access-Token`) |
+| 7 | Railway Login & Tokens docs | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth-for-third-party-apps (orthogonal to `RAILWAY_TOKEN`) |
+| 8 | Railway blog — Incident Report Jan 28–29 2026 | https://blog.railway.com/p/incident-report-january-26-2026 | Confirms recent incident is unrelated to `RAILWAY_TOKEN` |
+| 9 | GitHub Docs — Configuring OIDC in cloud providers | https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers | Railway not among OIDC-supported providers |
+| 10 | GitHub Docs — OpenID Connect | https://docs.github.com/en/actions/concepts/security/openid-connect | Reference for the OIDC-federation alternative to static tokens |
+| 11 | securebin.ai — API Key Rotation Best Practices | https://securebin.ai/blog/api-key-rotation-best-practices/ | Pre-save verification and dual-secret-rotation patterns |
+| 12 | Prior re-fire web research | `artifacts/runs/09146632082d189318409846f65d7fd6/web-research.md` (merged via [PR #834](https://github.com/alexsiri7/reli/pull/834)) | Background on token classes, TTL, OIDC, rotation hygiene |


### PR DESCRIPTION
## Summary

- Document the 3rd archon pickup of #833 (32nd `RAILWAY_TOKEN` expiration). Pickup cron re-fired #833 at 09:00Z because no live run + no linked open PR were observed since PR #834 (1st-pickup) merged at 04:30Z and the 2nd pickup (workflow `09146632082d189318409846f65d7fd6`) opened no new PR.
- Latest failing run on `main` is `25208240731` (08:34Z on SHA `76b58f5`). Six consecutive red runs since the original 03:35Z incident — token still unrotated.
- Conclusion is unchanged: human-only rotation is the unblocking action per [`CLAUDE.md > Railway Token Rotation`](https://github.com/alexsiri7/reli/blob/main/CLAUDE.md). No code/workflow/config changes; no `.github/RAILWAY_TOKEN_ROTATION_833.md` receipt (Category 1 error).

## What this PR adds

| File | Purpose |
|------|---------|
| `artifacts/runs/75416085b60b3c092951f0974961cd53/investigation.md` | 3rd-pickup investigation: latest-run evidence chain, lineage table, scope boundaries, validation plan. |
| `artifacts/runs/75416085b60b3c092951f0974961cd53/web-research.md` | Carry-forward of the run's web research: account-vs-project-vs-workspace token failure-mode taxonomy, the workspace-blank requirement, pre-save verification curl, OIDC gap. |

The web-research artifact's main *new* contribution over predecessor PR #834 is the **workspace-scoped account-token failure mode** (Finding 2) — a credible explanation for the 33-cycle recurrence pattern even when rotators believed they created a fresh token. Step 1 of the rotation plan now explicitly directs the rotator to leave the workspace selector blank, and Step 2 adds a pre-save verification curl that catches wrong-class/wrong-scope tokens before the secret is stored.

## Why no code change

`CLAUDE.md > Railway Token Rotation`:

> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
> Creating documentation that claims success on an action you cannot perform is a Category 1 error.

The validator at `.github/workflows/staging-pipeline.yml:32-58` is failing closed exactly as designed; editing it to mask the failure would itself be a defect. The structural fix (validator that distinguishes wrong-class vs expired tokens, env-var rename, scheduled cron, OIDC federation) has been mailed to mayor in prior cycles and is intentionally out-of-scope here.

## Sibling issues

- **#832** — same original run (`25201008471`), same SHA (`d01d31c`), staging-side framing. **Closed.**
- **#836** — 33rd recurrence on next-day SHA `392291c`. **Open.** One rotation closes both.

## Test plan

- [x] Investigation artifact written to canonical workflow path and copied into the worktree for commit.
- [x] GitHub comment posted to #833 with the 3rd-pickup framing and pointer to predecessor PRs #834 / #837 / #838.
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` rotation receipt created.
- [x] No edits to `.github/workflows/staging-pipeline.yml` or other production code.
- [ ] **Human action remains pending**: rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (account-scoped, workspace blank, no expiration; pre-save curl verification).
- [ ] **After rotation**: `gh run rerun 25208240731 --repo alexsiri7/reli --failed`; verify `Validate Railway secrets` passes, `Deploy to production` proceeds, `/healthz` returns ok.
- [ ] **After CI green**: close #833 and #836 together.

Part of #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)