### PR TITLE
docs: investigation for issue #862 (42nd RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/investigation.md
+++ b/artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/investigation.md
@@ -1,0 +1,187 @@
+# Investigation: Prod deploy failed on main (#862)
+
+**Issue**: #862 (https://github.com/alexsiri7/reli/issues/862)
+**Type**: BUG
+**Investigated**: 2026-05-02
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | CRITICAL | The `Validate Railway secrets` pre-flight gates every step of the staging→prod deploy pipeline; with it failing, no release can land until the token is rotated — this is an authentication outage on the deploy pipeline, not a code defect. |
+| Complexity | LOW | No source files change. Recovery is a 3-step manual rotation in the Railway dashboard plus a `gh secret set` and a workflow re-run; the bug exists exclusively in external secret state. |
+| Confidence | HIGH | The failed step's stderr (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) is unambiguous, the validator code is unchanged, and this is the 42nd occurrence of the identical pattern with a documented runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`). |
+
+---
+
+## Problem Statement
+
+The `Validate Railway secrets` step in the `Deploy to staging` job (workflow `Staging → Production Pipeline`, run [25242824636](https://github.com/alexsiri7/reli/actions/runs/25242824636)) failed because Railway's GraphQL endpoint rejected `RAILWAY_TOKEN` with `Not Authorized` when probing `{ me { id } }`. Because this validation gates the actual `serviceInstanceUpdate` deploy mutation, no staging/production release can land until the GitHub Actions secret `RAILWAY_TOKEN` is rotated by a human with railway.com access.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+The token stored in the GitHub Actions secret `RAILWAY_TOKEN` is no longer accepted by Railway's GraphQL API. The workflow's pre-flight authentication probe (`.github/workflows/staging-pipeline.yml:49-58`) correctly catches this and refuses to proceed, which is the intended fail-fast behaviour — there is no code regression here. The fix lives entirely outside the repo: a human must mint a new account-scoped Railway API token and overwrite the GitHub secret.
+
+### Evidence Chain
+
+WHY: Why did the prod deploy run fail?
+↓ BECAUSE: The `Deploy to staging` job exited 1 in the `Validate Railway secrets` step.
+  Evidence: workflow log — `##[error]Process completed with exit code 1.` at `2026-05-02T03:34:42.2305387Z`.
+
+↓ BECAUSE: Why did that step exit 1?
+  Evidence: log line `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` at `2026-05-02T03:34:42.2294149Z`.
+
+↓ BECAUSE: Why was the token rejected?
+  Evidence: `.github/workflows/staging-pipeline.yml:49-58` posts `{me{id}}` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN` and inspects `.data.me.id`. Railway returned `errors[0].message == "Not Authorized"` instead of a `me.id`.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret holds an account-scoped Railway API token that has been revoked or has expired (or, per the prior #860 web-research finding, may have been minted with a workspace bound rather than "No workspace" — silent rejection mode).
+  Evidence: Identical failure mode to 41 prior issues, all resolved by rotating the token via `docs/RAILWAY_TOKEN_ROTATION_742.md` with no source change. Commit-history numbering pins #850 = 38th, #854 = 39th, #858 = 40th, #860 = 41st, #862 = 42nd.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none — code) | — | — | No source/workflow change is required or appropriate. |
+| GitHub secret `RAILWAY_TOKEN` | n/a | ROTATE (human) | Replace with a freshly-issued account-scoped Railway API token (No expiration, No workspace). |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step (the failing pre-flight)
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` step (gated by the validate step; would fail equivalently if reached, since it uses the same `Authorization: Bearer $RAILWAY_TOKEN`)
+- `.github/workflows/railway-token-health.yml` — independent token-health probe (daily cron); will also fail on the same secret until rotated
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the canonical rotation runbook
+- `DEPLOYMENT_SECRETS.md` — CI secret setup reference (linked from the validator's error message)
+
+### Git History
+
+- **Failing SHA**: `c7a18a3f16ae4d2b07ccd22cf4a124b78a4a0a89` ("docs: investigation for issue #858 (40th RAILWAY_TOKEN expiration) (#859)") — docs-only, cannot have caused this.
+- **Validator step provenance**: `git log --oneline .github/workflows/staging-pipeline.yml` shows the most recent edit was `0040535` ("fix: use curl -sf consistently in Railway token validate steps (#744)"); the auth-check pattern itself was added in `3dfb995` (#738). Neither is recent — the validator has been stable for many cycles.
+- **Implication**: Not a regression. This is recurring secret-rotation toil — the token issued during the previous rotation (post-#860) has now been revoked or has expired again.
+
+---
+
+## Implementation Plan
+
+> **Agent-side: NO CODE CHANGES.** Per `CLAUDE.md` § "Railway Token Rotation":
+>
+> > Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. File a GitHub issue or send mail to mayor with the error details. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+>
+> Producing such a marker file would be a Category 1 error.
+
+### Step 1: Document the failure (agent action)
+
+**File**: `artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/investigation.md`
+**Action**: CREATE (this file)
+
+Captures the failing run URL, the exact error string, the rotation runbook pointer, and the prior-occurrence count so the human has a one-stop summary.
+
+### Step 2: Post investigation comment on #862 (agent action)
+
+Use `gh issue comment 862` with a formatted summary so the human can act without opening Actions logs.
+
+### Step 3: Human rotation per runbook (NOT an agent action)
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` (with the additional setting flagged by prior web-research):
+
+1. Sign in at https://railway.com/account/tokens.
+2. Create a new **account-scoped** API token. Required settings:
+   - Name: `github-actions-permanent` (or `gh-actions-2026-05-02b` to disambiguate from the post-#860 rotation earlier today).
+   - **Expiration: No expiration** (critical — do not accept the default TTL).
+   - **Workspace: No workspace** (per Railway support thread; workspace-bound tokens silently fail the `me { id }` probe).
+3. Update the GitHub Actions secret:
+   ```bash
+   gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+   # Paste the new token when prompted
+   ```
+4. Verify token before re-deploying:
+   ```bash
+   gh workflow run railway-token-health.yml --repo alexsiri7/reli
+   gh run watch <new-run-id> --repo alexsiri7/reli
+   ```
+5. Re-run the failed pipeline:
+   ```bash
+   gh run rerun 25242824636 --repo alexsiri7/reli --failed
+   ```
+6. Confirm the `Validate Railway secrets` step passes; close #862 with the green run URL.
+7. (Optional but useful) Revoke the previous token in Railway after the new one verifies green, to limit overlap.
+
+### Step 4: Verify (after human rotation)
+
+- `Validate Railway secrets` step succeeds (`me.id` returned).
+- `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no `errors`.
+- Health check on `RAILWAY_STAGING_URL` reports 200.
+- `railway-token-health.yml` next scheduled run is green.
+
+---
+
+## Patterns to Follow
+
+This issue's documentation pattern mirrors the prior 41 instances. Reference the most recent pair (issue #860, PR #861) for the docs-only investigation pattern — same artifact layout under `artifacts/runs/<hash>/investigation.md`.
+
+The runbook itself (`docs/RAILWAY_TOKEN_ROTATION_742.md`) is the canonical procedure — do not duplicate or fork it.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Cron re-fires #862 before rotation completes | Issue is labelled `archon:in-progress`; the pickup cron skips while that label is present. Do not strip the label until the deploy goes green. |
+| Cron re-fires #862 after PR merges (label cleared early) | Prior issues (#854, #850) saw this; harmless but wasteful. Out of scope for this fix — track separately if it recurs. |
+| Same-day repeat (post-#860 rotation already happened today, now token rejected again 30min later) | Possible causes: (a) the new token was minted with a workspace bound (silent rejection) — re-mint with **No workspace**; (b) the new token was minted with a TTL — re-mint with **No expiration**; (c) Railway revoked the just-minted token (rare, contact support). Investigate before assuming a third rotation will stick. |
+| New token rotates green but next deploy still fails | Likely a separate issue (e.g., revoked service ID, image registry permissions). Re-investigate from logs; do **not** assume same root cause. |
+| Human believes agent rotated the token because of a `.github/RAILWAY_TOKEN_ROTATION_*.md` file | Do **not** create such a file. The runbook is the only canonical rotation doc. |
+| Pickup cron fires for #862 after this PR — generating a duplicate investigation | Standard pattern: the next investigator should add a `(2nd pickup)` suffix and reuse the same artifact directory style as #850 (#853, #856). |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# Agent-side: docs-only diff. Standard suite is vacuously passing.
+# The actual signal lives in the deploy pipeline, which only goes green
+# AFTER the human rotates the token:
+gh workflow run railway-token-health.yml --repo alexsiri7/reli   # post-rotation sanity check
+gh run rerun 25242824636 --repo alexsiri7/reli --failed
+gh run watch <new-run-id> --repo alexsiri7/reli
+```
+
+### Manual Verification (post-rotation)
+
+1. The re-run of [25242824636](https://github.com/alexsiri7/reli/actions/runs/25242824636) reaches the `Deploy staging image to Railway` step and exits 0.
+2. `RAILWAY_STAGING_URL` returns the freshly-deployed SHA (`c7a18a3`) on `/api/version` (or equivalent health endpoint).
+3. `railway-token-health.yml` next scheduled run reports green.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE (agent):**
+- Investigate the failed run, identify the recurring root cause.
+- Produce this investigation artifact under `artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/`.
+- Post a summary comment on issue #862 directing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating the Railway API token (human-only — railway.com access required).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker (Category 1 error per `CLAUDE.md`).
+- Editing `.github/workflows/staging-pipeline.yml`, `railway-token-health.yml`, or `docs/RAILWAY_TOKEN_ROTATION_742.md` — none are wrong; the secret is.
+- Adding the "No workspace" instruction to the runbook (separate scope — file as a follow-up issue if pursued; per Polecat Scope Discipline, surface as mail to mayor rather than expanding this PR).
+- Designing token-expiration mitigations (longer-lived tokens, automatic rotation, OIDC federation) — Railway doesn't support OIDC today; file separate issues if pursued.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02
+- **Artifact**: `artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/investigation.md`
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25242824636
+- **Failing SHA**: `c7a18a3f16ae4d2b07ccd22cf4a124b78a4a0a89`
+- **Prior occurrences**: 41 (this is #42)
+- **Runbook**: `docs/RAILWAY_TOKEN_ROTATION_742.md`


### PR DESCRIPTION
## Summary

- Production deploy on `main` failed because the `RAILWAY_TOKEN` GitHub Actions secret is invalid/expired (`Not Authorized` from Railway GraphQL).
- This is the **42nd** occurrence of the same recurring auth-outage pattern; root cause is account-scoped Railway API token revocation/expiration.
- Per `CLAUDE.md` § *Railway Token Rotation*, agents cannot rotate the token. This PR is **docs-only**: it commits the investigation, web-research, implementation, and validation artifacts. The actual fix is a human rotation per `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/investigation.md` | CREATE | +187 |

No source, workflow YAML, or runbook was modified. No `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker was created (that would be a Category 1 error per `CLAUDE.md`).

The `web-research.md`, `implementation.md`, and `validation.md` artifacts in the same run directory are uncommitted by design — they document the no-op implementation/validation phases of a docs-only investigation.

## Root Cause

The `Validate Railway secrets` step (`.github/workflows/staging-pipeline.yml`) posts `{ me { id } }` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN`. Railway returned `errors[0].message == "Not Authorized"`, so the workflow fails fast before the deploy mutation. The pre-flight probe is correct — the secret is stale.

- Failing run: https://github.com/alexsiri7/reli/actions/runs/25242824636
- Failing log line: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
- Investigation comment posted to #862 at 2026-05-02T04:06:40Z

## Required Human Action (out of agent scope)

Per `docs/RAILWAY_TOKEN_ROTATION_742.md`:

1. Sign in at https://railway.com/account/tokens.
2. Issue a new **account-scoped** API token (label e.g. `gh-actions-2026-05-02`).
   - **Expiration: No expiration**
   - **Workspace: No workspace** (workspace-bound tokens silently fail the `me { id }` probe — see web-research Finding #2)
3. Update GitHub Actions secret `RAILWAY_TOKEN` at https://github.com/alexsiri7/reli/settings/secrets/actions.
4. Verify token health: `gh workflow run railway-token-health.yml --repo alexsiri7/reli`
5. Re-run the failed pipeline: `gh run rerun 25242824636 --repo alexsiri7/reli --failed`
6. Confirm the `Validate Railway secrets` step passes; close #862 with the green run URL.
7. (Optional) Revoke the prior token in Railway after the new one verifies green.

## Validation

| Check | Result | Notes |
|-------|--------|-------|
| Type check | N/A | Docs-only diff (vacuously passing) |
| Lint | N/A | Docs-only diff (vacuously passing) |
| Tests | N/A | Docs-only diff (vacuously passing) |
| Build | N/A | Docs-only diff (vacuously passing) |
| Scope discipline | PASS | Only files under `artifacts/runs/f6cb564f5a7676b3fb984ca59aae6ef5/` created; no Category 1 marker; no edits to workflows/runbook |
| Git state | PASS | Branch ahead of `origin/main` by 1 commit; working tree clean |

The standard suite is vacuously passing because the bead's deliverable is a docs-only artifact set. The actual deploy-pipeline signal can only go green **after** the human rotates the token.

### Validation that will apply post-rotation (human-owned, not gateable on this PR)

```bash
gh workflow run railway-token-health.yml --repo alexsiri7/reli
gh run rerun 25242824636 --repo alexsiri7/reli --failed
```

Expect: `conclusion: success` on both, plus `RAILWAY_STAGING_URL` returning the freshly-deployed SHA on its health endpoint.

## Test plan

- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (with **No expiration** + **No workspace** settings)
- [ ] `gh workflow run railway-token-health.yml` next run is green
- [ ] Re-run [staging-pipeline 25242824636](https://github.com/alexsiri7/reli/actions/runs/25242824636) — `Validate Railway secrets` step passes
- [ ] `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no errors
- [ ] Health check on `RAILWAY_STAGING_URL` reports 200 on the freshly-deployed SHA
- [ ] Close #862 with the green run URL

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)