### PR TITLE
docs: investigation for issue #854 (39th RAILWAY_TOKEN expiration, 2nd pickup)

### DIFF
--- a/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/investigation.md
+++ b/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/investigation.md
@@ -1,0 +1,171 @@
+# Investigation: Main CI red — `Deploy to staging` / RAILWAY_TOKEN expired (39th occurrence, issue #854, 2nd pickup)
+
+**Issue**: #854 (https://github.com/alexsiri7/reli/issues/854)
+**Type**: BUG (infrastructure / secret rotation — agent-unactionable)
+**Investigated**: 2026-05-02T02:35:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Staging gate continues to block every push to `main`; latest staging-pipeline run `25239867327` (2026-05-02T01:04:48Z) failed at `Validate Railway secrets` with the same signature seen in 38 prior occurrences. Live app keeps serving traffic and no data is at risk — not CRITICAL. |
+| Complexity | LOW | Zero-line code change. The fix is a human action: generate a new account-scoped Railway token at railway.com and update the GitHub Actions secret `RAILWAY_TOKEN`. No tree edits are appropriate. |
+| Confidence | HIGH | Failure signature is the exact `RAILWAY_TOKEN is invalid or expired: Not Authorized` string emitted by `staging-pipeline.yml` step `Validate Railway secrets`; identical to 38 prior occurrences and to the 1st pickup of this issue (PR #855, workflow `8a2386c3…`). The validator probe is correctly designed and is not the source of the bug. |
+
+---
+
+## Problem Statement
+
+This is the **2nd pickup** of issue #854. The 1st pickup landed PR #855 (merged 2026-05-02T01:00:10Z, workflow `8a2386c3ae1983d14df8161ca0d0849e`) with a docs-only no-op investigation. The cron at 02:30:37Z then re-queued #854 because it found `archon:in-progress` set with no live run and no linked PR — likely a label-cleanup race rather than a new failure mode. Independently, the **most recent staging-pipeline run** (`25239867327`, 2026-05-02T01:04:48Z) **failed with the same signature**, confirming the secret remains unrotated.
+
+Sibling issue #850 has been **closed** (`archon:done`) since the 1st pickup — only #854 is open under this root cause now.
+
+Per `CLAUDE.md` § "Railway Token Rotation", an agent **cannot** rotate this token; the action requires a human with railway.com access. This investigation produces a docs-only artifact pair (this file plus the already-written `web-research.md`) and a restating comment on the issue.
+
+---
+
+## Analysis
+
+### Primitive — first principles
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| Token validity probe | `.github/workflows/staging-pipeline.yml` step `Validate Railway secrets` | Yes | Fails fast on auth error and emits an actionable message; not the source of the bug. |
+| `RAILWAY_TOKEN` GitHub Actions secret | (GitHub UI) | No | Token is rejected by `https://backboard.railway.app/graphql/v2` `{me{id}}` — needs rotation by a human; agents cannot perform this. |
+| `pipeline-health-cron.sh` immediate-fire path | (mayor) | Yes | Auto-files under `archon:in-progress`; correctly suppresses double-pickup *as long as the label is removed only when the issue is actually closed*. |
+| `pipeline-health-cron.sh` re-pickup path | (mayor) | **Partial** | At 02:30:37Z the cron re-fired #854 because the label was still set with no live run — but PR #855 had already been merged 90 minutes earlier with a `Part of #854` reference. The cron's "no linked PR" detection apparently does not count `Part of` references; not in scope to fix here, but worth a follow-up mail to mayor. |
+
+The bug is in a non-code primitive (the secret value). No source change can fix it.
+
+### Root Cause
+
+WHY: Staging-pipeline run `25239867327` (2026-05-02T01:04:48Z, on `main`) ended in `failure`.
+↓ BECAUSE: Job `Deploy to staging` exited 1 in step `Validate Railway secrets` (15s end-to-end runtime — typical of a token-rejection failure).
+↓ BECAUSE: The `{me{id}}` probe to `https://backboard.railway.app/graphql/v2` returned `Not Authorized`.
+  Evidence: `2026-05-02T01:04:55.5764191Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` repository secret is no longer accepted by Railway's API. It has not been rotated since PRs #851 / #853 / #855 / #856 landed prior investigations. PR #855 (1st pickup of #854) was docs-only by policy and could not have changed the secret state.
+  Evidence: `staging-pipeline.yml` issues `curl -X POST … -d '{"query":"{me{id}}"}'`; Railway returns `Not Authorized`. The `railway-token-health.yml` cron's last 3 daily runs (`25211139148` 2026-05-01, `25161724763` 2026-04-30, `25105119767` 2026-04-29) are all `failure`.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (GitHub secret `RAILWAY_TOKEN`) | — | UPDATE | Human rotates via railway.com → repo secrets |
+| (none in source tree) | — | — | No code, workflow, or runbook changes are required or appropriate |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml` consumes the secret for the `{me{id}}` probe and reuses it for the deploy mutations downstream.
+- `.github/workflows/railway-token-health.yml` runs the same probe daily on a schedule; will go green automatically once the secret is rotated.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` is the canonical human runbook. (Note: `web-research.md` § 1 in this artifact directory now flags that the runbook's "select No expiration" instruction is **not corroborated** by official Railway docs — worth a screenshot during the next rotation.)
+
+### Git History
+
+- **PR #855** merged 2026-05-02T01:00:10Z — 1st pickup of #854, docs-only no-op investigation; no source change.
+- **PR #856** merged after #855 — 5th pickup of sibling #850; docs-only; closed #850 via `archon:done`.
+- **No commits to `.github/`** between the 1st and 2nd pickup of #854 — confirming nothing on the agent side has changed (and nothing should).
+- **Implication**: This is still a stuck-on-human-action condition. The cron's re-firing of #854 at 02:30:37Z is a label-tracking artifact, not a new failure mode. Each merge to `main` will continue to file fresh sibling issues until the token is rotated.
+
+---
+
+## Implementation Plan
+
+### Step 1: Human rotates `RAILWAY_TOKEN`
+
+**File**: GitHub Actions secret (out-of-tree)
+**Action**: UPDATE
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:
+
+1. Log into railway.com.
+2. Generate a new **account-scoped** API token at `https://railway.com/account/tokens`. Workspace and project tokens cannot answer `{me{id}}` (see `web-research.md` § 1, § 5 in workflow `8a2386c3…`'s artifact dir, plus this run's `web-research.md` § 1, § 2). **Screenshot the token-creation UI** — `web-research.md` § 1 (this run) found that Railway's official docs do not document any "No expiration" option for any static token type, so the runbook's central instruction is unverified after 39 occurrences.
+3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
+4. Re-run the failed pipeline: `gh run rerun 25239867327 --failed --repo alexsiri7/reli`.
+5. Confirm `Validate Railway secrets` passes and the deploy proceeds through `Deploy staging image to Railway` → `Wait for staging health` → `Staging E2E smoke tests` → `Deploy to production`.
+6. Comment on issue #854 with the green run URL, remove `archon:in-progress`, close. (Sibling #850 is already closed — no need to touch it.)
+7. Verify the next scheduled `railway-token-health.yml` run also goes green.
+
+**Why**: Without this human action, every subsequent merge to `main` will trigger a fresh staging-pipeline failure and `pipeline-health-cron.sh` will keep filing new sibling issues.
+
+---
+
+### Step 2 (Explicitly NOT done — Category 1 traps)
+
+Per `CLAUDE.md`:
+
+- Do NOT create `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming rotation is done.
+- Do NOT edit `.github/workflows/staging-pipeline.yml` — the validator is correctly designed.
+- Do NOT edit `.github/workflows/railway-token-health.yml` — same reasoning.
+- Do NOT edit `docs/RAILWAY_TOKEN_ROTATION_742.md` — canonical runbook owned by separate change.
+- Do NOT swap to `Project-Access-Token` headers — although `web-research.md` § 2 (this run) now confirms the validation query as `query { projectToken { projectId environmentId } }`, the migration also requires changes to deploy-step mutations and `railway up` compatibility verification; out of scope for this emergency bead.
+
+---
+
+## Patterns to Follow
+
+This pickup mirrors the established no-op pattern (PRs #848, #851, #852, #853, #855, #856 — and 35 prior occurrences):
+
+1. Verify the failure signature matches `RAILWAY_TOKEN is invalid or expired`.
+2. Write a short investigation artifact (this file) under `artifacts/runs/<workflow-id>/`.
+3. Post a brief comment on the issue restating the human action.
+4. Land the artifact via PR with `Part of #854` (so `gt done` links it).
+5. Do NOT modify any source/workflow/runbook file.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| `pipeline-health-cron.sh` files yet another sibling issue before the human rotates | Tolerable — comment trail makes the human action obvious; each pickup is a docs-only PR. |
+| Cron's "no linked PR" detection re-picks up #854 again after this PR lands | Possible — PR #855 used `Part of #854` and the cron still re-fired. Acceptable (cost = one more docs-only PR); a follow-up mail to mayor would address the cron logic. |
+| Human rotates but creates a workspace/project token by mistake | `docs/RAILWAY_TOKEN_ROTATION_742.md`, `web-research.md` § 1 (8a2386c3 dir), and `web-research.md` § 1 (this dir) all call out account-scope explicitly. |
+| Token rotation lands while another bead is mid-flight | No conflict — secret rotation is out-of-tree; other PRs proceed unaffected once pipeline is green. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+gh run list --repo alexsiri7/reli --workflow=staging-pipeline.yml --limit 1
+gh run list --repo alexsiri7/reli --workflow=railway-token-health.yml --limit 1
+```
+
+Both should show `success` after rotation.
+
+### Manual Verification
+
+1. Human reruns failed pipeline; `Validate Railway secrets` step passes.
+2. `Deploy to production` step completes `success`.
+3. Issue #854 closed with green run URL.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- This investigation artifact under `artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/`.
+- A brief restating-comment on issue #854 directing the human to the runbook, calling out the "screenshot the No-expiration UI" ask.
+
+**OUT OF SCOPE (do not touch):**
+- `.github/workflows/staging-pipeline.yml`
+- `.github/workflows/railway-token-health.yml`
+- `docs/RAILWAY_TOKEN_ROTATION_742.md`
+- Any `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" file
+- Migrating `staging-pipeline.yml` to a Project token (technically de-risked by `web-research.md` § 2 of this run; still a follow-up issue, not this bead)
+- Investigating the cron's "no linked PR" detection so `Part of` references are recognized (mail to mayor as a separate bead)
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T02:35:00Z
+- **Workflow ID**: 0aa164affe30087c42fdb1f17b4c013d
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/investigation.md`
+- **Companion**: `web-research.md` in the same directory (confirmation of token-validation queries and absence of documented "No expiration" UI; written before this artifact)
+- **Prior pickup**: PR #855 / workflow `8a2386c3ae1983d14df8161ca0d0849e` (1st pickup, merged 2026-05-02T01:00:10Z)
+- **Sibling open issue**: none (#850 closed `archon:done` after the 5th pickup landed in PR #856)
+- **Latest failing run**: `25239867327` (2026-05-02T01:04:48Z, branch `main`)

--- a/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/web-research.md
+++ b/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/web-research.md
@@ -1,0 +1,177 @@
+---
+name: Web Research — Issue #854 (RAILWAY_TOKEN expiration, 39th occurrence, 2nd pickup)
+description: Web research informing the recurring RAILWAY_TOKEN failure; this run confirms the Project-token validation query and the absence of any official "No expiration" UI option, building on prior workflow 8a2386c3
+---
+
+# Web Research: fix #854
+
+**Researched**: 2026-05-02T02:35:00Z
+**Workflow ID**: `0aa164affe30087c42fdb1f17b4c013d`
+**Issue**: [#854 — Main CI red: Deploy to staging](https://github.com/alexsiri7/reli/issues/854) (39th occurrence of `RAILWAY_TOKEN is invalid or expired: Not Authorized` in `staging-pipeline.yml` step `Validate Railway secrets`).
+
+**Prior art**: Workflow `8a2386c3ae1983d14df8161ca0d0849e` (~2h earlier today) produced a comprehensive `web-research.md` for the same issue. This document does **not** restate that work verbatim — it confirms the open questions from that artifact against authoritative Railway docs and adds two new findings.
+
+Path of prior artifact: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/8a2386c3ae1983d14df8161ca0d0849e/web-research.md`
+
+---
+
+## Summary
+
+Two questions were left open by prior research and are now answered:
+
+1. **The official Railway API docs do NOT document any "No expiration" option** for any token type (account, workspace, or project). The internal runbook `docs/RAILWAY_TOKEN_ROTATION_742.md` instructs the rotator to "select No expiration", but no public Railway documentation corroborates such a UI affordance exists. This makes the runbook's central premise unverified — a likely reason the issue has now recurred 39 times.
+2. **The Project-token validation query is now confirmed** as `query { projectToken { projectId environmentId } }` (verbatim from Railway's Public API docs). This was marked "confirm against the GraphQL schema before implementing" in prior research — it is now a known-good probe, removing the technical blocker for migrating `staging-pipeline.yml` to a Project token.
+
+The 2025/2026 Railway changelog contains **no** token-related entries, so the community claim ("Railway changed token requirements") is not officially substantiated; the recurrence pattern is the only evidence that something has shifted.
+
+Action posture is unchanged: agent cannot rotate the token; human action against railway.com + GitHub Actions secrets is the only fix. See investigation.md for the human checklist.
+
+---
+
+## Findings
+
+### 1. Confirmed: Railway docs document NO expiration UI for any static token
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api) (fetched 2026-05-02)
+**Authority**: Official Railway documentation
+**Relevant to**: The runbook's "select No expiration" instruction.
+
+**Key Information** (verbatim from the fetched page summary):
+
+| Token type | Auth header | Docs example validation query | TTL/expiration mentioned? |
+|------------|-------------|-------------------------------|---------------------------|
+| Account    | `Authorization: Bearer <API_TOKEN>` | `query { me { name email } }` | **No** |
+| Workspace  | `Authorization: Bearer <WORKSPACE_TOKEN>` | `query { workspace(workspaceId: "<WORKSPACE_ID>") { name id } }` | **No** |
+| Project    | `Project-Access-Token: <PROJECT_TOKEN>` | `query { projectToken { projectId environmentId } }` | **No** |
+
+The docs do not describe the token-creation UI's expiration controls at all. The OAuth flow (a separate concept, not what CI uses) is documented as 1-hour access tokens / 1-year refresh tokens — no relation to the static `RAILWAY_TOKEN` secret.
+
+**Why this matters**: The runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md` line 22) tells the human "**Expiration: No expiration** (critical — do not accept default TTL)". If this UI option does not exist, the runbook is impossible to follow correctly, and every "rotation" produces a token with whatever the default TTL is. After 39 occurrences this is the most plausible failure mode — the runbook itself is the bug.
+
+**What to do next**: When the human next rotates, screenshot the Railway token-creation UI. Either (a) confirm "No expiration" exists and was missed previously, or (b) confirm it doesn't exist and update the runbook to reflect the actual default TTL.
+
+---
+
+### 2. Confirmed: Project-token validation query
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: The Project-token migration path proposed in prior research §3 / Recommendation 3.
+
+**Key Information**: The exact query the validator step would use after migration is:
+
+```bash
+curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ projectToken { projectId environmentId } }"}'
+```
+
+A non-error response with both fields populated means the token is valid for the bound environment.
+
+Prior research left this query as an unverified hypothesis. With the official docs example in hand, the migration is now technically a one-PR change:
+
+1. Generate a Project token under the project's Settings → Tokens (not Account → Tokens).
+2. Update the `RAILWAY_TOKEN` GitHub Actions secret with the new token.
+3. Edit `.github/workflows/staging-pipeline.yml`:
+   - Change `Authorization: Bearer ***` → `Project-Access-Token: ***`.
+   - Change `'{"query":"{me{id}}"}'` → `'{"query":"{ projectToken { projectId environmentId } }"}'`.
+   - Update the success check from `.data.me.id` → `.data.projectToken.projectId`.
+4. Confirm the deploy job (which presumably uses the Railway CLI's `railway up` or similar) still works — the CLI accepts `RAILWAY_TOKEN` in either form, but verify against the deploy step.
+
+**This is still out of scope for issue #854.** The change is clearly defined now, but #854 is a "rotate the secret" ticket, not a "refactor the auth model" ticket. Send to mayor as a follow-up, per polecat scope discipline.
+
+---
+
+### 3. Confirmed: No 2025–2026 changelog entries on token behavior
+
+**Source**: [Changelog | Railway](https://railway.com/changelog)
+**Authority**: Official Railway product changelog
+**Relevant to**: The community claim ([Help Station thread](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)) that "Railway changed its token requirements".
+
+**Key Information**: A scan of 2025/2026 changelog entries returned **no** mentions of API tokens, account tokens, project tokens, expiration, rotation, or session/token revocation. Entries in the period cover features like Undoable Volume Deletes, Railway Agent, IPv6, CDN integration, and AI features — nothing in the auth/token space.
+
+**Implication**: The "Railway changed token requirements" claim from the community thread is **unsupported by official sources**. It remains a hypothesis. The 39-occurrence pattern could equally be explained by (a) the runbook's "No expiration" step being wrong (Finding 1), or (b) Railway silently expiring tokens on a TTL the docs don't disclose, or (c) some account-level event (password reset, plan downgrade) that is not documented as a token-revoking event.
+
+---
+
+### 4. Strengthened: Community thread says project tokens are now mandatory
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20) (re-fetched 2026-05-02)
+**Authority**: Community user (`bytekeim`); no Railway staff confirmation
+**Relevant to**: Whether the repo's account-token approach is structurally obsolete.
+
+**Key information** (paraphrased from the fetched thread):
+
+- The OP reported the same `RAILWAY_TOKEN invalid or expired` message and that recreating the token "does nothing".
+- `bytekeim` claimed "RAILWAY_TOKEN now only accepts project token" — that account tokens no longer work for the `RAILWAY_TOKEN` slot. Recommended fix: generate the token under project settings, not account settings; remove any `RAILWAY_API_TOKEN` variable.
+- **Railway staff did not respond directly** to the token-type claim — only automated suggestions linking to other issues. So this is community lore, not vendor-confirmed.
+
+**Implication**: This thread, taken with Finding 1 (no documented "No expiration" option for account tokens) and Finding 2 (Project-token migration is technically straightforward), strengthens the case for migrating off account tokens — even though prior research correctly classified it as out of scope for #854.
+
+---
+
+## Code Examples
+
+Current validator (account token, account-token query — what's failing):
+
+```bash
+# .github/workflows/staging-pipeline.yml — current
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+echo "$RESP" | jq -e '.data.me.id' > /dev/null \
+  || { echo "::error::RAILWAY_TOKEN is invalid or expired: $(echo "$RESP" | jq -r '.errors[0].message')"; exit 1; }
+```
+
+Migration target (Project token, Project-token query — confirmed against [official docs](https://docs.railway.com/integrations/api)):
+
+```bash
+# .github/workflows/staging-pipeline.yml — proposed (FOLLOW-UP, NOT FOR #854)
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Project-Access-Token: ${{ secrets.RAILWAY_TOKEN }}" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ projectToken { projectId environmentId } }"}')
+echo "$RESP" | jq -e '.data.projectToken.projectId' > /dev/null \
+  || { echo "::error::RAILWAY_TOKEN (project token) rejected: $(echo "$RESP" | jq -r '.errors[0].message')"; exit 1; }
+```
+
+---
+
+## Gaps and Conflicts
+
+- **The "No expiration" UI claim is now actively contradicted** by the absence of any such option in the Railway docs (Finding 1). It's still possible the option exists in the live UI and is undocumented — only a screenshot from the next human rotation will resolve this.
+- **Railway staff have not publicly confirmed or denied the "account tokens no longer work" hypothesis** (Finding 4). Worth posting on the Help Station as a follow-up to get an authoritative answer, but that's beyond what an automated agent can do.
+- **No upstream changelog signal** for any of this. If Railway tightened token policy, they didn't announce it (Finding 3).
+- **CLI behavior** with project vs account tokens for the actual `railway up` deploy step is still unverified. The validator change is well-defined; the deploy-step compatibility needs to be tested in a follow-up branch before any migration ships.
+
+---
+
+## Recommendations
+
+Carrying forward the prior research's recommendations, with two updates from this run:
+
+1. **Do NOT rotate the token from this agent.** Unchanged — Category 1 trap per `CLAUDE.md`.
+
+2. **When the human next rotates, capture ground truth on the "No expiration" option.** Now upgraded to **HIGH PRIORITY**: the docs explicitly do not describe such an option, so the runbook is suspect until proven correct. Screenshot the UI either way.
+
+3. **Migrate the deploy job to a Project token (follow-up issue).** Now technically de-risked — the validator query is `query { projectToken { projectId environmentId } }` per official docs, and the diff to `staging-pipeline.yml` is mechanically small. Still out of scope for #854; send to mayor.
+
+4. **Long-term: investigate OAuth refresh-token flow.** Unchanged — eliminates static-token recurrence entirely but is significant net-new work.
+
+5. **Do not modify the validation step in this PR.** Unchanged — the validator is correctly catching the bug, not causing it.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Docs — Public API (re-fetched 2026-05-02) | https://docs.railway.com/integrations/api | Confirmed: validation queries per token type; no expiration UI documented |
+| 2 | Railway Docs — Login & Tokens | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth/refresh — separate from static API tokens; no static-token TTL |
+| 3 | Railway — Changelog (scanned 2025–2026) | https://railway.com/changelog | Confirmed: no token-related entries in the relevant period |
+| 4 | Railway Help Station — RAILWAY_TOKEN invalid or expired (re-fetched 2026-05-02) | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Community claim: account tokens no longer accepted; no Railway staff confirmation |
+| 5 | Railway Help Station — GraphQL "Not Authorized" for PAT | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | Community note: `me` query requires personal/account token |
+| 6 | Railway Blog — Using GitHub Actions with Railway | https://blog.railway.com/p/github-actions | Official recommendation to use Project tokens for CI |
+| 7 | Prior research artifact (workflow `8a2386c3…`) | `artifacts/runs/8a2386c3ae1983d14df8161ca0d0849e/web-research.md` | Comprehensive baseline this artifact builds on, not duplicates |

--- a/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/web-research.md
+++ b/artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/web-research.md
@@ -46,7 +46,7 @@ Action posture is unchanged: agent cannot rotate the token; human action against
 
 The docs do not describe the token-creation UI's expiration controls at all. The OAuth flow (a separate concept, not what CI uses) is documented as 1-hour access tokens / 1-year refresh tokens — no relation to the static `RAILWAY_TOKEN` secret.
 
-**Why this matters**: The runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md` line 22) tells the human "**Expiration: No expiration** (critical — do not accept default TTL)". If this UI option does not exist, the runbook is impossible to follow correctly, and every "rotation" produces a token with whatever the default TTL is. After 39 occurrences this is the most plausible failure mode — the runbook itself is the bug.
+**Why this matters**: The runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md` lines 20, 26) instructs the human to set "**Expiration: No expiration** (critical — do not accept default TTL)". If this UI option does not exist, the runbook is impossible to follow correctly, and every "rotation" produces a token with whatever the default TTL is. After 39 occurrences this is the most plausible failure mode — the runbook itself is the bug.
 
 **What to do next**: When the human next rotates, screenshot the Railway token-creation UI. Either (a) confirm "No expiration" exists and was missed previously, or (b) confirm it doesn't exist and update the runbook to reflect the actual default TTL.
 


### PR DESCRIPTION
## Summary

2nd pickup of #854 — the 39th occurrence of the `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure in the `Deploy to staging` job. The root cause is **out-of-tree**: the `RAILWAY_TOKEN` GitHub Actions secret has been rejected by `https://backboard.railway.app/graphql/v2` and must be rotated by a human (railway.com → repo secrets). Per `CLAUDE.md` § "Railway Token Rotation", agents cannot perform this action.

This PR is the established docs-only no-op pattern: it lands the investigation artifact pair so the cron has a linked PR for #854 and the next pickup has full context.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/investigation.md` | CREATE | +172 |
| `artifacts/runs/0aa164affe30087c42fdb1f17b4c013d/web-research.md` | CREATE | +177 |

No source, workflow YAML, runbook, or `.github/` content was modified — that would be a Category 1 trap.

## Why no code change

Per the investigation:

- The token-validity probe in `.github/workflows/staging-pipeline.yml` (`Validate Railway secrets` step) is correctly designed and is **not** the source of the bug.
- The bug is in a non-code primitive: the secret value itself.
- Producing a `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" file is explicitly forbidden by `CLAUDE.md` (it would claim completion of an action only a human can perform).
- Latest failing run: `25239867327` (2026-05-02T01:04:48Z, branch `main`).

## Human action required (out of scope for this PR)

Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:

1. Generate a new **account-scoped** API token at https://railway.com/account/tokens (workspace/project tokens cannot answer the `{me{id}}` probe).
2. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
3. `gh run rerun 25239867327 --failed --repo alexsiri7/reli`.
4. Confirm `Deploy to production` reaches `success` and close #854.

## Validation

| Check | Result |
|-------|--------|
| Type check | N/A — docs-only diff |
| Lint | N/A — docs-only diff |
| Tests | N/A — docs-only diff |
| Build | N/A — docs-only diff |
| Working tree clean | ✅ |
| Commit references issue (`Part of #854`) | ✅ |

The standard validation suite does not apply: there is no source on the branch to exercise. The two `gh run list` checks called out in the investigation's Validation section only go green **after the human rotates the token** and are not gateable on this PR.

## Notes for reviewer

- 1st pickup of #854 was PR #855 (merged 2026-05-02T01:00:10Z) — same docs-only no-op pattern. The cron at 02:30:37Z re-fired #854 because `archon:in-progress` lingered with no detected linked PR. The investigation flags as a follow-up: the cron's "no linked PR" check apparently does not count `Part of #N` references; not fixed here per polecat scope discipline.
- Sibling #850 is already closed (`archon:done`) since PR #856 landed; only #854 remains open under this root cause.
- `web-research.md` § 1 in this run flags a discrepancy worth tracking on the next rotation: the `docs/RAILWAY_TOKEN_ROTATION_742.md` runbook's "select No expiration" instruction is **not corroborated** by official Railway docs. Worth a screenshot during rotation.

Part of #854