### PR TITLE
docs: investigation for issue #850 (38th RAILWAY_TOKEN expiration, 4th pickup)

### DIFF
--- a/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md
+++ b/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md
@@ -1,0 +1,162 @@
+# Investigation: Prod deploy failed on `main` — RAILWAY_TOKEN expired (38th occurrence, 3rd pickup of #850)
+
+**Issue**: #850 (https://github.com/alexsiri7/reli/issues/850)
+**Type**: BUG (infrastructure / secret rotation — agent-unactionable)
+**Investigated**: 2026-05-02T00:00:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Prod deploy pipeline still blocked at the staging gate — three further `staging-pipeline.yml` runs (`25237747540`, `25229747557`, `25227442673`) failed at `Validate Railway secrets` since PR #851 merged; live app keeps serving traffic, no data loss, so not CRITICAL. |
+| Complexity | LOW | Single GitHub Actions secret update by a human via railway.com — zero code changes; complexity is purely the human handoff that has not yet occurred. |
+| Confidence | HIGH | Most recent failed run `25237747540` (2026-05-01T23:34:49Z) emits the exact string `RAILWAY_TOKEN is invalid or expired: Not Authorized` from `staging-pipeline.yml:55` — identical signature to the 37 prior occurrences; no token rotation has landed. |
+
+---
+
+## Problem Statement
+
+Issue #850 is the 38th `RAILWAY_TOKEN` expiration. PR #851 (merged 2026-05-01T19:30:09Z) shipped the prior investigation artifact and web research, but a human has not yet rotated the secret — the staging pipeline has continued to fail after that merge (most recently run `25237747540` at 2026-05-01T23:34:49Z). The pickup cron has now re-queued #850 twice (comments at 2026-05-01T21:00:41Z and 2026-05-01T23:30:38Z) because no new PR was opened. Per `CLAUDE.md` § "Railway Token Rotation", an agent **cannot** rotate this token; the action requires a human with railway.com access.
+
+---
+
+## Analysis
+
+### Primitive — first principles
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| Token validity probe | `.github/workflows/staging-pipeline.yml:49-58` | Yes | Correctly fails fast on auth error and emits an actionable message; not the source of the bug. |
+| `RAILWAY_TOKEN` GitHub Actions secret | (GitHub UI) | No | Token is rejected by `https://backboard.railway.app/graphql/v2` `{me{id}}` — needs rotation by a human; cannot be done by an agent. |
+| Pickup cron / re-queue logic | (mayor) | Yes | Re-queueing on a stuck `archon:in-progress` label is correct behaviour; the loop will keep firing until the secret is rotated and the issue is closed. |
+
+The bug is in a non-code primitive (the secret value). No source change can fix it.
+
+### Root Cause
+
+WHY: Latest staging pipeline run `25237747540` ended in `failure`.
+↓ BECAUSE: `Deploy to staging` exited 1 at `Validate Railway secrets`.
+↓ BECAUSE: The `{me{id}}` probe to `https://backboard.railway.app/graphql/v2` returned `Not Authorized`.
+  Evidence: `2026-05-01T23:34:49.1344177Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` repository secret is still not accepted by Railway's API; it has not been rotated since PR #851 merged.
+  Evidence: `staging-pipeline.yml:49-58` issues the probe; Railway returns `Not Authorized`. The `railway-token-health.yml` cron (last run `25211139148`, 2026-05-01T10:27:15Z) is also still `failure`.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (GitHub secret `RAILWAY_TOKEN`) | — | UPDATE | Human rotates via railway.com → repo secrets |
+| (none in source tree) | — | — | No code, workflow, or runbook changes are required or appropriate |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:49-58` consumes the secret for the probe and the deploy step (lines 60-67).
+- `.github/workflows/railway-token-health.yml` runs the same probe daily; will go green automatically once the secret is rotated.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` is the canonical human runbook.
+
+### Git History
+
+- **PR #851** merged 2026-05-01T19:30:09Z — landed the prior investigation artifact (commit `4f11147`); no source change.
+- **No subsequent commits to `.github/`** since that merge — confirming nothing on the agent side has changed (and nothing should).
+- **Implication**: This is a stuck-on-human-action condition, not a regression.
+
+---
+
+## Implementation Plan
+
+### Step 1: Human rotates `RAILWAY_TOKEN`
+
+**File**: GitHub Actions secret (out-of-tree)
+**Action**: UPDATE
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:
+
+1. Log into railway.com.
+2. Generate a new **account/team-scoped** API token at `https://railway.com/account/tokens` (workspace and project tokens cannot answer `{me{id}}` — see `web-research.md` in this artifact dir).
+3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
+4. Re-run the failed pipeline: `gh run rerun 25237747540 --failed` (or `25227458546`, the original).
+5. Confirm `Validate Railway secrets` passes and the deploy proceeds through `Deploy staging image to Railway` → `Wait for staging health` → `Staging E2E smoke tests` → `Deploy to production`.
+6. Comment on issue #850 with the green run URL, remove `archon:in-progress`, close the issue.
+7. Verify the next scheduled `railway-token-health.yml` run also goes green.
+
+**Why**: Without this human action, every subsequent merge to `main` will trigger a fresh staging-pipeline failure and the pickup cron will keep re-queueing #850.
+
+---
+
+### Step 2 (Explicitly NOT done — Category 1 traps)
+
+Per `CLAUDE.md`:
+
+- ❌ Do **not** create `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming rotation is done.
+- ❌ Do **not** edit `.github/workflows/staging-pipeline.yml` — the validator is correctly designed.
+- ❌ Do **not** edit `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook owned by separate change.
+- ❌ Do **not** swap to `Project-Access-Token` headers — per `web-research.md`, project tokens cannot call `serviceInstanceUpdate`/`serviceInstanceDeploy` and cannot answer `{me{id}}`; that path would require a half-day refactor and is out of scope for this emergency bead.
+
+---
+
+## Patterns to Follow
+
+This pickup mirrors the pattern established in PR #848, #851, #852 (and the 35 prior occurrences):
+
+1. Verify the failure signature matches `RAILWAY_TOKEN is invalid or expired`.
+2. Write a short investigation artifact (this file).
+3. Post a brief comment on the issue restating the human action.
+4. Land the artifact via PR with `Part of #850` (so `gt done` links it).
+5. Do **not** modify any source/workflow/runbook file.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Cron re-queues #850 again before human rotates | Tolerable — comment trail makes the human action obvious; each pickup is a docs-only PR |
+| Human rotates but creates a workspace/project token by mistake | `docs/RAILWAY_TOKEN_ROTATION_742.md` and `web-research.md` both call out account-scope explicitly |
+| Token rotation lands while another bead is mid-flight | No conflict — secret rotation is out-of-tree; other PRs proceed unaffected once pipeline is green |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+gh run list --workflow=staging-pipeline.yml --limit 1
+gh run list --workflow=railway-token-health.yml --limit 1
+```
+
+Both should show `success` after rotation.
+
+### Manual Verification
+
+1. Human reruns failed pipeline; `Validate Railway secrets` step passes.
+2. `Deploy to production` step completes `success`.
+3. Issue #850 closed with green run URL.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- This investigation artifact under `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/`.
+- A brief restating-comment on issue #850 directing the human to the runbook.
+
+**OUT OF SCOPE (do not touch):**
+- `.github/workflows/staging-pipeline.yml`
+- `.github/workflows/railway-token-health.yml`
+- `docs/RAILWAY_TOKEN_ROTATION_742.md`
+- Any `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" file
+- Refactoring the deploy job to use the Railway CLI + project token (durable but ~half-day; deferred)
+- Renaming `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN` (deferred, low value)
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T00:00:00Z
+- **Workflow ID**: 143fba6af8ed9a6eee7eae7c6cc02a7d
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md`
+- **Companion**: `web-research.md` in the same directory (from prior pickup)
+- **Prior PRs for #850**: #851 (merged 2026-05-01T19:30:09Z)
+- **Latest failing runs**: `25237747540` (2026-05-01T23:34:49Z), `25229747557`, `25227458546` (original)

--- a/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md
+++ b/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md
@@ -74,7 +74,7 @@ Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:
 1. Log into railway.com.
 2. Generate a new **account/team-scoped** API token at `https://railway.com/account/tokens` (workspace and project tokens cannot answer `{me{id}}` — see `web-research.md` in this artifact dir).
 3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
-4. Re-run the failed pipeline: `gh run rerun 25237747540 --failed` (or `25227458546`, the original).
+4. Re-run the failed pipeline: `gh run rerun 25237747540 --failed` (or `25227442673`, the original).
 5. Confirm `Validate Railway secrets` passes and the deploy proceeds through `Deploy staging image to Railway` → `Wait for staging health` → `Staging E2E smoke tests` → `Deploy to production`.
 6. Comment on issue #850 with the green run URL, remove `archon:in-progress`, close the issue.
 7. Verify the next scheduled `railway-token-health.yml` run also goes green.
@@ -159,4 +159,4 @@ Both should show `success` after rotation.
 - **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md`
 - **Companion**: `web-research.md` in the same directory (from prior pickup)
 - **Prior PRs for #850**: #851 (merged 2026-05-01T19:30:09Z)
-- **Latest failing runs**: `25237747540` (2026-05-01T23:34:49Z), `25229747557`, `25227458546` (original)
+- **Latest failing runs**: `25237747540` (2026-05-01T23:34:49Z), `25229747557`, `25227442673` (original)

--- a/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/web-research.md
+++ b/artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/web-research.md
@@ -1,0 +1,137 @@
+# Web Research: fix #850
+
+**Researched**: 2026-05-02
+**Workflow ID**: 143fba6af8ed9a6eee7eae7c6cc02a7d
+
+---
+
+## Summary
+
+Issue #850 is the 38th occurrence of the same `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure in the staging pipeline. Web research confirms the workflow is calling Railway's GraphQL `me` query with an `Authorization: Bearer` header, which **requires an account (personal) token** — matching the prescription in `docs/RAILWAY_TOKEN_ROTATION_742.md`. Railway's public documentation does **not** describe any expiration policy or "no expiration" option for account tokens, which is the central unknown driving the recurring rotations: the runbook's "create with No expiration" instruction has no source we could find in Railway's published docs.
+
+---
+
+## Findings
+
+### Railway token model: three distinct types with different semantics
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Validating that the workflow's auth pattern is using the right token type
+
+**Key Information**:
+
+- Three token types exist with non-interchangeable semantics:
+  - **Account (personal) token** — scope: "All your resources and workspaces"; header: `Authorization: Bearer <API_TOKEN>`; **can authenticate the `me` query**.
+  - **Workspace token** — scope: "Single workspace"; header: `Authorization: Bearer <WORKSPACE_TOKEN>`; explicitly **cannot** authenticate `me`: "This query cannot be used with a workspace or project token".
+  - **Project token** — scope: "Single environment in a project"; header is **different**: `Project-Access-Token: <PROJECT_TOKEN>` (not `Authorization: Bearer`); also **cannot** authenticate `me`.
+- The repo's `.github/workflows/staging-pipeline.yml:49-52` sends `Authorization: Bearer $RAILWAY_TOKEN` and queries `{me{id}}`. By Railway's docs, **only an account token will succeed**. This matches what `docs/RAILWAY_TOKEN_ROTATION_742.md` instructs (create at `https://railway.com/account/tokens`).
+- Implication: a "Not Authorized" response on the `me` query is consistent with (a) the token having been revoked/expired, (b) the token being created as a workspace or project token instead of an account token, or (c) the token being malformed in the secret.
+
+---
+
+### Account token expiration / lifetime is undocumented in Railway's public docs
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/reference/oauth/login-and-tokens), [Public API | Railway Docs](https://docs.railway.com/integrations/api), [CLI guide](https://docs.railway.com/guides/cli)
+**Authority**: Official Railway documentation
+**Relevant to**: Why tokens keep "expiring" — and whether the runbook's "No expiration" claim is accurate
+
+**Key Information**:
+
+- The OAuth/Login & Tokens page documents OAuth flows only: "Access tokens expire after one hour" and "The new refresh token has a fresh one-year lifetime from the time of issuance." These are **OAuth** access/refresh tokens, **not** the personal API tokens used by GitHub Actions.
+- Across the three pages we fetched (`integrations/api`, `guides/cli`, `reference/oauth/login-and-tokens`), Railway's documentation **contains no statement** about TTL, expiration, or rotation policy for account, workspace, or project tokens.
+- The runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md:21`) asserts: "When creating tokens on Railway, the default TTL may be short (e.g., 1 day or 7 days). Previous rotations may have used these defaults. The new token must be created with 'No expiration'." We could not corroborate either the default-TTL claim or the "No expiration" option from official documentation. This is either UI-only behavior (changeable at any time without doc updates) or a misremembered convention.
+
+---
+
+### The error string "Not Authorized" can occur even with a brand-new token if token type is wrong
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)
+**Authority**: Railway community help forum (user-reported, high signal for failure-mode taxonomy)
+**Relevant to**: Distinguishing genuine expiration from token-type mismatch
+
+**Key Information**:
+
+- A user describes the same error string we are seeing: "RAILWAY_TOKEN now only accepts *project token*, if u put the normal account token... it literally says 'invalid or expired' even if u just made it 2 seconds ago."
+- This describes the **Railway CLI** (`railway up`) behavior, not raw GraphQL. Our workflow uses raw GraphQL (`curl` to `backboard.railway.app/graphql/v2`), so the inverse holds for us: a project token would fail because `me` is an account-only query and the `Authorization: Bearer` header is wrong for project tokens.
+- Takeaway: the same "invalid or expired" string is emitted both for genuine expiration **and** for token-type mismatch. The validator step cannot distinguish them. When investigating recurrences, ask the rotator to confirm token type, not just freshness.
+
+---
+
+### Confirmation of `me` query restriction from Railway moderator
+
+**Source**: [GraphQL requests returning "Not Authorized" for PAT — Railway Help Station](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52)
+**Authority**: Railway moderator response on official help forum
+**Relevant to**: Reinforces that `{me{id}}` is account-token-only
+
+**Key Information**:
+
+- Moderator quote: "`query { me { id email } }` ... not using your personal access token here is the only reason I can see why it would be returning an authentication error."
+- "There are only two scopes, personal access token and workspace access token... the personal access token is the highest level token and should work with essentially any workspace."
+- This independently confirms the docs: the validator step in `staging-pipeline.yml` requires a **personal/account** token, not a workspace or project token.
+
+---
+
+### CLI env-var convention is the opposite of the GraphQL header convention — naming is misleading
+
+**Source**: [Using the CLI | Railway Docs](https://docs.railway.com/guides/cli)
+**Authority**: Official Railway documentation
+**Relevant to**: Naming hygiene of the `RAILWAY_TOKEN` GitHub secret
+
+**Key Information**:
+
+- Railway CLI documents two env vars with opposite scopes from what the secret name suggests:
+  - `RAILWAY_TOKEN` → "project-level actions" (i.e., expects a **project** token).
+  - `RAILWAY_API_TOKEN` → "account-level actions" (i.e., expects an **account** token).
+- This repo's secret is named `RAILWAY_TOKEN` but holds an **account** token (correctly, for the GraphQL `me` query). If anyone running rotation reads Railway's CLI docs without context, they could create the wrong token type for the secret name. This is a latent foot-gun in the rotation procedure, not a bug in the workflow itself (the workflow uses raw curl, not the CLI, so the env var name doesn't affect runtime behavior).
+
+---
+
+## Code Examples
+
+The exact GraphQL call pattern from Railway docs that matches our validator step:
+
+```bash
+# From Railway Public API docs
+# https://docs.railway.com/integrations/api
+curl -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ me { id email } }"}'
+```
+
+This is identical to `.github/workflows/staging-pipeline.yml:49-52` except Railway's docs name the variable `RAILWAY_API_TOKEN`. The HTTP semantics are the same; the variable name is a local convention.
+
+---
+
+## Gaps and Conflicts
+
+- **No source corroborates "default TTL of 1 day or 7 days" for account tokens.** The claim in `docs/RAILWAY_TOKEN_ROTATION_742.md:21` could not be verified against Railway's published documentation. Either the UI exposes TTL options not described in docs, or the claim is folklore.
+- **No source corroborates a "No expiration" creation option for account tokens.** Railway's public docs are silent on token TTL entirely. The option may exist in the dashboard UI; we cannot confirm without dashboard access.
+- **Cannot determine *why* the token has actually expired 38 times.** Possibilities consistent with available evidence: (a) tokens are being created with a finite TTL despite the runbook's instruction, (b) Railway is silently revoking tokens (security policy, plan change, billing), (c) the token type is being mis-set on rotation and failing immediately — though the multi-day-old age of repeated failures argues against (c).
+- **Frequency/cadence of expirations is not in scope of web research** but worth noting: 38 expirations is far above any plausible "natural" account-token expiry rate. The pattern itself suggests something procedural (or an account-side policy) is wrong, not just the token.
+
+---
+
+## Recommendations
+
+These are research-informed observations, **not** code changes — agents cannot rotate the token (per CLAUDE.md > Railway Token Rotation).
+
+1. **Surface the token-type ambiguity to the human rotating the token.** Update the runbook (or the issue comment) to tell the rotator: "Create an *account* (personal) token at https://railway.com/account/tokens. The validator step uses the GraphQL `me` query, which only accepts account tokens — not workspace or project tokens. The secret being named `RAILWAY_TOKEN` is misleading; it must hold an account token, not a project token."
+2. **Verify the "No expiration" claim against the actual Railway dashboard during the next rotation.** If the option exists, confirm it was selected. If it doesn't exist, remove the claim from the runbook — it's misleading the human rotators every time.
+3. **Consider whether the validator's error message can be improved** to distinguish "expired" from "wrong token type." The Railway API returns `"Not Authorized"` for both, but the `MSG=` capture step in `staging-pipeline.yml:54` could include a hint pointing to token-type guidance, not just rotation. (Out-of-scope for this task — would need a mayor mail per Polecat scope discipline.)
+4. **The Railway Help Station thread suggests opening a Railway support ticket** if rotations continue at this cadence — sustained 30+ token revocations is unusual enough that it may indicate an account-side issue (plan, billing, security flag) only Railway support can diagnose.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Public API docs (token types, headers, `me` query) | https://docs.railway.com/integrations/api | Confirms the workflow's auth pattern requires an account token |
+| 2 | Railway CLI docs (`RAILWAY_TOKEN` vs `RAILWAY_API_TOKEN` env vars) | https://docs.railway.com/guides/cli | Documents the misleading naming convention |
+| 3 | Railway Login & Tokens reference | https://docs.railway.com/reference/oauth/login-and-tokens | Documents OAuth token TTLs only; silent on account-token TTL |
+| 4 | Railway Help Station — "RAILWAY_TOKEN invalid or expired" | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Community evidence that "invalid or expired" is also emitted for token-type mismatch |
+| 5 | Railway Help Station — "GraphQL requests returning Not Authorized" | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | Moderator-confirmed that `me` query needs personal/account token |
+| 6 | Railway GitHub Actions guide | https://docs.railway.com/tutorials/github-actions-pr-environment | Tutorial context on Railway × GitHub Actions integration |
+| 7 | Railway blog — Using GitHub Actions with Railway | https://blog.railway.com/p/github-actions | General CI/CD integration patterns |


### PR DESCRIPTION
## Summary

- 4th pickup of issue #850 — the 38th `RAILWAY_TOKEN` expiration. Three further `staging-pipeline.yml` runs (`25237747540`, `25229747557`, `25227442673`) failed at `Validate Railway secrets` since PR #851 merged, with the exact signature `RAILWAY_TOKEN is invalid or expired: Not Authorized`.
- Docs-only artifact landing under `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/`. No source / workflow / runbook files are touched, per `CLAUDE.md` § "Railway Token Rotation".
- Merging this PR will **not** turn the pipeline green. A human must still rotate the secret via `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/investigation.md` | CREATE | +163 |
| `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/web-research.md`  | CREATE | +138 |

Total: 2 files, +299 lines (commit `e7783d2`).

## Root Cause (from investigation)

WHY: Latest staging pipeline run `25237747540` ended in `failure`.
↓ BECAUSE: `Deploy to staging` exited 1 at `Validate Railway secrets`.
↓ BECAUSE: The `{me{id}}` probe to `https://backboard.railway.app/graphql/v2` returned `Not Authorized` (`staging-pipeline.yml:49-58`).
↓ ROOT CAUSE: The `RAILWAY_TOKEN` repository secret has not been rotated since PR #851 merged. The `railway-token-health.yml` cron is also still red.

This is a non-code primitive — agents cannot rotate the secret.

## Category-1 Traps Avoided

- ❌ No `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" file created.
- ❌ No edits to `.github/workflows/staging-pipeline.yml`.
- ❌ No edits to `.github/workflows/railway-token-health.yml`.
- ❌ No edits to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
- ❌ No project-token / Railway-CLI refactor (out of scope; would require ~half-day).

## Validation

| Check              | Result | Notes                                                                     |
|--------------------|--------|---------------------------------------------------------------------------|
| Scope verification | ✅     | `git diff --name-only origin/main..HEAD` returns only the two artifact MDs. |
| Type check / Lint / Format / Tests / Build | N/A | Markdown-only diff under `artifacts/runs/<workflow-id>/`. |
| Working tree       | ✅     | Clean; branch 1 commit ahead of `origin/main`.                            |
| Trap re-check      | ✅     | All five Category-1 traps verified avoided in the diff.                   |

Standard CI (pytest, type-check, screenshot tests, build) is not applicable — no source files changed. See `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/validation.md` for the full report.

## Required Human Follow-up (out of agent scope)

Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:

1. Generate a new **account-scoped** Railway token at https://railway.com/account/tokens (workspace/project tokens cannot satisfy the `{me{id}}` probe — see `web-research.md`).
2. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
3. Re-run the failed staging pipeline: `gh run rerun 25237747540 --failed`.
4. Confirm `Validate Railway secrets` passes; deploy proceeds through prod; `railway-token-health.yml` goes green on its next scheduled run.
5. Comment on issue #850 with the green run URL, remove `archon:in-progress`, close the issue.

## Test Plan

- [x] Diff contains only `artifacts/runs/143fba6af8ed9a6eee7eae7c6cc02a7d/{investigation,web-research}.md`.
- [x] No `.github/` paths in the diff.
- [x] No `docs/RAILWAY_TOKEN_ROTATION_742.md` edits.
- [ ] Human rotates `RAILWAY_TOKEN` per runbook.
- [ ] `gh run rerun 25237747540 --failed` goes green end-to-end.
- [ ] Issue #850 closed with green run URL.

Part of #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)