### PR TITLE
docs: investigation for issue #841 (34th RAILWAY_TOKEN expiration, prod-deploy framing)

### DIFF
--- a/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md
+++ b/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md
@@ -19,10 +19,10 @@
 
 The `RAILWAY_TOKEN` GitHub Actions secret is still expired/wrong-class. The `Validate Railway secrets` pre-flight in `.github/workflows/staging-pipeline.yml:32-58` issues `Authorization: Bearer $RAILWAY_TOKEN` against Railway's `{me{id}}` GraphQL probe, receives `Not Authorized`, exits 1, and `Deploy to production` is skipped.
 
-This is a **fresh prod-deploy framing** of a defect already tracked by **two open issues**:
+This is a **fresh prod-deploy framing** of a defect previously tracked by sibling issues:
 
-- **#833** — original CI-red framing (32nd recurrence, original SHA `d01d31c`). Three pickups merged: PR #834 (1st), `09146632082d189318409846f65d7fd6` (2nd, no PR), PR #840 (3rd).
-- **#836** — CI-red framing for next-day SHA `392291c` (33rd recurrence). Two pickups merged: PR #837 (1st), PR #838 (2nd).
+- **#833** — original CI-red framing (32nd recurrence, original SHA `d01d31c`). **Closed at 2026-05-01T09:30:10Z** alongside PR #840's merge. Three pickups merged: PR #834 (1st), `09146632082d189318409846f65d7fd6` (2nd, no PR), PR #840 (3rd, closing pickup).
+- **#836** — CI-red framing for next-day SHA `392291c` (33rd recurrence). **Open.** Two pickups merged: PR #837 (1st), PR #838 (2nd).
 - **#832** (closed) — staging-side framing on the same original run.
 
 Issue #841 was filed by `pipeline-health-cron.sh` at 10:00:29Z when the prod-deploy pipeline observed run `25209787350` red on the merge commit of PR #840. The archon pickup cron then re-queued it at 12:00:40Z with the comment *"archon was labeled in-progress 7207s ago but no live run and no linked PR were found"* — making this the **1st pickup of #841** specifically (worktree `task-archon-fix-github-issue-1777636849757`, workflow `8531a0fb983e22588f40e6f43484ee47`).
@@ -75,7 +75,7 @@ WHY: Run 25209787350 (latest, 09:34:51Z on SHA da29247 — the merge of PR #840)
   expired or is the wrong class/scope. It has not been rotated since
   the original 03:35Z incident on SHA d01d31c (run 25200994188 /
   25201008471).
-  Evidence: 8 consecutive failed main runs since 03:35Z on 4 distinct
+  Evidence: 8 consecutive failed main runs since 03:35Z on 6 distinct
             merge SHAs (d01d31c, 3db8f1b, 392291c, ee9d0fb, 76b58f5,
             da29247), all matching the validator's "Not Authorized"
             shape.
@@ -120,10 +120,10 @@ WHY: Run 25209787350 (latest, 09:34:51Z on SHA da29247 — the merge of PR #840)
 - **All intervening main runs failed identically** (8 consecutive reds): `25202385518` & `25202388806` on `3db8f1b` (PR #834 merge); `25203795132` on `392291c` (PR #837 merge); `25207459124` on `ee9d0fb` (PR #838 merge); `25208240731` on `76b58f5` (PR #839 merge); `25209787350` on `da29247` (PR #840 merge).
 - **Sibling-issue lineage**:
   - **#832** — 32nd recurrence, staging-side framing on the same original run. **Closed.**
-  - **#833** — 32nd recurrence, deploy-down framing. **Open.** 3 pickups (PR #834, no-PR pickup, PR #840).
+  - **#833** — 32nd recurrence, deploy-down framing. **Closed at 2026-05-01T09:30:10Z** (alongside PR #840's merge). 3 pickups (PR #834, no-PR pickup, PR #840).
   - **#836** — 33rd recurrence, CI-red on next-day SHA. **Open.** 2 pickups (PR #837, PR #838).
   - **#841** (this) — 34th recurrence, prod-deploy framing on PR #840's merge SHA. **Open, in-progress.** 1st pickup.
-- One rotation closes #833, #836, and #841 simultaneously.
+- One rotation closes **#836** and **#841** simultaneously. (#833 is already closed.)
 
 ---
 
@@ -135,7 +135,7 @@ WHY: Run 25209787350 (latest, 09:34:51Z on SHA da29247 — the merge of PR #840)
 | 2 | Pre-save verification — local terminal | Before storing the token, verify it against the *exact* probe the validator uses: `curl -sf -X POST https://backboard.railway.app/graphql/v2 -H "Authorization: Bearer <NEW_TOKEN>" -H "Content-Type: application/json" -d '{"query":"{me{id}}"}' \| jq '.data.me.id'`. Output **must** be a non-null string. If null/error, the token is the wrong class/scope for this validator — discard and retry. |
 | 3 | Local terminal | `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the verified token. |
 | 4 | Local terminal | `gh run rerun 25209787350 --repo alexsiri7/reli --failed` (use the *latest* failing run; older runs may be locked). If rejected, push a no-op commit to `main` to trigger a fresh `staging-pipeline.yml` run. |
-| 5 | GitHub | Once `Validate Railway secrets` passes, `Deploy staging image to Railway` reaches Railway, `Wait for staging health` returns ok, `Deploy to production` proceeds, and `/healthz` on `RAILWAY_PRODUCTION_URL` returns ok — close **#833**, **#836**, and **#841** together. Re-confirm **#832** stays closed. |
+| 5 | GitHub | Once `Validate Railway secrets` passes, `Deploy staging image to Railway` reaches Railway, `Wait for staging health` returns ok, `Deploy to production` proceeds, and `/healthz` on `RAILWAY_PRODUCTION_URL` returns ok — close **#836** and **#841** together. Re-confirm **#832** and **#833** stay closed. |
 
 > ⚠️ **Do NOT create `.github/RAILWAY_TOKEN_ROTATION_841.md`** — that is a Category 1 error per `CLAUDE.md`.
 >

--- a/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md
+++ b/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md
@@ -1,0 +1,228 @@
+# Investigation: Prod deploy failed on main (#841 — 34th `RAILWAY_TOKEN` expiration cycle, prod-deploy framing)
+
+**Issue**: #841 (https://github.com/alexsiri7/reli/issues/841)
+**Type**: BUG
+**Investigated**: 2026-05-01T12:15:00Z
+**Workflow**: `8531a0fb983e22588f40e6f43484ee47`
+
+## Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Prod auto-deploy on every push to `main` is still broken at `Validate Railway secrets`. The latest failing run `25209787350` (09:34:51Z, SHA `da29247` — the merge commit of PR #840 itself, the 3rd-pickup investigation of #833) confirms the secret has not been rotated since the original 03:35Z incident. `Deploy to production` is `skipped` on every merge. HIGH (not CRITICAL) because a documented human-only rotation workaround exists. |
+| Complexity | LOW | Single human action — rotate the `RAILWAY_TOKEN` GitHub Actions secret per `docs/RAILWAY_TOKEN_ROTATION_742.md`. No code, workflow, or config edit is in scope. Agents are forbidden from rotating per `CLAUDE.md > Railway Token Rotation`. |
+| Confidence | HIGH | Run `25209787350` emits the validator's exact diagnostic — `RAILWAY_TOKEN is invalid or expired: Not Authorized` at `.github/workflows/staging-pipeline.yml:55`. 8 consecutive identical-shape red runs on `main` since 03:35Z (`25200994188`, `25201008471`, `25202385518`, `25202388806`, `25203795132`, `25207459124`, `25208240731`, `25209787350`). Web research for this run (`web-research.md` Findings 1–2) further explains the structural recurrence: `RAILWAY_TOKEN` only accepts a *Project Token* per Railway employee statements. |
+
+---
+
+## Problem Statement
+
+The `RAILWAY_TOKEN` GitHub Actions secret is still expired/wrong-class. The `Validate Railway secrets` pre-flight in `.github/workflows/staging-pipeline.yml:32-58` issues `Authorization: Bearer $RAILWAY_TOKEN` against Railway's `{me{id}}` GraphQL probe, receives `Not Authorized`, exits 1, and `Deploy to production` is skipped.
+
+This is a **fresh prod-deploy framing** of a defect already tracked by **two open issues**:
+
+- **#833** — original CI-red framing (32nd recurrence, original SHA `d01d31c`). Three pickups merged: PR #834 (1st), `09146632082d189318409846f65d7fd6` (2nd, no PR), PR #840 (3rd).
+- **#836** — CI-red framing for next-day SHA `392291c` (33rd recurrence). Two pickups merged: PR #837 (1st), PR #838 (2nd).
+- **#832** (closed) — staging-side framing on the same original run.
+
+Issue #841 was filed by `pipeline-health-cron.sh` at 10:00:29Z when the prod-deploy pipeline observed run `25209787350` red on the merge commit of PR #840. The archon pickup cron then re-queued it at 12:00:40Z with the comment *"archon was labeled in-progress 7207s ago but no live run and no linked PR were found"* — making this the **1st pickup of #841** specifically (worktree `task-archon-fix-github-issue-1777636849757`, workflow `8531a0fb983e22588f40e6f43484ee47`).
+
+---
+
+## Analysis
+
+### First-Principles: Primitive Soundness
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| Secret-validator probe | `.github/workflows/staging-pipeline.yml:49-58` | Partial | Fails closed correctly, but the `{me{id}}` shape only accepts *account/workspace* tokens (returning `data.me.id`); a true *Project Token* uses a different header (`Project-Access-Token`) and would fail this validator even when valid. The diagnostic message ("invalid or expired") collapses three distinct failure modes — true expiration, wrong-class token, wrong-scope token — into one indistinguishable string, which is the proximate enabler of the 34-cycle recurrence. |
+| Token rotation runbook | `docs/RAILWAY_TOKEN_ROTATION_742.md` | Partial | Directs the rotator to `https://railway.com/account/tokens` and asserts a "1-day or 7-day default TTL." Per this run's `web-research.md` Finding 5, no Railway public doc describes a TTL on Project / Account / Workspace tokens — that claim is folklore. Per Findings 1–2, `/account/tokens` produces account or workspace tokens, **not** project tokens; a Railway employee says `RAILWAY_TOKEN` "now only accepts project token." So the runbook may be directing rotators to a URL that produces a token the validator will reject by design. |
+| Issue/pickup taxonomy | n/a (cron behavior) | Partial | Three crons (`pipeline-health-cron.sh` for prod-deploy, the staging-CI-red filer, and archon's pickup cron) each open or re-queue an issue per cycle. One unrotated secret consequently produces 3+ open issues with overlapping causes, and successive-pickup PRs whose merge commits become the SHA on which the *next* failed run is filed (this issue was filed against PR #840's merge SHA). The taxonomy is fixable structurally but is out-of-scope for this bead. |
+
+**Root cause vs symptom.** The symptom (CI red, prod-deploy skipped, multiple open issues) originates from a single unrotated GitHub Actions secret. Every fix path that does not rotate the secret is fixing where the error manifests, not where it originates.
+
+### Root Cause / Change Rationale
+
+**Process / human-action defect, not a code defect.** Per `CLAUDE.md > Railway Token Rotation`:
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+The structural recurrence is now well-characterized in the companion `web-research.md` for this run (15 cited sources, including official Railway docs and Railway-employee statements):
+
+- `RAILWAY_TOKEN` (the env-var name reli's workflow uses) accepts **only Project Tokens**, which are minted at `project settings → Tokens` and use the `Project-Access-Token` HTTP header. Source: Railway Help Station (employee-confirmed).
+- An account/workspace token created at `/account/tokens` will return `Not Authorized` against `RAILWAY_TOKEN` "even if u just made it 2 seconds ago" — same diagnostic as a truly expired token.
+- Railway's *own* GitHub Actions example uses `RAILWAY_API_TOKEN` (account-scoped, workspace blank) with `Authorization: Bearer`.
+- No public Railway documentation describes a TTL on Project / Account / Workspace tokens; the "1-day / 7-day default TTL" guidance in `docs/RAILWAY_TOKEN_ROTATION_742.md` is unverified.
+
+This finding strengthens the explanation for the 34-cycle recurrence: it is plausible that every prior rotation produced a wrong-class or wrong-scope token, which the validator rejected on next CI run with the same misleading "invalid or expired" string. The structural fix is mailed-to-mayor in prior cycles (per PR #840) and is **deliberately not re-mailed** per that PR's guidance.
+
+### Evidence Chain
+
+```
+WHY: Run 25209787350 (latest, 09:34:51Z on SHA da29247 — the merge of PR #840)
+     failed.
+↓ BECAUSE: "Deploy to staging" → "Validate Railway secrets" exited 1.
+  Evidence: gh run view 25209787350 →
+    "X Validate Railway secrets" / "Process completed with exit code 1."
+
+↓ BECAUSE: Railway GraphQL {me{id}} returned no data.me.id.
+  Evidence: "RAILWAY_TOKEN is invalid or expired: Not Authorized"
+            (.github/workflows/staging-pipeline.yml:55 emits this exact string)
+
+↓ ROOT CAUSE (immediate): RAILWAY_TOKEN GitHub Actions secret has
+  expired or is the wrong class/scope. It has not been rotated since
+  the original 03:35Z incident on SHA d01d31c (run 25200994188 /
+  25201008471).
+  Evidence: 8 consecutive failed main runs since 03:35Z on 4 distinct
+            merge SHAs (d01d31c, 3db8f1b, 392291c, ee9d0fb, 76b58f5,
+            da29247), all matching the validator's "Not Authorized"
+            shape.
+
+↓ ROOT CAUSE (structural, recurring 34×): RAILWAY_TOKEN env-var name
+  in .github/workflows/staging-pipeline.yml only authenticates against
+  the {me{id}} probe when the secret is an account- or workspace-
+  scoped token (which uses Authorization: Bearer). Per web-research.md
+  Finding 2, Railway publicly states RAILWAY_TOKEN should only contain
+  a Project Token (Project-Access-Token header). The validator's
+  shape is incompatible with what the env-var name implies — every
+  rotation that uses Railway's UI defaults at the namesake URL
+  (/account/tokens) will fail on next CI run.
+```
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md` | NEW | CREATE | This investigation artifact (1st pickup of #841 — prod-deploy framing of the same #833/#836 root cause). |
+| `artifacts/runs/8531a0fb983e22588f40e6f43484ee47/web-research.md` | (already in canonical workspace) | CARRY-FORWARD | Web research authored earlier in this run that documents the four Railway token types, the `RAILWAY_TOKEN` ↔ Project-Token-only constraint, the workspace-blank account-token gotcha, and the unverified-TTL gap in the runbook. |
+
+**Deliberately not changed** (per `CLAUDE.md`):
+
+- `.github/workflows/staging-pipeline.yml` — failing closed correctly; the validator's *shape* is part of the structural defect, but editing it here would mask the unrotated-secret signal during an active incident.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook is referenced from `CLAUDE.md`. Per scope discipline, runbook corrections (drop the unverified TTL claim; clarify Project vs Account token) are not this bead's concern; the structural findings are recorded here and in `web-research.md` for future reference.
+- **No `.github/RAILWAY_TOKEN_ROTATION_841.md`** will be created — Category 1 error per `CLAUDE.md`.
+- **No re-mail to mayor** — PR #840's test plan explicitly says *"do not re-mail"*; the structural fix is already in mayor's queue.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step using `Authorization: Bearer $RAILWAY_TOKEN` against `{me{id}}` (account/workspace-token shape).
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` (`serviceInstanceUpdate` + `serviceInstanceDeploy` mutations) — also depends on `RAILWAY_TOKEN` and would also fail without rotation.
+- `.github/workflows/railway-token-health.yml` — independent health-check workflow the operator can use to verify a freshly rotated secret before re-running deploys.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical rotation runbook referenced from `CLAUDE.md`. (Note caveats above re: Project vs Account token framing.)
+- `pipeline-health-cron.sh` — the cron that filed #841 against PR #840's merge SHA. Will re-fire on each subsequent failed deploy until `Deploy to production` reaches Railway green.
+
+### Git History
+
+- **Original failing run cited by sibling #833**: `25201008471` at 2026-05-01T03:35:29Z on SHA `d01d31c` (also `25200994188` at 03:34:43Z, same SHA — duplicate trigger).
+- **This issue's failing run**: `25209787350` at 2026-05-01T09:34:51Z on SHA `da29247c1d9e94da19992e43f3f1f029b759016` (the merge commit of PR #840 itself, the 3rd pickup of #833).
+- **All intervening main runs failed identically** (8 consecutive reds): `25202385518` & `25202388806` on `3db8f1b` (PR #834 merge); `25203795132` on `392291c` (PR #837 merge); `25207459124` on `ee9d0fb` (PR #838 merge); `25208240731` on `76b58f5` (PR #839 merge); `25209787350` on `da29247` (PR #840 merge).
+- **Sibling-issue lineage**:
+  - **#832** — 32nd recurrence, staging-side framing on the same original run. **Closed.**
+  - **#833** — 32nd recurrence, deploy-down framing. **Open.** 3 pickups (PR #834, no-PR pickup, PR #840).
+  - **#836** — 33rd recurrence, CI-red on next-day SHA. **Open.** 2 pickups (PR #837, PR #838).
+  - **#841** (this) — 34th recurrence, prod-deploy framing on PR #840's merge SHA. **Open, in-progress.** 1st pickup.
+- One rotation closes #833, #836, and #841 simultaneously.
+
+---
+
+## Implementation Plan (HUMAN-ONLY)
+
+| Step | Where | Action |
+|------|-------|--------|
+| 1 | Read `docs/RAILWAY_TOKEN_ROTATION_742.md` end-to-end. | Note the runbook's URL is `https://railway.com/account/tokens`. **Caveat (this run's web-research.md Finding 2)**: Railway publicly states the env-var name `RAILWAY_TOKEN` only accepts Project Tokens (created at *project settings → Tokens*, not at `/account/tokens`). If the runbook's account-tokens URL is the historical source of the 34-cycle recurrence, the proper rotation is at project settings → Tokens. Until the runbook is corrected (out-of-scope here), the rotator's choice is between (a) following the runbook exactly and risking another rejected token, or (b) creating a Project Token and updating the runbook in a follow-up PR. |
+| 2 | Pre-save verification — local terminal | Before storing the token, verify it against the *exact* probe the validator uses: `curl -sf -X POST https://backboard.railway.app/graphql/v2 -H "Authorization: Bearer <NEW_TOKEN>" -H "Content-Type: application/json" -d '{"query":"{me{id}}"}' \| jq '.data.me.id'`. Output **must** be a non-null string. If null/error, the token is the wrong class/scope for this validator — discard and retry. |
+| 3 | Local terminal | `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the verified token. |
+| 4 | Local terminal | `gh run rerun 25209787350 --repo alexsiri7/reli --failed` (use the *latest* failing run; older runs may be locked). If rejected, push a no-op commit to `main` to trigger a fresh `staging-pipeline.yml` run. |
+| 5 | GitHub | Once `Validate Railway secrets` passes, `Deploy staging image to Railway` reaches Railway, `Wait for staging health` returns ok, `Deploy to production` proceeds, and `/healthz` on `RAILWAY_PRODUCTION_URL` returns ok — close **#833**, **#836**, and **#841** together. Re-confirm **#832** stays closed. |
+
+> ⚠️ **Do NOT create `.github/RAILWAY_TOKEN_ROTATION_841.md`** — that is a Category 1 error per `CLAUDE.md`.
+>
+> ⚠️ **Do NOT pick a workspace-scoped token** — selecting a workspace at `/account/tokens` creates a workspace-scoped token; per Railway employee "brody" (web-research.md Finding 3), workspace-scoped tokens fail many CLI/API operations. Leave the workspace selector blank for an account-scoped token, **or** rotate at project settings → Tokens for a true Project Token (web-research.md Finding 2 — strongly attested but inconsistent with the existing validator's `Authorization: Bearer` + `{me{id}}` shape).
+
+---
+
+## Patterns to Follow
+
+The validator that gates this deploy remains the contract a fresh token must satisfy — verify against it before storing:
+
+```bash
+# .github/workflows/staging-pipeline.yml:49-58
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
+  exit 1
+fi
+```
+
+A token that returns a non-null `data.me.id` against this probe is, by construction, accepted by the validator. Any other response is rejected.
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Rotator follows the runbook literally and creates a token at `/account/tokens` with a workspace selected | Pre-save verification curl in Step 2 surfaces the rejection before the secret is stored. Step 5 re-runs the workflow as final ground truth. |
+| Rotator creates a Project Token (web-research.md Finding 2) and stores it in `RAILWAY_TOKEN` | Pre-save curl will fail because Project Tokens use `Project-Access-Token` header, not `Authorization: Bearer`. The token would also fail the existing validator at runtime. Recommend: account-scoped token with workspace blank for the existing validator's shape, OR a structural change (env-var rename, validator rewrite) tracked separately by the mailed-to-mayor structural fix. |
+| Run `25209787350` is too old to rerun by the time the rotator acts | Step 4 fallback: push a no-op commit to `main` to trigger a fresh `staging-pipeline.yml` run on the new HEAD. |
+| The pickup cron re-fires #841 before the human rotates | Expected per the cron's "no live run + no linked PR" heuristic. The next pickup will reach the same conclusion; this artifact already documents it. |
+| `pipeline-health-cron.sh` files a 35th-cycle issue (e.g., #842) on the merge SHA of *this* PR | Possible if the human has not rotated by the time this PR merges. Resolution is identical: same root cause, same fix. The structural fix to break this loop has been mailed-to-mayor; do not re-mail. |
+| Sibling #833 or #836 re-fires concurrently | Resolution is identical (one rotation closes all three). Step 5 prompts the human to close them together. |
+| Runbook's "1-day/7-day TTL" claim leads the rotator to expect another expiration in days | Per web-research.md Finding 5, no Railway public doc supports a TTL on Project/Account/Workspace tokens. If repeated expirations are real, they are likely caused by scope/type mismatch — addressed by Step 2's pre-save verification, not by setting "No expiration." |
+
+---
+
+## Validation
+
+### Automated Checks (post-rotation)
+
+```bash
+gh run rerun 25209787350 --repo alexsiri7/reli --failed
+gh run watch --repo alexsiri7/reli
+gh secret list --repo alexsiri7/reli | grep RAILWAY_TOKEN
+```
+
+Expected sequence: `Validate Railway secrets` passes → `Deploy staging image to Railway` reaches Railway → `Wait for staging health` returns ok → `Deploy to production` proceeds → `/healthz` on `RAILWAY_PRODUCTION_URL` returns `{"status":"ok"}` → `railway-token-health.yml` (independent health workflow) goes green.
+
+### This Pickup's Validation (pre-rotation)
+
+Diff is docs-only (one new investigation artifact + a copy in the worktree of the existing canonical web-research). N/A across type-check, lint, tests, build. The rotation that would unblock CI is human-only and cannot be performed by this agent.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+
+- Authoring this 1st-pickup investigation artifact for #841 at the canonical workflow path.
+- Posting a GitHub comment on #841 with the assessment, evidence chain, and pointer to `docs/RAILWAY_TOKEN_ROTATION_742.md` plus the web-research.md caveats.
+- Carrying the existing `web-research.md` into the worktree alongside the investigation for the PR.
+- Pointing the human at the existing runbook and the workspace-blank pre-save verification.
+
+**OUT OF SCOPE (do not touch):**
+
+- The actual `RAILWAY_TOKEN` rotation (human-only per `CLAUDE.md`).
+- `.github/workflows/staging-pipeline.yml` (failing closed correctly during an active incident).
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` corrections (drop unverified TTL claim; clarify Project vs Account token semantics) — record findings here for a future bead; do not edit during this pickup.
+- A `.github/RAILWAY_TOKEN_ROTATION_841.md` rotation receipt (Category 1 error).
+- The structural fix (env-var rename to `RAILWAY_API_TOKEN`, validator that distinguishes wrong-class vs expired tokens, scheduled secret-validation cron, GitHub OIDC federation). Already mailed-to-mayor; **do not re-mail** per PR #840.
+- Migration off Railway (tracked separately in #629).
+- Re-mailing mayor or filing additional issues — three are already open for the same root cause.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7, 1M context)
+- **Timestamp**: 2026-05-01T12:15:00Z
+- **Workflow**: `8531a0fb983e22588f40e6f43484ee47` (1st pickup of #841)
+- **Predecessor PRs**: #834 (1st of #833, merged), #837 (1st of #836, merged), #838 (2nd of #836, merged), #839 (#758 stale-dup investigation, merged), #840 (3rd of #833, merged)
+- **Companion artifact**: `artifacts/runs/8531a0fb983e22588f40e6f43484ee47/web-research.md`
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md`

--- a/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/web-research.md
+++ b/artifacts/runs/8531a0fb983e22588f40e6f43484ee47/web-research.md
@@ -1,0 +1,209 @@
+# Web Research: fix #841
+
+**Researched**: 2026-05-01T12:03:50Z
+**Workflow ID**: 8531a0fb983e22588f40e6f43484ee47
+**Issue**: #841 — "Prod deploy failed on main" (Railway staging deploy fails with `RAILWAY_TOKEN is invalid or expired: Not Authorized`)
+
+---
+
+## Summary
+
+Issue #841 is the 34th+ recurrence of a `RAILWAY_TOKEN` "Not Authorized" failure in this repo. Public Railway documentation does **not** describe any TTL for project, account, or workspace tokens — so the existing rotation runbook's claim of a "1-day or 7-day default TTL" is unverified by official sources. The much more strongly attested cause across Railway's own docs and Help Station threads is **token-type / scope mismatch**: `RAILWAY_TOKEN` only accepts a true *Project Token* (created in project settings → Tokens), while a token created at `/account/tokens` is either an account-scoped or workspace-scoped token and the CLI returns "invalid or expired" against it even when freshly minted. For GitHub Actions, Railway's own deploying-with-CLI page now uses `RAILWAY_API_TOKEN` (account-scoped, workspace field left blank) in its examples.
+
+---
+
+## Findings
+
+### 1. Railway has four distinct token types — they are not interchangeable
+
+**Source**: [Public API — Railway Docs](https://docs.railway.com/reference/integrations)
+**Authority**: Official Railway documentation
+**Relevant to**: Root cause investigation; runbook accuracy
+
+**Key Information**:
+
+- **Account Token** — "If you select 'No workspace', the token will be tied to your Railway account." Recommended for "Personal scripts, local development."
+- **Workspace Token** — "Select a specific workspace in the dropdown to create a token scoped to that workspace." Recommended for "Team CI/CD, shared automation."
+- **Project Token** — "can only be used to authenticate requests to that environment." Recommended for "Deployments, service-specific automation."
+- **OAuth tokens** — separate flow.
+- Account/workspace/OAuth tokens use `Authorization: Bearer` header; **project tokens use a different header — `Project-Access-Token`**. This is why a wrongly-typed token fails authorization.
+
+---
+
+### 2. `RAILWAY_TOKEN` ONLY accepts a Project Token (not an account token)
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)
+**Authority**: Railway's official user forum, including a clarification consistently echoed by Railway employees
+**Relevant to**: Likely root cause of the 34× recurring failure
+
+**Key Information**:
+
+- Direct quote: *"RAILWAY_TOKEN now only accepts project token, if u put the normal account token (the one u make in account settings) it literally says 'invalid or expired' even if u just made it 2 seconds ago."*
+- Project tokens are generated at **project settings → Tokens** (not at `https://railway.com/account/tokens`).
+- If both `RAILWAY_TOKEN` and `RAILWAY_API_TOKEN` are set, `RAILWAY_TOKEN` takes priority — a wrong `RAILWAY_TOKEN` will mask a correct `RAILWAY_API_TOKEN`.
+
+---
+
+### 3. Workspace-vs-account-scope gotcha at `/account/tokens`
+
+**Source**: [RAILWAY_API_TOKEN not Working — Railway Help Station](https://station.railway.com/questions/railway-api-token-not-working-2083f58a) (resolved 2026-01-21)
+**Authority**: Railway employee "brody" provided the fix; user confirmed working
+**Relevant to**: A second known cause of "Not Authorized" with a fresh token
+
+**Key Information**:
+
+- Direct quote (brody, Railway): *"For the resources you are trying to use, you would need to use an account-scoped token, not a workspace-scoped token."*
+- Resolution: at `https://railway.com/account/tokens`, leave the **Workspace field blank** to create an account-scoped token. Selecting your workspace silently produces a workspace-scoped token that fails for many CLI/API operations.
+- Issue date: 2026-01-21 — within the last few months, so this gotcha is current.
+
+---
+
+### 4. Railway's own GitHub Actions example uses `RAILWAY_API_TOKEN`, not `RAILWAY_TOKEN`
+
+**Source**: [Deploying with the CLI — Railway Docs](https://docs.railway.com/cli/deploying); [Token for GitHub Action — Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Official Railway docs + Railway employee statement
+**Relevant to**: Whether the reli workflow is using the right env var
+
+**Key Information**:
+
+- Railway's PR-environment example uses `RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}` and notes: *"ensure the token is scoped to your account, not a specific workspace"*.
+- Railway employee on Help Station: *"use a Railway API token scoped to the user account, not a project token, for the GitHub Action."*
+- Project Tokens can perform: `railway up`, `railway redeploy`, `railway logs`. They **cannot** create environments, link projects, or do anything cross-environment — useful guardrail for deploy-only workflows.
+- Project Token compatibility note: an older CLI bug (pre-4.5.0) caused `RAILWAY_API_TOKEN` to be ignored, forcing a fallback to `RAILWAY_TOKEN`. Fixed in CLI 4.5.0+ ([railwayapp/cli#668](https://github.com/railwayapp/cli/pull/668/)).
+
+---
+
+### 5. No documented TTL on Project, Account, or Workspace tokens
+
+**Sources**: [Login & Tokens — Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens); [Public API — Railway Docs](https://docs.railway.com/reference/integrations); [Using GitHub Actions with Railway](https://blog.railway.com/p/github-actions)
+**Authority**: All three are official Railway sources
+**Relevant to**: Validates/invalidates the existing runbook's "default TTL" claim
+
+**Key Information**:
+
+- The Login & Tokens doc only documents expirations for **OAuth** tokens: access tokens expire in 1 hour; refresh tokens have a "fresh one-year lifetime from the time of issuance" and rotate.
+- The Public API page describing Project / Account / Workspace tokens **mentions no TTL or expiration policy** at all.
+- The blog post on GitHub Actions integration likewise does not mention an expiration.
+- **Implication**: The reli runbook's note that "the default TTL may be short (e.g., 1 day or 7 days)" appears to be folklore — there is no public evidence of a user-selectable TTL on these token types, and "No expiration" is not visibly an option in the public docs. If repeated expirations are real, they are likely caused by something other than a TTL the user is forgetting to override (e.g., scope mismatch, workspace deletion/rotation, an undocumented session invalidation).
+
+---
+
+### 6. Open upstream issue: tokens rejected by API directly (not just CLI)
+
+**Source**: [railwayapp/cli#699 — CLI authentication fails with valid API token on Linux](https://github.com/railwayapp/cli/issues/699)
+**Authority**: Railway's own CLI repo; opened 2025-11-21, status open as of last fetch
+**Relevant to**: Indicates Railway has had real auth-side regressions recently
+
+**Key Information**:
+
+- User reproduced failure by hitting `https://backboard.railway.app/graphql/v2` directly with the token; got `{"errors":[{"message":"Not Authorized"…}]}`.
+- Authentication failure is at the **API layer**, not the CLI client.
+- No Railway team response or fix as of last fetch — so users have been seeing legitimate token-rejection bugs upstream during this window.
+
+---
+
+### 7. Community alternative for token rotation automation
+
+**Source**: [0xdps/railway-secrets on GitHub](https://github.com/0xdps/railway-secrets)
+**Authority**: Community project; not official Railway
+**Relevant to**: Long-term mitigation if rotations remain manual
+
+**Key Information**:
+
+- Self-hosted PHP dashboard that "rotate Railway environment variables with AES-256-GCM encryption."
+- Rotation runs via crond inside a container, with per-secret interval logic.
+- Note: this rotates **app environment variables in Railway**, not the auth token itself — so it is partial coverage.
+
+---
+
+### 8. OIDC alternative: not yet available for Railway
+
+**Sources**: [GitHub OpenID Connect docs](https://docs.github.com/en/actions/concepts/security/openid-connect); [Securing CI/CD with OIDC — Amplify Security](https://amplify.security/blog/securing-ci/cd-dont-use-long-lived-api-tokens-use-openid-connect-instead)
+**Authority**: GitHub official + security industry blog
+**Relevant to**: Best-practice north star
+
+**Key Information**:
+
+- The cloud-native pattern is to **drop long-lived tokens entirely**: GitHub Actions presents an OIDC identity, and the cloud provider issues a short-lived token scoped to one job.
+- Railway supports OAuth/OIDC for *Login with Railway* (third-party apps logging in as a Railway user), but no public docs describe a GitHub-Actions ↔ Railway OIDC trust relationship that would replace `RAILWAY_TOKEN`.
+- Conclusion: **OIDC is not a viable workaround today** — the workflow has to keep handling some long-lived secret, but should reduce rotation surface area (correct token type, correct scope).
+
+---
+
+## Code Examples
+
+### Recommended GitHub Actions snippet (from Railway docs, simplified)
+
+```yaml
+# From Railway's official "Deploying with the CLI" page
+# https://docs.railway.com/cli/deploying
+- name: Deploy to Railway
+  env:
+    RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+  run: railway up --service my-service
+```
+
+### How a Project Token differs at the wire level
+
+```http
+# Project Token — uses dedicated header (NOT Authorization: Bearer)
+POST /graphql/v2 HTTP/1.1
+Host: backboard.railway.app
+Project-Access-Token: <project-token>
+
+# Account / Workspace Token — uses standard bearer
+POST /graphql/v2 HTTP/1.1
+Host: backboard.railway.app
+Authorization: Bearer <account-token>
+```
+
+Source: [Public API — Railway Docs](https://docs.railway.com/reference/integrations)
+
+---
+
+## Gaps and Conflicts
+
+- **Gap (significant)**: Railway's public docs do not state any expiration / TTL policy for Project, Account, or Workspace tokens. The reli runbook's "1 day / 7 day default TTL" guidance is not corroborated by any source found and may not reflect the actual UI today.
+- **Gap**: No official docs confirm whether a workspace-scoped token tracks a workspace's billing/admin lifecycle (e.g., gets invalidated when seat counts change, when admins rotate, etc.). This would be a plausible explanation for repeated "valid this week, invalid next week" behavior.
+- **Conflict**: The current reli runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) instructs creating the token at `https://railway.com/account/tokens`. That URL produces account or workspace tokens, **not** Project Tokens. But the workflow uses the env var `RAILWAY_TOKEN`, which Help Station threads explicitly say only accepts Project Tokens. This mismatch alone could cause "invalid or expired" on a freshly minted token.
+- **Currency caveat**: Several Help Station threads cited are from late 2025 / early 2026; Railway has been actively shipping changes in this area, so behavior may shift again.
+
+---
+
+## Recommendations
+
+Based on research, the following changes would address the recurring symptom directly, ranked by confidence:
+
+1. **Switch the workflow env var to `RAILWAY_API_TOKEN` and the secret to an account-scoped token created with the Workspace field BLANK** at `https://railway.com/account/tokens`. This is what Railway's own docs and a Railway employee both recommend for GitHub Actions ([Deploying with the CLI](https://docs.railway.com/cli/deploying); [Help Station thread](https://station.railway.com/questions/token-for-git-hub-action-53342720)). High confidence this resolves "Not Authorized" episodes that are actually scope-mismatch.
+
+2. **Alternatively, keep `RAILWAY_TOKEN` but rotate it from the right place — project settings → Tokens, not the account page.** If rotations are happening at `/account/tokens`, the token type is wrong and rejection is expected even when fresh ([Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)).
+
+3. **Update `docs/RAILWAY_TOKEN_ROTATION_742.md`** to (a) drop the unverified TTL claim, (b) document the workspace-blank requirement, (c) make the `RAILWAY_TOKEN` (Project Token, project settings) vs `RAILWAY_API_TOKEN` (account token, workspace blank) distinction explicit, and (d) name which one this repo uses.
+
+4. **Pin a recent Railway CLI version** (≥4.5.0; current is 4.26.0) in CI to avoid the historical bug where `RAILWAY_API_TOKEN` was silently ignored ([railwayapp/cli#668](https://github.com/railwayapp/cli/pull/668/)).
+
+5. **Add a pre-flight token sanity check** to the workflow that calls a cheap authenticated endpoint and fails fast with a clear error pointing at the rotation runbook — turning the 34th expiration into a one-line diagnostic instead of a deploy failure.
+
+6. **Do not pursue OIDC for Railway today** — Railway does not appear to offer a GitHub Actions OIDC trust path; revisit if Railway publishes one.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Public API — Railway Docs | https://docs.railway.com/reference/integrations | Definitive source on the four token types and headers |
+| 2 | Deploying with the CLI — Railway Docs | https://docs.railway.com/cli/deploying | Official GitHub Actions example uses `RAILWAY_API_TOKEN` |
+| 3 | Login & Tokens — Railway Docs | https://docs.railway.com/integrations/oauth/login-and-tokens | Confirms only OAuth tokens have documented expiration |
+| 4 | Using GitHub Actions with Railway — Railway Blog | https://blog.railway.com/p/github-actions | Walkthrough; uses Project Token for `railway up` |
+| 5 | Using the CLI — Railway Docs | https://docs.railway.com/guides/cli | CLI auth modes overview |
+| 6 | RAILWAY_TOKEN invalid or expired — Help Station | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | "RAILWAY_TOKEN now only accepts project token" |
+| 7 | RAILWAY_API_TOKEN not Working — Help Station | https://station.railway.com/questions/railway-api-token-not-working-2083f58a | Workspace-blank fix, employee-confirmed (2026-01-21) |
+| 8 | RAILWAY_API_TOKEN not being respected — Help Station | https://station.railway.com/questions/railway-api-token-not-being-respected-364b3135 | Confirms scope-vs-env-var mismatch pattern |
+| 9 | CLI throwing "Unauthorized" with RAILWAY_TOKEN — Help Station | https://station.railway.com/questions/cli-throwing-unauthorized-with-railway-24883ba1 | Token-type mismatch + config corruption causes |
+| 10 | Token for GitHub Action — Help Station | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Railway employee: use account-scoped `RAILWAY_API_TOKEN` |
+| 11 | railwayapp/cli#699 — CLI auth fails with valid token | https://github.com/railwayapp/cli/issues/699 | Active upstream auth bug (Nov 2025, still open) |
+| 12 | railwayapp/cli#668 — CLI 4.5.0 fix for `RAILWAY_API_TOKEN` | https://github.com/railwayapp/cli/pull/668/ | Historical bug; pin CLI ≥4.5.0 |
+| 13 | 0xdps/railway-secrets | https://github.com/0xdps/railway-secrets | Community rotation tool (rotates app vars, not auth token) |
+| 14 | OpenID Connect — GitHub Docs | https://docs.github.com/en/actions/concepts/security/openid-connect | OIDC pattern background |
+| 15 | Securing CI/CD with OIDC — Amplify Security | https://amplify.security/blog/securing-ci/cd-dont-use-long-lived-api-tokens-use-openid-connect-instead | Best-practice rationale for moving off long-lived tokens |


### PR DESCRIPTION
## Summary

- Document the 1st archon pickup of #841 (34th `RAILWAY_TOKEN` expiration cycle, prod-deploy framing). Filed by `pipeline-health-cron.sh` at 10:00:29Z when run `25209787350` went red on `da29247` — the merge commit of PR #840 (3rd pickup of #833). The archon pickup cron re-queued #841 at 12:00:40Z because no PR had been opened in 2 hours.
- Latest failing run on `main` is `25209787350` (09:34:51Z on SHA `da29247`). Eight consecutive red runs since the 03:35Z incident across 6 distinct merge SHAs — token still unrotated.
- Conclusion is unchanged: human-only rotation is the unblocking action per [`CLAUDE.md > Railway Token Rotation`](https://github.com/alexsiri7/reli/blob/main/CLAUDE.md). No code/workflow/config changes; no `.github/RAILWAY_TOKEN_ROTATION_841.md` receipt (Category 1 error). One rotation closes **#836** and **#841** together (#833 was already auto-closed at 09:30:10Z alongside PR #840's merge).

## What this PR adds

| File | Purpose |
|------|---------|
| `artifacts/runs/8531a0fb983e22588f40e6f43484ee47/investigation.md` | 1st-pickup investigation for #841: latest-run evidence chain, sibling-issue lineage table, scope boundaries, validation plan, edge cases. |
| `artifacts/runs/8531a0fb983e22588f40e6f43484ee47/web-research.md` | Carry-forward of the run's web research: Railway's four token types, the `RAILWAY_TOKEN` ↔ Project-Token-only constraint (employee-confirmed on Help Station), workspace-blank account-token gotcha, unverified-TTL gap in the runbook, OIDC unavailability. |

The web-research artifact's main *new* contribution over predecessor PRs is **Finding 2** — Railway publicly states `RAILWAY_TOKEN` only accepts a Project Token (which uses the `Project-Access-Token` HTTP header), while the existing validator at `.github/workflows/staging-pipeline.yml:49-58` uses `Authorization: Bearer` + `{me{id}}` (the account/workspace-token shape). This mismatch is a credible structural explanation for the 34-cycle recurrence: every rotation following the runbook's `/account/tokens` URL produces a token the validator rejects with the same misleading "invalid or expired" string, regardless of TTL. **Finding 5** further notes that no Railway public doc supports a TTL on Project/Account/Workspace tokens — the runbook's "1-day/7-day default TTL" claim is folklore.

## Why no code change

`CLAUDE.md > Railway Token Rotation`:

> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
> Creating documentation that claims success on an action you cannot perform is a Category 1 error.

The validator at `.github/workflows/staging-pipeline.yml:32-58` is failing closed exactly as designed; editing it during an active incident would mask the unrotated-secret signal. The structural fix (validator rewrite that distinguishes wrong-class vs expired tokens, env-var rename to `RAILWAY_API_TOKEN`, scheduled secret-validation cron, GitHub OIDC federation) has been mailed-to-mayor in prior cycles and is intentionally **not re-mailed here** per PR #840's test plan.

## Sibling issues

- **#832** — same original run (`25201008471`), same SHA (`d01d31c`), staging-side framing. **Closed.**
- **#833** — 32nd recurrence, deploy-down framing. **Closed at 2026-05-01T09:30:10Z** (alongside PR #840's merge). 3 pickups merged (PR #834, no-PR pickup, PR #840).
- **#836** — 33rd recurrence on next-day SHA `392291c`, CI-red framing. **Open** with 2 pickups merged (PR #837, PR #838).
- **#841** — 34th recurrence on PR #840's merge SHA, prod-deploy framing. **Open**, this PR is the 1st pickup.

One rotation resolves the two remaining open issues (#836 and #841).

## Test plan

- [x] Investigation artifact written to canonical workflow path and copied into the worktree for commit.
- [x] GitHub comment posted to #841 with the prod-deploy framing and pointer to predecessor PRs #834 / #837 / #838 / #840.
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` rotation receipt created.
- [x] No edits to `.github/workflows/staging-pipeline.yml`, `docs/RAILWAY_TOKEN_ROTATION_742.md`, or other production code.
- [x] No re-mail to mayor (structural fix already in mayor's queue per PR #840).
- [ ] **Human action remains pending**: rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`. Pre-save verification curl required (must return non-null `data.me.id`); workspace selector must be blank.
- [ ] **After rotation**: `gh run rerun 25209787350 --repo alexsiri7/reli --failed`; verify `Validate Railway secrets` passes, `Deploy to production` proceeds, `/healthz` returns ok.
- [ ] **After CI green**: close **#836** and **#841** together (re-confirm **#833** stays closed).

Part of #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)
