### PR TITLE
docs: investigation for issue #860 (41st RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md
+++ b/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md
@@ -1,0 +1,188 @@
+# Investigation: Prod deploy failed on main (#860)
+
+**Issue**: #860 (https://github.com/alexsiri7/reli/issues/860)
+**Type**: BUG
+**Investigated**: 2026-05-02
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | CRITICAL | The `Validate Railway secrets` pre-flight gates every deploy step; with it failing, no staging or production release can land until the token is rotated — this is an authentication outage on the deploy pipeline, not a code defect. |
+| Complexity | LOW | No source files change. Recovery is a 3-step manual rotation in the Railway dashboard plus a `gh secret set` and a re-run; the bug exists exclusively in external secret state. |
+| Confidence | HIGH | The failed step's stderr (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) is unambiguous, the validator code is intact, and this is the 41st occurrence of the identical pattern with a documented runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`). |
+
+---
+
+## Problem Statement
+
+The `Validate Railway secrets` step in the `Deploy to staging` job (workflow `Staging → Production Pipeline`, run [25242236208](https://github.com/alexsiri7/reli/actions/runs/25242236208)) failed because Railway's GraphQL endpoint rejected `RAILWAY_TOKEN` with `Not Authorized` when probing `{ me { id } }`. Because this validation gates the actual `serviceInstanceUpdate` deploy mutation, no staging/production release can land until the GitHub Actions secret `RAILWAY_TOKEN` is rotated by a human with railway.com access.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+The token stored in the GitHub Actions secret `RAILWAY_TOKEN` is no longer accepted by Railway's GraphQL API. The workflow's pre-flight authentication probe (`.github/workflows/staging-pipeline.yml:49-58`) correctly catches this and refuses to proceed, which is the intended fail-fast behaviour — there is no code regression here. The fix lives entirely outside the repo: a human must mint a new account-scoped Railway API token and overwrite the GitHub secret.
+
+### Evidence Chain
+
+WHY: Why did the prod deploy run fail?
+↓ BECAUSE: The `Deploy to staging` job exited 1 in the `Validate Railway secrets` step.
+  Evidence: workflow log — `##[error]Process completed with exit code 1.` at `2026-05-02T03:04:50.0824485Z`.
+
+↓ BECAUSE: Why did that step exit 1?
+  Evidence: log line `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` at `2026-05-02T03:04:50.0814013Z`.
+
+↓ BECAUSE: Why was the token rejected?
+  Evidence: `.github/workflows/staging-pipeline.yml:49-58` posts `{me{id}}` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN` and inspects `.data.me.id`. Railway returned `errors[0].message == "Not Authorized"` instead of a `me.id`.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret holds an account-scoped Railway API token that has been revoked or has expired (or, per `web-research.md` Finding #2, may have been minted with a workspace bound rather than "No workspace" — silent rejection mode).
+  Evidence: Identical failure mode to 40 prior closed issues, all resolved by rotating the token via `docs/RAILWAY_TOKEN_ROTATION_742.md` with no source change. The canonical prior-occurrence list is reproducible by `gh issue list --repo alexsiri7/reli --search '"RAILWAY_TOKEN" "Not Authorized"' --state closed --json number -q '.[].number'`; commit-history numbering pins #850 = 38th, #854 = 39th, #858 = 40th, #860 = 41st.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none — code) | — | — | No source/workflow change is required or appropriate. |
+| GitHub secret `RAILWAY_TOKEN` | n/a | ROTATE (human) | Replace with a freshly-issued account-scoped Railway API token (No expiration, No workspace). |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step (the failing pre-flight)
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` step (gated by the validate step; would fail equivalently if reached, since it uses the same `Authorization: Bearer $RAILWAY_TOKEN`)
+- `.github/workflows/railway-token-health.yml` — independent token-health probe (daily `0 9 * * *` cron); will also fail on the same secret until rotated
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the canonical rotation runbook
+- `DEPLOYMENT_SECRETS.md` — CI secret setup reference (linked from the validator's error message)
+
+### Git History
+
+- **Failing commit**: `3570101` ("docs: investigation for issue #854 (39th RAILWAY_TOKEN expiration, 2nd pickup) (#857)") — docs-only, cannot have caused this.
+- **Validator step provenance**: `git log --oneline .github/workflows/staging-pipeline.yml` shows the `Validate Railway secrets` pattern is well-established; it has not been modified in any recent commit.
+- **Implication**: Not a regression. This is recurring secret-rotation toil — the token issued during the previous rotation has now been revoked or has expired again.
+
+---
+
+## Implementation Plan
+
+> **Agent-side: NO CODE CHANGES.** Per `CLAUDE.md` § "Railway Token Rotation":
+>
+> > Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. File a GitHub issue or send mail to mayor with the error details. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+>
+> Producing such a marker file would be a Category 1 error.
+
+### Step 1: Document the failure (agent action)
+
+**File**: `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md`
+**Action**: CREATE (this file)
+
+Captures the failing run URL, the exact error string, the rotation runbook pointer, and the prior-occurrence count so the human has a one-stop summary.
+
+### Step 2: Post investigation comment on #860 (agent action)
+
+Use `gh issue comment 860` with a formatted summary so the human can act without opening Actions logs.
+
+### Step 3: Human rotation per runbook (NOT an agent action)
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` (with the additional setting flagged by `web-research.md` Finding #2):
+
+1. Sign in at https://railway.com/account/tokens.
+2. Create a new **account-scoped** API token. Required settings:
+   - Name: `github-actions-permanent` (or `gh-actions-2026-05-02`).
+   - **Expiration: No expiration** (critical — do not accept the default TTL).
+   - **Workspace: No workspace** (per Railway support thread; workspace-bound tokens silently fail the `me { id }` probe).
+3. Update the GitHub Actions secret:
+   ```bash
+   gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+   # Paste the new token when prompted
+   ```
+4. Verify token before re-deploying:
+   ```bash
+   gh workflow run railway-token-health.yml --repo alexsiri7/reli
+   gh run watch <new-run-id> --repo alexsiri7/reli
+   ```
+5. Re-run the failed pipeline:
+   ```bash
+   gh run rerun 25242236208 --repo alexsiri7/reli --failed
+   ```
+6. Confirm the `Validate Railway secrets` step passes; close #860 with the green run URL.
+7. (Optional but useful) Revoke the previous token in Railway after the new one verifies green, to limit overlap.
+
+### Step 4: Verify (after human rotation)
+
+- `Validate Railway secrets` step succeeds (`me.id` returned).
+- `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no `errors`.
+- Health check on `RAILWAY_STAGING_URL` reports 200.
+- `railway-token-health.yml` next scheduled run is green.
+
+---
+
+## Patterns to Follow
+
+This issue's documentation pattern mirrors the prior 40 instances. Reference the most recent pair (issue #858, PR #859) for the docs-only investigation pattern.
+
+The runbook itself (`docs/RAILWAY_TOKEN_ROTATION_742.md`) is the canonical procedure — do not duplicate or fork it.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Cron re-fires #860 before rotation completes | Issue is labelled `archon:in-progress`; the pickup cron skips while that label is present. Do not strip the label until the deploy goes green. |
+| Cron re-fires #860 after PR merges (label cleared early) | Prior issues (#854) saw this; harmless but wasteful. Out of scope for this fix — track separately if it recurs. |
+| New token rotates green but next deploy still fails | Likely a separate issue (e.g., revoked service ID, image registry permissions). Re-investigate from logs; do **not** assume same root cause. |
+| Token created with workspace bound (silent rejection) | Web-research Finding #2: ensure the Railway dashboard token is created with **"No workspace"** selected, otherwise `me { id }` returns `Not Authorized` even on a fresh token. |
+| Human believes agent rotated the token because of a `.github/RAILWAY_TOKEN_ROTATION_*.md` file | Do **not** create such a file. The runbook is the only canonical rotation doc. |
+| Pickup cron fires for #860 after this PR — generating a duplicate investigation | Standard pattern: the next investigator should add a `(2nd pickup)` suffix and reuse the same artifact directory style as #850 (#853, #856). |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# Agent-side: docs-only diff. Standard suite is vacuously passing.
+# The actual signal lives in the deploy pipeline, which only goes green
+# AFTER the human rotates the token:
+gh workflow run railway-token-health.yml --repo alexsiri7/reli   # post-rotation sanity check
+gh run rerun 25242236208 --repo alexsiri7/reli --failed
+gh run watch <new-run-id> --repo alexsiri7/reli
+```
+
+### Manual Verification (post-rotation)
+
+1. The re-run of [25242236208](https://github.com/alexsiri7/reli/actions/runs/25242236208) reaches the `Deploy staging image to Railway` step and exits 0.
+2. `RAILWAY_STAGING_URL` returns the freshly-deployed SHA (`3570101`) on `/api/version` (or equivalent health endpoint).
+3. `railway-token-health.yml` next scheduled run reports green.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE (agent):**
+- Investigate the failed run, identify the recurring root cause.
+- Produce this investigation artifact under `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/`.
+- Post a summary comment on issue #860 directing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating the Railway API token (human-only — railway.com access required).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker (Category 1 error per `CLAUDE.md`).
+- Editing `.github/workflows/staging-pipeline.yml`, `railway-token-health.yml`, or `docs/RAILWAY_TOKEN_ROTATION_742.md` — none are wrong; the secret is.
+- Adding the "No workspace" instruction to the runbook (separate scope — file as a follow-up issue if pursued; per Polecat Scope Discipline, surface as mail to mayor rather than expanding this PR).
+- Designing token-expiration mitigations (longer-lived tokens, automatic rotation, OIDC federation) — Railway doesn't support OIDC today (web-research Finding #6); file separate issues if pursued.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md`
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25242236208
+- **Failing SHA**: `3570101c6de497ab5171c7a2c1fdd70baa411a57`
+- **Prior occurrences**: 40 (this is #41)
+- **Runbook**: `docs/RAILWAY_TOKEN_ROTATION_742.md`
+- **Companion artifact**: `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md`

--- a/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md
+++ b/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md
@@ -10,7 +10,7 @@
 
 | Check | Result | Details |
 |-------|--------|---------|
-| Diff scope | ✅ | Docs-only — 2 markdown artifacts, 0 source files |
+| Diff scope | ✅ | Docs-only — 3 markdown artifacts, 0 source files |
 | Type check | ⏭️ N/A | No TS/Python source changed |
 | Lint | ⏭️ N/A | No source changed |
 | Format | ⏭️ N/A | No source changed |
@@ -27,8 +27,9 @@
 
 ```
 artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md  | 188 +++++
+artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md     |  97 +++++
 artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md   | 195 +++++
-2 files changed, 383 insertions(+)
+3 files changed, 480 insertions(+)
 ```
 
 No source files (`backend/`, `frontend/`, `scripts/`), no workflows (`.github/workflows/`), no
@@ -85,8 +86,8 @@ See `docs/RAILWAY_TOKEN_ROTATION_742.md` for the canonical runbook.
 
 ## Files Modified During Validation
 
-None. Validation produced no fixes because there was nothing to fix — the diff is two
-investigation artifacts, both already authored in the previous step.
+None. Validation produced no fixes because there was nothing to fix — the diff is three
+investigation artifacts, all authored as part of this workflow run.
 
 ---
 

--- a/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md
+++ b/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md
@@ -1,0 +1,97 @@
+# Validation Results
+
+**Generated**: 2026-05-02
+**Workflow ID**: 31b45d722d1961ae59edfe9b72e7cf08
+**Status**: ALL_PASS (vacuously — docs-only diff)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Diff scope | ✅ | Docs-only — 2 markdown artifacts, 0 source files |
+| Type check | ⏭️ N/A | No TS/Python source changed |
+| Lint | ⏭️ N/A | No source changed |
+| Format | ⏭️ N/A | No source changed |
+| Tests | ⏭️ N/A | No source/test changed |
+| Build | ⏭️ N/A | No source changed |
+| Real signal | ⏳ BLOCKED on human | Deploy pipeline cannot pass until `RAILWAY_TOKEN` is rotated |
+
+---
+
+## Diff Scope
+
+**Command**: `git diff origin/main --stat`
+**Result**: ✅ Pass — docs-only
+
+```
+artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md  | 188 +++++
+artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md   | 195 +++++
+2 files changed, 383 insertions(+)
+```
+
+No source files (`backend/`, `frontend/`, `scripts/`), no workflows (`.github/workflows/`), no
+runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`), no `CLAUDE.md`, and (correctly) no
+`.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker.
+
+---
+
+## Standard Suite
+
+The plan's "Validation Commands" block (`investigation.md` § Validation → Automated Checks)
+explicitly states:
+
+> Agent-side: docs-only diff. Standard suite is vacuously passing. The actual signal
+> lives in the deploy pipeline, which only goes green AFTER the human rotates the token.
+
+Running `npm run lint` / `npm run build` / `pytest` against unchanged code would produce
+the same result as on `main` (whatever that may be) and would not be evidence of fitness
+for this PR. They are intentionally skipped.
+
+### Why "vacuously passing" is the right call here
+
+| Concern | Reasoning |
+|---------|-----------|
+| Could the docs change break a linter? | No — neither `eslint` (frontend) nor `ruff`/`mypy` (backend) inspects `artifacts/**/*.md`. |
+| Could the docs change break tests? | No — pytest collection roots (`backend/`, `tests/`) and vitest globs (`frontend/src/**`) do not include `artifacts/`. |
+| Could the docs change break the build? | No — `vite build` and the Dockerfile do not bundle `artifacts/`. |
+| Could the docs change affect CI? | No — `.github/workflows/ci.yml` was not modified on this branch. |
+
+---
+
+## Real Validation (post-human-rotation)
+
+Per `investigation.md` § Validation → Manual Verification, the real green signal is:
+
+1. `Validate Railway secrets` step succeeds (returns `me.id`) on rerun of run
+   [25242236208](https://github.com/alexsiri7/reli/actions/runs/25242236208).
+2. `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no `errors`.
+3. Health check on `RAILWAY_STAGING_URL` reports 200.
+4. `railway-token-health.yml` next scheduled run is green.
+
+These cannot be agent-validated — they require a human to:
+
+```bash
+# In Railway dashboard: mint new account-scoped token (No expiration, No workspace)
+gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run rerun 25242236208 --repo alexsiri7/reli --failed
+```
+
+See `docs/RAILWAY_TOKEN_ROTATION_742.md` for the canonical runbook.
+
+---
+
+## Files Modified During Validation
+
+None. Validation produced no fixes because there was nothing to fix — the diff is two
+investigation artifacts, both already authored in the previous step.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update the PR (already exists implicitly via the
+`archon/task-archon-fix-github-issue-1777692623356` branch) and post the investigation
+summary on issue #860 directing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.

--- a/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md
+++ b/artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md
@@ -1,0 +1,195 @@
+# Web Research: fix #860
+
+**Researched**: 2026-05-02T00:00:00Z (date of writing)
+**Workflow ID**: 31b45d722d1961ae59edfe9b72e7cf08
+
+---
+
+## Summary
+
+Issue #860 is the **41st** consecutive `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure on the prod deploy pipeline, blocked at the "Validate Railway secrets" pre-flight that issues a `{me{id}}` GraphQL probe to `https://backboard.railway.app/graphql/v2` with an `Authorization: Bearer` header. Web research surfaces two structural fixes the existing rotation runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) does not address: (a) the `me { id }` query and `Authorization: Bearer` header only work with **account/personal tokens** — not the project tokens that `RAILWAY_TOKEN` is documented for — and Railway support has explicitly stated personal tokens must be generated with **"No workspace"** selected to avoid silent rejection; (b) Railway provides **no OIDC/federated** alternative to long-lived tokens, so the only durable mitigations are creating a non-expiring account token and adding a **proactive weekly health check** (already present at `.github/workflows/railway-token-health.yml`) so rotations happen ahead of a prod deploy, not on top of one. The root cause is a procedural/configuration mismatch — not a Railway platform bug — and the fix has to be human-driven each time.
+
+---
+
+## Findings
+
+### 1. The validator's `{me{id}}` query requires an **account/personal token**, not a project token
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/guides/public-api)
+**Authority**: Official Railway documentation
+**Relevant to**: Diagnosing whether the secret stored as `RAILWAY_TOKEN` is the right *type* of token
+
+**Key Information**:
+
+- Railway has four auth methods: **account tokens**, **workspace tokens**, **project tokens**, and **OAuth tokens**.
+- Header convention is **type-dependent**:
+  - Account / workspace / OAuth → `Authorization: Bearer <TOKEN>`
+  - Project → `Project-Access-Token: <TOKEN>` (NOT `Authorization: Bearer`)
+- The `query { me { id email } }` GraphQL query "cannot be used with workspace or project tokens because the data returned is scoped to your personal account" — only **personal/account access tokens** can resolve `me`.
+- Reli's `.github/workflows/staging-pipeline.yml` validator uses `Authorization: ***` + `{me{id}}` against `backboard.railway.app/graphql/v2`. That probe shape implies the secret in `RAILWAY_TOKEN` must be an **account token** for validation to pass.
+
+**Implication**: If the rotator ever pastes a project token (or a workspace token) into `RAILWAY_TOKEN`, the validator will return `Not Authorized` even with a brand-new, non-expired token. This is consistent with the recurring "rotated yesterday, broken today" pattern.
+
+---
+
+### 2. Railway support: account tokens must be created with **"No workspace"** selected
+
+**Source**: [API Token "Not Authorized" Error for Public API and MCP — Railway Help Station](https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1)
+**Authority**: Official Railway support thread (resolved)
+**Relevant to**: How the token must be created in the dashboard
+
+**Key Information**:
+
+- "Personal API tokens should grant full access to your personal resources. However, some users have reported that personal API tokens don't work with the GraphQL endpoint."
+- The thread's resolved fix: navigate to **personal Account Settings** (not project settings), generate a new token, **explicitly select "No workspace"** rather than the default workspace.
+- Tokens silently authenticate against a different scope when bound to a workspace — they will not satisfy `me { id }` queries.
+
+**Implication**: The Reli rotation runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) tells the human to "Create a new Railway token … Name: `github-actions-permanent`, Expiration: No expiration" but does **not** tell them to select "No workspace". Adding this step will likely eliminate the most common silent failure mode.
+
+---
+
+### 3. Railway Help Station explicit confirmation: `RAILWAY_TOKEN` and account tokens are not interchangeable
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)
+**Authority**: Railway support thread (multiple confirmed resolutions)
+**Relevant to**: Naming conflict between Reli's secret and the CLI's expected token type
+
+**Key Information**:
+
+- A Railway user states: *"RAILWAY_TOKEN now only accepts project token; if u put the normal account token … it literally says 'invalid or expired' even if u just made it 2 seconds ago."*
+- For CLI-level CI/CD use, Railway's docs prescribe:
+  - `RAILWAY_TOKEN` → **project token** (`railway up` style deploys, scoped to one environment)
+  - `RAILWAY_API_TOKEN` → **account or workspace token** (cross-project / account-level operations)
+- If both are set, `RAILWAY_TOKEN` takes precedence in the CLI.
+
+**Implication**: There is a **naming conflict** in Reli's setup. The validator script needs an account token (because it queries `me`), but the env var it uses (`RAILWAY_TOKEN`) is the slot the Railway CLI expects to be a project token. The current pipeline works only because the validator hits the GraphQL API directly via `curl`, not via the CLI. If the team ever introduces `railway up` or `railway redeploy`, the same secret will mysteriously fail. The cleaner long-term fix is to rename the secret to `RAILWAY_API_TOKEN` for the validator and switch to `Project-Access-Token` + project tokens for the actual deploy steps.
+
+---
+
+### 4. Token expiration is **set at creation time**; default is not "no expiration"
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens), [Token for GitHub Action — Railway Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+**Authority**: Official Railway documentation + support thread
+**Relevant to**: Why expiration keeps recurring (41 incidents)
+
+**Key Information**:
+
+- Railway's published docs only describe the OAuth path explicitly: **"Access tokens expire after one hour."** Refresh tokens have a 1-year rolling lifetime when issued with `offline_access`.
+- For account / workspace / project tokens (the dashboard-generated kind used in CI), Railway docs do **not** publish a default TTL. The dashboard UI offers an expiration picker, and selecting "No expiration" is required to get a permanent token.
+- Reli's existing runbook captures this: *"the default TTL may be short (e.g., 1 day or 7 days). Previous rotations may have used these defaults. The new token must be created with 'No expiration'."* Yet the issue keeps recurring 41 times — strong signal the human is either (a) missing the "No expiration" toggle on rotation, (b) creating a workspace-bound token that is silently rejected, or (c) the token is being revoked by Railway for an unrelated reason (workspace change, account event, refresh-token rotation).
+
+**Implication**: The dashboard step is the failure point. The runbook needs more defensive checks — ideally, after pasting the new token into the GitHub secret, the human should run `gh workflow run railway-token-health.yml` immediately (the health check workflow already exists in this repo) and verify the **next scheduled** Monday run also passes, before considering the rotation done.
+
+---
+
+### 5. Refresh-token rotation can silently revoke an entire authorization chain
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens)
+**Authority**: Official Railway documentation
+**Relevant to**: An alternative explanation for unexpected expirations (OAuth-derived tokens only)
+
+**Key Information**:
+
+- Refresh tokens are rotated for security. *"If your user's authorization is suddenly revoked when using a refresh token, you likely used an old, already-rotated token. As a security measure, using a rotated refresh token immediately revokes the entire authorization."*
+- Each user authorization can have a maximum of 100 refresh tokens; oldest are auto-revoked beyond that.
+
+**Implication**: This applies only if the GitHub-secret token was provisioned via Railway's OAuth flow (with `offline_access`). Dashboard-generated personal access tokens are a different code path. Worth confirming during rotation that the token in use is a **dashboard PAT**, not an OAuth-derived access token.
+
+---
+
+### 6. Railway does **not** support GitHub OIDC federation — no zero-rotation path today
+
+**Source**: [GitHub OIDC docs](https://docs.github.com/en/actions/concepts/security/openid-connect), [Railway docs (no OIDC entry found)](https://docs.railway.com/integrations/api)
+**Authority**: GitHub official docs + absence of any matching Railway OIDC documentation
+**Relevant to**: Whether long-lived `RAILWAY_TOKEN` can be replaced entirely
+
+**Key Information**:
+
+- GitHub Actions supports OIDC for AWS, Azure, GCP, HashiCorp Vault, etc. — a job receives a short-lived JWT, and the cloud provider exchanges it for a per-job access token, eliminating long-lived secrets.
+- A search for Railway-specific OIDC integration returns **no results**. Railway has no `id-token` exchange endpoint and is not in GitHub's documented OIDC cloud provider list.
+- Railway's only published CI auth pattern is "store a long-lived token as a GitHub secret".
+
+**Implication**: Until Railway ships OIDC, the long-lived token *will* keep needing rotation. The leverage points are (a) make the token last as long as Railway allows ("No expiration"), (b) detect expiry early via the existing weekly health-check cron, and (c) fail loudly with a clear runbook pointer (the validator already does this). Replacing with OIDC is not currently possible.
+
+---
+
+### 7. The `backboard.railway.app` vs `backboard.railway.com` host distinction
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/guides/public-api), multiple Help Station threads
+**Authority**: Official docs + community confirmation
+**Relevant to**: Whether the validator's URL is contributing to errors
+
+**Key Information**:
+
+- One thread asserts the "correct" endpoint is `https://backboard.railway.com/graphql/v2`; others (and many production examples) successfully use `https://backboard.railway.app/graphql/v2`.
+- Both hostnames currently resolve to Railway's GraphQL gateway; the `.app` variant has been the historical canonical form. There is **no evidence** that the host choice is causing the `Not Authorized` errors here — the same workflow has succeeded against `.app` many times.
+- Worth a future hardening pass to switch to `.com` for forward-compat, but this is not the root cause of #860.
+
+**Implication**: Out of scope for the current fix. Mention only as a future cleanup.
+
+---
+
+## Code Examples
+
+The recommended dual-token pattern from Railway's official guide (relevant if the team ever splits validator-vs-deploy roles):
+
+```yaml
+# From https://docs.railway.com/guides/public-api
+# Validator step (account/workspace token)
+- name: Validate Railway secrets
+  env:
+    RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+  run: |
+    curl -sf -X POST "https://backboard.railway.com/graphql/v2" \
+      -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{ me { id } }"}'
+
+# Deploy step (project token)
+- name: Deploy
+  env:
+    RAILWAY_TOKEN: ${{ secrets.RAILWAY_PROJECT_TOKEN }}
+  run: railway up --service=$SVC_ID
+```
+
+---
+
+## Gaps and Conflicts
+
+- **Default TTL for dashboard-generated PATs is undocumented.** Railway docs publish OAuth TTLs (1 hour access / 1 year refresh) but not the default for personal access tokens created via `https://railway.com/account/tokens`. Empirically the Reli incident pattern (~weekly) suggests a 7-day default if "No expiration" is not selected, but this is inferred, not confirmed.
+- **Conflicting reports on whether personal tokens work with the GraphQL `me` query.** Railway's own docs say `me` only works for personal/account tokens; one Help Station thread reports personal tokens *don't* work with GraphQL. The resolved fix in that thread was to create the token with **"No workspace"** selected — suggesting the report was a workspace-binding mismatch, not a fundamental incompatibility.
+- **No first-party Railway statement on tokens being silently revoked outside expiration.** Several community reports describe "valid yesterday, invalid today" without a clear cause. We could not find a published cause list from Railway.
+- **`.app` vs `.com` host:** community guidance is mixed; official docs use both in different pages. Not the cause of #860 but worth a cleanup pass.
+
+---
+
+## Recommendations
+
+Based on research, the fix for #860 itself is unchanged from the existing process — **a human must rotate `RAILWAY_TOKEN` via the Railway dashboard**, since agents cannot perform this action (per `CLAUDE.md`). Beyond the immediate rotation, the research suggests three durable improvements that would reduce recurrence below the current ~weekly cadence:
+
+1. **Update the rotation runbook to require two non-default settings, not one.** `docs/RAILWAY_TOKEN_ROTATION_742.md` already says "Expiration: No expiration". Add: **"Workspace: No workspace"** (Finding #2). Both must be set, or the validator's `me { id }` probe will fail.
+
+2. **Add a post-rotation verification step that runs the health-check workflow before closing the issue.** The repo already has `.github/workflows/railway-token-health.yml` (per `DEPLOYMENT_SECRETS.md`). The runbook should require: after `gh secret set RAILWAY_TOKEN`, run `gh workflow run railway-token-health.yml --repo alexsiri7/reli` and wait for green before re-running the failed deploy. This catches workspace-binding errors immediately rather than at the next prod deploy.
+
+3. **Do not attempt OIDC migration.** Railway does not support GitHub OIDC federation as of this research (Finding #6). The long-lived-token pattern is the only path Railway publishes. The recurring rotation pain is a Railway product gap, not a Reli configuration error — the only meaningful mitigation is detect-early (health check) + rotate-correctly (runbook).
+
+4. **Avoid touching the `Authorization` header / endpoint.** The validator's choice of `Authorization: Bearer` + `{me{id}}` against `backboard.railway.app` is correct for an account token (Finding #1). Don't switch to `Project-Access-Token` — that would break validation. Optional: switch host to `backboard.railway.com` in a future cleanup, but not in this fix (Finding #7).
+
+Per `CLAUDE.md`'s Railway Token Rotation policy, the agent's role on #860 is to **file/investigate, not rotate**. This research informs the human handoff and proposes runbook improvements that can be merged independently.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Public API — Railway Docs | https://docs.railway.com/guides/public-api | Authoritative on token types, headers, scopes |
+| 2 | Login & Tokens — Railway Docs | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth TTLs, refresh-rotation revocation behavior |
+| 3 | Using the CLI — Railway Docs | https://docs.railway.com/guides/cli | `RAILWAY_TOKEN` vs `RAILWAY_API_TOKEN` env-var semantics |
+| 4 | RAILWAY_TOKEN invalid or expired — Help Station | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Confirms `RAILWAY_TOKEN` only accepts project tokens at the CLI layer |
+| 5 | API Token "Not Authorized" — Help Station | https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1 | "No workspace" selection is required for personal tokens to satisfy `me` queries |
+| 6 | Token for GitHub Action — Help Station | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Account-scoped token recommendation for GitHub Actions |
+| 7 | Using GitHub Actions with Railway — Railway Blog | https://blog.railway.com/p/github-actions | Official walkthrough; confirms no published rotation guidance |
+| 8 | Unable to Generate API Token with Deployment Permissions — Help Station | https://station.railway.com/questions/unable-to-generate-api-token-with-deploy-4d2ccc12 | Confirms project-token deploy-permission limits |
+| 9 | OpenID Connect — GitHub Docs | https://docs.github.com/en/actions/concepts/security/openid-connect | Establishes that OIDC federation is the zero-rotation pattern (not available for Railway) |
+| 10 | CLI authentication fails with valid API token on Linux — railwayapp/cli #699 | https://github.com/railwayapp/cli/issues/699 | Background on token-auth failure modes in Railway CLI |


### PR DESCRIPTION
## Summary

- Production deploy on `main` failed because the `RAILWAY_TOKEN` GitHub Actions secret is invalid/expired (`Not Authorized` from Railway GraphQL).
- This is the **41st** occurrence of the same recurring auth-outage pattern; root cause is account-scoped Railway API token revocation/expiration.
- Per `CLAUDE.md` § *Railway Token Rotation*, agents cannot rotate the token. This PR is **docs-only**: it commits the investigation, web-research, and validation artifacts. The actual fix is a human rotation per `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/investigation.md` | CREATE | +188 |
| `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/web-research.md` | CREATE | +195 |
| `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/validation.md` | CREATE | +97 |

No source, workflow YAML, or runbook was modified. No `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker was created (that would be a Category 1 error per `CLAUDE.md`).

## Root Cause

The `Validate Railway secrets` step (`.github/workflows/staging-pipeline.yml:49-58`) posts `{ me { id } }` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN`. Railway returned `errors[0].message == "Not Authorized"`, so the workflow fails fast before the deploy mutation. The pre-flight probe is correct — the secret is stale.

- Failing run: https://github.com/alexsiri7/reli/actions/runs/25242236208
- Failing log line: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
- Failing SHA: `3570101c6de497ab5171c7a2c1fdd70baa411a57`

## Required Human Action (out of agent scope)

Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:

1. Sign in at https://railway.com/account/tokens.
2. Issue a new **account-scoped** API token (label e.g. `gh-actions-2026-05-02`).
   - **Expiration: No expiration**
   - **Workspace: No workspace** (workspace-bound tokens silently fail the `me { id }` probe — see web-research Finding #2)
3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
4. Verify token health: `gh workflow run railway-token-health.yml --repo alexsiri7/reli`
5. Re-run the failed pipeline: `gh run rerun 25242236208 --repo alexsiri7/reli --failed`
6. Confirm the `Validate Railway secrets` step passes; close #860 with the green run URL.
7. (Optional) Revoke the prior token in Railway after the new one verifies green.

## Validation

| Check | Result | Notes |
|-------|--------|-------|
| Type check | N/A | Docs-only diff |
| Lint | N/A | Docs-only diff |
| Tests | N/A | Docs-only diff |
| Build | N/A | Docs-only diff |
| Scope discipline | PASS | Only files under `artifacts/runs/31b45d722d1961ae59edfe9b72e7cf08/` created; no Category 1 marker; no edits to workflows/runbook |
| Git state | PASS | Branch ahead of `origin/main`; working tree clean |

The standard suite is vacuously passing because the bead's deliverable is a docs-only artifact set. The actual deploy-pipeline signal can only go green **after** the human rotates the token.

### Validation that will apply post-rotation (human-owned, not gateable on this PR)

```bash
gh workflow run railway-token-health.yml --repo alexsiri7/reli
gh run rerun 25242236208 --repo alexsiri7/reli --failed
```

Expect: `conclusion: success` on both, plus `RAILWAY_STAGING_URL` returning the freshly-deployed SHA on its health endpoint.

## Test plan

- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (with **No expiration** + **No workspace** settings)
- [ ] `gh workflow run railway-token-health.yml` next run is green
- [ ] Re-run [staging-pipeline 25242236208](https://github.com/alexsiri7/reli/actions/runs/25242236208) — `Validate Railway secrets` step passes
- [ ] `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no errors
- [ ] Health check on `RAILWAY_STAGING_URL` reports 200 on the freshly-deployed SHA
- [ ] Close #860 with the green run URL

Fixes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)