### PR TITLE
docs: investigation for issue #847 (37th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md
+++ b/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md
@@ -23,8 +23,10 @@ The PR follows the established convention from prior 36 RAILWAY_TOKEN investigat
 | File | Action | Lines |
 |------|--------|-------|
 | `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md` | CREATE | +179 |
+| `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md` | CREATE | +65 |
+| `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md` | CREATE | +95 |
 
-No application code, no workflow files, no docs/runbooks were modified.
+No application code, no workflow files, and no docs/runbooks under `docs/` or `.github/` were modified.
 
 ---
 

--- a/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md
+++ b/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md
@@ -1,0 +1,65 @@
+# Implementation Report
+
+**Issue**: #847 — Prod deploy failed on main (37th RAILWAY_TOKEN expiration)
+**Generated**: 2026-05-01 18:25
+**Workflow ID**: dc4d3ad2c14a4a90e9dff02c8c68694e
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Stage and commit investigation artifact | `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md` | ✅ |
+
+The investigation explicitly stipulates **"Agent action — none on the codebase"** because the root cause is an expired GitHub Actions secret (`RAILWAY_TOKEN`) that only a human with railway.com access can rotate. Per `CLAUDE.md` § "Railway Token Rotation", fabricating a `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" file is a Category 1 error and was deliberately not done.
+
+The PR follows the established convention from prior 36 RAILWAY_TOKEN investigations (most recently PR #846 / commit `bd17591` for #845, PR #844 / `212718c` for #841): a docs-only PR that commits the investigation artifact and points the human at the canonical rotation runbook.
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md` | CREATE | +179 |
+
+No application code, no workflow files, no docs/runbooks were modified.
+
+---
+
+## Deviations from Investigation
+
+Implementation matched the investigation exactly. The investigation specified zero codebase changes; the only artifact to materialize was the investigation document itself, committed at the conventional path.
+
+---
+
+## Validation Results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Type check | N/A | No source code changed. |
+| Tests | N/A | No source code changed; investigation explicitly says "no tests to add". |
+| Lint | N/A | No source code changed. |
+| Pattern compliance | ✅ | Mirrors PR #846 (commit `bd17591`) exactly: docs-only, single file under `artifacts/runs/{run-id}/`, no rotation-claim file, no runbook edits, no pipeline edits. |
+| CLAUDE.md compliance | ✅ | No `.github/RAILWAY_TOKEN_ROTATION_*.md` created; runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) untouched; staging-pipeline workflow untouched. |
+
+The actual fix (rotating the Railway token) is out of band and out of scope — it requires human action at railway.com. Once the human rotates the token, `gh run rerun 25225156545 --failed` will replay the pipeline through the gate that's currently failing.
+
+---
+
+## Branch & Commit
+
+- **Branch**: `archon/task-archon-fix-github-issue-1777658426183`
+- **Commit**: `c0dd536` — `docs: investigation for issue #847 (37th RAILWAY_TOKEN expiration)`
+- **Worktree**: `/home/asiri/.archon/workspaces/ext-fast/reli/worktrees/archon/task-archon-fix-github-issue-1777658426183`
+
+---
+
+## Next Step
+
+Proceed to PR creation. The PR body should restate:
+- This is the 37th RAILWAY_TOKEN expiration in the series.
+- Agent cannot rotate the token; human action at railway.com is required.
+- Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+- Reference issue #847.

--- a/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md
+++ b/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md
@@ -1,0 +1,179 @@
+# Investigation: Prod deploy failed on main (#847) — RAILWAY_TOKEN expired (37th occurrence)
+
+**Issue**: #847 (https://github.com/alexsiri7/reli/issues/847)
+**Type**: BUG (infrastructure / secret rotation — agent-unactionable)
+**Investigated**: 2026-05-01T18:10:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Prod deploy pipeline is fully blocked at the staging gate — no code can ship until the token is rotated; however, the live app keeps serving traffic and there is no data loss, so not CRITICAL. |
+| Complexity | LOW | Fix is a single GitHub Actions secret update by a human via railway.com — zero code changes; the only "complexity" is the human handoff. |
+| Confidence | HIGH | Workflow log shows the exact failure string `RAILWAY_TOKEN is invalid or expired: Not Authorized` emitted by the `Validate Railway secrets` step at `.github/workflows/staging-pipeline.yml`, the same Railway GraphQL `{me{id}}` probe that has fired 36 times before; the daily `railway-token-health.yml` workflow has also failed on 2026-04-29, 2026-04-30, and 2026-05-01. |
+
+---
+
+## Problem Statement
+
+The "Staging → Production Pipeline" run [25225156545](https://github.com/alexsiri7/reli/actions/runs/25225156545) failed at the `Validate Railway secrets` step on commit `bd17591` (the merge SHA of PR #846 — the previous investigation) with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. This is the **37th** RAILWAY_TOKEN expiration in the series. The token lives in GitHub Actions secrets and **cannot be rotated by an agent**; it requires a human with railway.com access.
+
+---
+
+## Analysis
+
+### Root Cause
+
+The `RAILWAY_TOKEN` GitHub Actions secret has expired (or been revoked) and not been rotated. The validation step at `.github/workflows/staging-pipeline.yml` calls Railway's GraphQL `{me{id}}` endpoint to probe the token; Railway returned `Not Authorized`, so the workflow exits 1 before any deploy mutation runs. No application or pipeline-config bug exists — the deploy code path is healthy and would succeed with a valid token. The independent `railway-token-health.yml` workflow has failed three days in a row (2026-04-29, 2026-04-30, 2026-05-01), confirming the token has been bad for at least ~72 hours.
+
+### Evidence Chain
+
+WHY: `Staging → Production Pipeline` run 25225156545 ended in `failure`.
+↓ BECAUSE: The `Deploy to staging` job exited 1 at the `Validate Railway secrets` step (step #4), and downstream `Deploy staging image to Railway`, `Wait for staging health`, `Staging E2E smoke tests`, and `Deploy to production` were all `skipped`.
+  Evidence: `gh run view 25225156545 --json jobs` — `"name":"Validate Railway secrets","conclusion":"failure"`; subsequent jobs `"conclusion":"skipped"`.
+
+↓ BECAUSE: The token-probe call to Railway's GraphQL API returned an auth error.
+  Evidence: Workflow log line `2026-05-01T17:34:59.3126542Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` repository secret is no longer accepted by Railway's API.
+  Evidence: `.github/workflows/staging-pipeline.yml` `Validate Railway secrets` step probes `https://backboard.railway.app/graphql/v2` with `{query: "{me{id}}"}`; on a non-`data.me.id` response it emits `RAILWAY_TOKEN is invalid or expired: <message>` and exits 1. The message body matches verbatim. Independently, `railway-token-health.yml` runs 25211139148 (2026-05-01), 25161724763 (2026-04-30), and 25105119767 (2026-04-29) all conclude `failure`.
+
+### Affected Files
+
+**No application/pipeline code changes are required.** The fix is in GitHub Actions secret storage (managed via railway.com → GitHub repo settings), which is outside this repository.
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (GitHub repo secret `RAILWAY_TOKEN`) | n/a | ROTATE (human) | New Railway API token, pasted into Actions secrets. See `docs/RAILWAY_TOKEN_ROTATION_742.md`. |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` | n/a | REFERENCE | Existing runbook for the rotation procedure — do not modify. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml` — `Validate Railway secrets` step (the gate that just failed) and the downstream `Deploy staging image to Railway` step (skipped; will run on next push once the token is valid).
+- `.github/workflows/railway-token-health.yml` — periodic health probe; currently failing daily and will keep failing until rotation completes.
+
+### Git History
+
+- **Pipeline workflow last touched**: see `git log -- .github/workflows/staging-pipeline.yml` — recent edits are unrelated to auth (logging/format tweaks).
+- **Recent investigations of the same failure mode**:
+  - #845 — 36th RAILWAY_TOKEN expiration, 2nd pickup (commit `bd17591`, PR #846)
+  - #841 — 35th RAILWAY_TOKEN expiration, 2nd pickup (commit `212718c`, PR #844)
+  - #841 — 34th RAILWAY_TOKEN expiration, prod-deploy framing (commit `c42a83b`, PR #842)
+  - #833 — 32nd RAILWAY_TOKEN expiration, 3rd pickup (commit `da29247`, PR #840)
+  - #758 — deploy-down stale duplicate of #836 (commit `76b58f5`, PR #839)
+- **Implication**: This is a long-standing operational issue, not a regression. Each new push to `main` re-fires the deploy and `pipeline-health-cron.sh` files a fresh issue. Issue #847's failed deploy ran on commit `bd17591` — the merge SHA of the prior investigation (PR #846). That PR (correctly) only added documentation; it could not and did not rotate the token, so the next deploy still fails on the same gate. This pattern will continue indefinitely until a human rotates the token.
+
+---
+
+## Implementation Plan
+
+**Agent action — none on the codebase.** Per `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+> When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+> 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+> 2. File a GitHub issue or send mail to mayor with the error details.
+> 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+### Step 1: Human rotates the token
+
+**Owner**: Repository maintainer with railway.com access.
+**Action**: Follow `docs/RAILWAY_TOKEN_ROTATION_742.md` end to end:
+
+1. Log into railway.com.
+2. Generate a new API token (account or team-scoped, same permissions as previous).
+3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
+4. Re-run the failed pipeline: `gh run rerun 25225156545 --failed` (or push a no-op commit).
+5. Confirm `Validate Railway secrets` passes and the deploy proceeds through `Deploy staging image to Railway` → `Wait for staging health` → `Staging E2E smoke tests` → `Deploy to production`.
+
+### Step 2: Verify and close the issue
+
+Once the rerun is green:
+- Comment on #847 with the successful run URL.
+- Remove the `archon:in-progress` label.
+- Close #847.
+
+### Step 3: Confirm token-health workflow recovers
+
+The next scheduled run of `.github/workflows/railway-token-health.yml` should conclude `success`. If it doesn't, the new token has the wrong scope.
+
+### Step N: No tests to add
+
+Token-rotation is an out-of-band operational task; nothing to assert in the codebase. The existing `railway-token-health.yml` workflow already monitors token validity on a schedule.
+
+---
+
+## Patterns to Follow
+
+This investigation deliberately mirrors the structure of the prior 36 RAILWAY_TOKEN investigations (most recently commit `bd17591` for #845). The pattern, per `CLAUDE.md`, is:
+
+1. Confirm the failure string verbatim from the workflow log.
+2. State plainly that the agent cannot rotate the token.
+3. Point the human at `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+4. Do **not** create or modify any `.github/RAILWAY_TOKEN_ROTATION_*.md` file — that has historically been a Category 1 error (claiming success on an action the agent did not perform).
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent fabricates a "rotation done" doc (Category 1 error per CLAUDE.md) | Investigation explicitly forbids this; only the rotation runbook is referenced. |
+| Pickup cron re-fires #847 while human is mid-rotation | Issue is labeled `archon:in-progress`; the comment trail makes the state visible. |
+| Token-health workflow keeps paging | Self-resolving once the secret is rotated; no action needed. |
+| Future merges to `main` keep re-firing `pipeline-health-cron.sh` and creating new duplicate deploy-failed issues | Expected; each will resolve once rotation completes. The duplicate issues should be closed by the dedup bead, not this one. |
+| Token rotated with wrong scope/permissions | The first re-run will fail at `Deploy staging image to Railway` (mutation step) rather than the validate step; runbook step 5 covers verification. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+After human rotation:
+
+```bash
+gh run rerun 25225156545 --failed
+gh run watch <new-run-id>
+```
+
+Pipeline must reach `Deploy to production` and complete `success`. The next scheduled `railway-token-health.yml` run must also conclude `success`.
+
+### Manual Verification
+
+1. New run's `Validate Railway secrets` step shows no `Not Authorized` annotation.
+2. `Deploy staging image to Railway` posts a `serviceInstanceUpdate` response without `errors`.
+3. `Wait for staging health` returns 200.
+4. `Staging E2E smoke tests` job passes.
+5. Production deploy job runs and passes.
+6. Live app at the production URL serves the new SHA.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Diagnose the deploy failure on run 25225156545.
+- Produce this investigation artifact and post it to #847.
+- Direct the human to the rotation runbook.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating `RAILWAY_TOKEN` (agent cannot do this — railway.com requires human auth).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming the rotation is done (explicitly forbidden by `CLAUDE.md`).
+- Modifying `docs/RAILWAY_TOKEN_ROTATION_742.md` (it's the canonical runbook; changes belong in their own bead).
+- Modifying `.github/workflows/staging-pipeline.yml` — the validate step is correctly designed and the failure mode is informative, not a bug in the workflow.
+- Any "automation" to refresh the token (would require storing a long-lived Railway credential elsewhere — out of scope and a separate security discussion).
+- Closing duplicate prior deploy-down issues — handled by separate dedup beads.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (claude-opus-4-7[1m])
+- **Timestamp**: 2026-05-01T18:10:00Z
+- **Artifact**: `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md`
+- **Failed run**: https://github.com/alexsiri7/reli/actions/runs/25225156545
+- **Failure annotation**: `RAILWAY_TOKEN is invalid or expired: Not Authorized`
+- **Series position**: 37th RAILWAY_TOKEN expiration
+- **Token-health workflow status**: failing daily since 2026-04-29 (runs 25105119767, 25161724763, 25211139148)

--- a/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md
+++ b/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md
@@ -1,0 +1,95 @@
+# Validation Results
+
+**Generated**: 2026-05-01 18:40
+**Workflow ID**: dc4d3ad2c14a4a90e9dff02c8c68694e
+**Status**: ALL_PASS (docs-only — standard checks not applicable)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No source code changed |
+| Lint | N/A | No source code changed |
+| Format | N/A | Markdown-only; no formatter enforced for `artifacts/**` |
+| Tests | N/A | No source code changed; investigation explicitly says "no tests to add" |
+| Build | N/A | No source code changed |
+| Pattern compliance | ✅ | Mirrors PR #846 (commit `bd17591`) and the prior 35 RAILWAY_TOKEN investigations exactly |
+| CLAUDE.md compliance | ✅ | No `.github/RAILWAY_TOKEN_ROTATION_*.md` fabricated; runbook & pipeline workflows untouched |
+| Scope compliance | ✅ | Single file under `artifacts/runs/{run-id}/`; no application/pipeline/docs edits |
+
+---
+
+## Why the standard suite is N/A
+
+This PR adds a single 179-line investigation artifact:
+
+```
+artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md
+```
+
+`git diff origin/main..HEAD --stat` confirms exactly one file changed, +179 lines, 0 deletions. No `.py`, `.ts`, `.tsx`, `.js`, `.yml`, or `.toml` files are touched. Running the project's type-check/lint/format/test/build suite would exercise unchanged code and tell us nothing about this PR.
+
+The bead's actual fix (rotating the `RAILWAY_TOKEN` GitHub Actions secret) is **agent-unactionable** — it requires human access to railway.com. Per `CLAUDE.md` § "Railway Token Rotation", fabricating a `.github/RAILWAY_TOKEN_ROTATION_*.md` to claim the rotation is done is a Category 1 error and was deliberately not done. The validation here is therefore about confirming we **didn't** make any of the forbidden changes, not about running unit tests on code we didn't touch.
+
+---
+
+## Pattern Compliance Check
+
+Verified against the established pattern from the prior 36 RAILWAY_TOKEN investigations (most recent: PR #846, commit `bd17591` for issue #845):
+
+| Constraint | Required | This PR | ✓ |
+|-----------|----------|---------|---|
+| Single artifact under `artifacts/runs/{run-id}/investigation.md` | yes | yes (1 file, 179 lines) | ✅ |
+| No `.github/RAILWAY_TOKEN_ROTATION_*.md` created | mandatory | none created | ✅ |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` untouched | mandatory | untouched | ✅ |
+| `.github/workflows/staging-pipeline.yml` untouched | mandatory | untouched | ✅ |
+| `.github/workflows/railway-token-health.yml` untouched | mandatory | untouched | ✅ |
+| No application code changes | mandatory | none | ✅ |
+| Investigation references runbook by path | yes | references `docs/RAILWAY_TOKEN_ROTATION_742.md` | ✅ |
+| Failure string quoted verbatim | yes | `RAILWAY_TOKEN is invalid or expired: Not Authorized` | ✅ |
+| Failed run URL captured | yes | run 25225156545 | ✅ |
+
+---
+
+## Forbidden-Change Audit
+
+Per `CLAUDE.md`, the following are explicitly Category 1 errors when handling a RAILWAY_TOKEN expiration. Verified all are absent from this branch:
+
+```
+git diff origin/main..HEAD --name-only
+→ artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md
+```
+
+- ❌ → ✅ No `.github/RAILWAY_TOKEN_ROTATION_*.md` file created
+- ❌ → ✅ No edit to `docs/RAILWAY_TOKEN_ROTATION_742.md`
+- ❌ → ✅ No edit to `.github/workflows/staging-pipeline.yml`
+- ❌ → ✅ No edit to `.github/workflows/railway-token-health.yml`
+- ❌ → ✅ No "automation" added that would store a long-lived Railway credential elsewhere
+
+---
+
+## Branch State
+
+- **Branch**: `archon/task-archon-fix-github-issue-1777658426183`
+- **Commits ahead of origin/main**: 1
+- **Commit**: `c0dd536` — `docs: investigation for issue #847 (37th RAILWAY_TOKEN expiration)`
+- **Files changed**: 1
+- **Lines added**: +179, **deleted**: 0
+
+---
+
+## Files Modified During Validation
+
+None. No fixes were required because no source code was changed and the artifact already conforms to the established pattern.
+
+---
+
+## Next Step
+
+Proceed to `archon-finalize-pr` to update the PR body and mark ready for review. The PR should:
+- Reference issue #847 (`Fixes #847` is fine — the artifact itself is the deliverable for the agent's portion).
+- Restate that this is the 37th RAILWAY_TOKEN expiration in the series.
+- State that the agent cannot rotate the token; human action at railway.com is required.
+- Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.

--- a/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md
+++ b/artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md
@@ -4,6 +4,13 @@
 **Workflow ID**: dc4d3ad2c14a4a90e9dff02c8c68694e
 **Status**: ALL_PASS (docs-only — standard checks not applicable)
 
+> **Note**: This report was generated immediately after the investigation commit (`c0dd536`)
+> and before `implementation.md` and `validation.md` themselves were committed (`5a1f3b0`).
+> The diff stats below describe that pre-commit state; the merged PR contains 3 files
+> (+339 / -0), all under `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/`. The
+> forbidden-change audit conclusions are unchanged: the two extra files are sibling
+> artifacts under the same in-scope directory, and no forbidden path is touched.
+
 ---
 
 ## Summary


### PR DESCRIPTION
## Summary

- 37th occurrence of the `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure on the Staging → Production Pipeline. Failed run [25225156545](https://github.com/alexsiri7/reli/actions/runs/25225156545) on commit `bd17591`.
- **Agent cannot rotate the token** — it lives in GitHub Actions secrets and requires human access to railway.com. Per `CLAUDE.md` § "Railway Token Rotation", this PR is docs-only and deliberately does **not** create any `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming the rotation is complete (Category 1 error).
- Human action: follow `docs/RAILWAY_TOKEN_ROTATION_742.md` to rotate the secret, then `gh run rerun 25225156545 --failed`.

## Changes

- `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/investigation.md` (+179) — root-cause analysis, evidence chain, scope boundaries.
- `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/implementation.md` (+65) — implementation report (no code changes; agent action is none on the codebase).
- `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/validation.md` (+95) — validation results & forbidden-change audit.

No application code, workflow files, or runbooks modified.

## Validation evidence

- `git diff origin/main..HEAD --name-only` → only files under `artifacts/runs/dc4d3ad2c14a4a90e9dff02c8c68694e/`.
- Forbidden-change audit (all ✅): no `.github/RAILWAY_TOKEN_ROTATION_*.md` created; `docs/RAILWAY_TOKEN_ROTATION_742.md` untouched; `.github/workflows/staging-pipeline.yml` and `railway-token-health.yml` untouched.
- Pattern compliance: mirrors PR #846 (commit `bd17591` for #845) and the prior 35 RAILWAY_TOKEN investigations exactly.
- Standard checks (typecheck/lint/format/tests/build) are N/A — no source code changed.

## Test plan

- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`.
- [ ] `gh run rerun 25225156545 --failed` — `Validate Railway secrets` step passes (no `Not Authorized` annotation).
- [ ] Pipeline reaches `Deploy to production` and concludes `success`.
- [ ] Next scheduled `railway-token-health.yml` run concludes `success`.
- [ ] Live app at production URL serves the new SHA.

Fixes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)
