### PR TITLE
docs: investigation for issue #864 (43rd RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md
+++ b/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md
@@ -1,0 +1,193 @@
+# Investigation: Prod deploy failed on main (#864)
+
+**Issue**: #864 (https://github.com/alexsiri7/reli/issues/864)
+**Type**: BUG
+**Investigated**: 2026-05-02
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | CRITICAL | The `Validate Railway secrets` pre-flight gates every step of the staging→prod deploy pipeline; with it failing, no release can land until the token is rotated — this is an authentication outage on the deploy pipeline, not a code defect. |
+| Complexity | LOW | No source files change. Recovery is a 3-step manual rotation in the Railway dashboard plus a `gh secret set` and a workflow re-run; the bug exists exclusively in external secret state. |
+| Confidence | HIGH | The failed step's stderr (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) is unambiguous, the validator code is unchanged since `0040535` (#744), and this is the 43rd occurrence of the identical pattern with a documented runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`). |
+
+---
+
+## Problem Statement
+
+The `Validate Railway secrets` step in the `Deploy to staging` job (workflow `Staging → Production Pipeline`, run [25243338235](https://github.com/alexsiri7/reli/actions/runs/25243338235)) failed because Railway's GraphQL endpoint rejected `RAILWAY_TOKEN` with `Not Authorized` when probing `{ me { id } }`. Because this validation gates the actual `serviceInstanceUpdate` deploy mutation, no staging/production release can land until the GitHub Actions secret `RAILWAY_TOKEN` is rotated by a human with railway.com access.
+
+This is the **43rd** instance of this identical authentication failure on the prod deploy pipeline (and notably the **3rd today** — issues #860 and #862 were both rotated earlier on 2026-05-02, and the new token has already been rejected again).
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+The token stored in the GitHub Actions secret `RAILWAY_TOKEN` is no longer accepted by Railway's GraphQL API. The workflow's pre-flight authentication probe (`.github/workflows/staging-pipeline.yml:49-58`) correctly catches this and refuses to proceed, which is the intended fail-fast behaviour — there is no code regression here. The fix lives entirely outside the repo: a human must mint a new account-scoped Railway API token and overwrite the GitHub secret.
+
+The same-day repeat (3 rotations in one day) strongly suggests the post-#862 token was minted with a workspace bound (silent rejection mode) or with a TTL — both call out the "No expiration / No workspace" settings the runbook now emphasizes.
+
+### Evidence Chain
+
+WHY: Why did the prod deploy run fail?
+↓ BECAUSE: The `Deploy to staging` job exited 1 in the `Validate Railway secrets` step.
+  Evidence: workflow log — `##[error]Process completed with exit code 1.` at `2026-05-02T04:04:50.3153232Z`.
+
+↓ BECAUSE: Why did that step exit 1?
+  Evidence: log line `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` at `2026-05-02T04:04:50.3137106Z`.
+
+↓ BECAUSE: Why was the token rejected?
+  Evidence: `.github/workflows/staging-pipeline.yml:49-58` posts `{me{id}}` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN` and inspects `.data.me.id`. Railway returned `errors[0].message == "Not Authorized"` instead of a `me.id`.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret holds an account-scoped Railway API token that has been revoked, has expired, or was minted with a workspace bound (silent rejection per Railway support).
+  Evidence: Identical failure mode to 42 prior issues, all resolved by rotating the token via `docs/RAILWAY_TOKEN_ROTATION_742.md` with no source change. Commit-history numbering pins #850 = 38th, #854 = 39th, #858 = 40th, #860 = 41st, #862 = 42nd, #864 = 43rd.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none — code) | — | — | No source/workflow change is required or appropriate. |
+| GitHub secret `RAILWAY_TOKEN` | n/a | ROTATE (human) | Replace with a freshly-issued account-scoped Railway API token (No expiration, No workspace). |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step (the failing pre-flight)
+- `.github/workflows/staging-pipeline.yml:60-88` — `Deploy staging image to Railway` step (gated by the validate step; would fail equivalently if reached, since it uses the same `Authorization: Bearer $RAILWAY_TOKEN`)
+- `.github/workflows/railway-token-health.yml` — independent token-health probe (daily cron); will also fail on the same secret until rotated
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the canonical rotation runbook
+- `DEPLOYMENT_SECRETS.md` — CI secret setup reference (linked from the validator's error message)
+
+### Git History
+
+- **Failing SHA**: `c13e1e4db7e555c6e1830013f5442c065ca3ff6e` ("docs: investigation for issue #860 (41st RAILWAY_TOKEN expiration) (#861)") — docs-only, cannot have caused this.
+- **Validator step provenance**: `git log --oneline .github/workflows/staging-pipeline.yml` shows the most recent edit was `0040535` ("fix: use curl -sf consistently in Railway token validate steps (#744)"); the auth-check pattern itself was added in `3dfb995` (#738). Neither is recent — the validator has been stable for many cycles.
+- **Implication**: Not a regression. This is recurring secret-rotation toil — the token issued during the #862 rotation earlier today (post-cd6ecef) has now been revoked, expired, or was minted incorrectly.
+
+---
+
+## Implementation Plan
+
+> **Agent-side: NO CODE CHANGES.** Per `CLAUDE.md` § "Railway Token Rotation":
+>
+> > Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done. File a GitHub issue or send mail to mayor with the error details. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+>
+> Producing such a marker file would be a Category 1 error.
+
+### Step 1: Document the failure (agent action)
+
+**File**: `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md`
+**Action**: CREATE (this file)
+
+Captures the failing run URL, the exact error string, the rotation runbook pointer, and the prior-occurrence count so the human has a one-stop summary.
+
+### Step 2: Post investigation comment on #864 (agent action)
+
+Use `gh issue comment 864` with a formatted summary so the human can act without opening Actions logs. Emphasize the same-day-repeat angle (3rd rotation today) and the "No workspace / No expiration" mint settings.
+
+### Step 3: Human rotation per runbook (NOT an agent action)
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` (with the additional setting flagged by prior web-research):
+
+1. Sign in at https://railway.com/account/tokens.
+2. Create a new **account-scoped** API token. Required settings:
+   - Name: `gh-actions-2026-05-02c` (third rotation today; disambiguates from the #860 and #862 rotations).
+   - **Expiration: No expiration** (critical — do not accept the default TTL).
+   - **Workspace: No workspace** (per Railway support thread; workspace-bound tokens silently fail the `me { id }` probe).
+3. Update the GitHub Actions secret:
+   ```bash
+   gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+   # Paste the new token when prompted
+   ```
+4. Verify token before re-deploying:
+   ```bash
+   gh workflow run railway-token-health.yml --repo alexsiri7/reli
+   gh run watch <new-run-id> --repo alexsiri7/reli
+   ```
+5. Re-run the failed pipeline:
+   ```bash
+   gh run rerun 25243338235 --repo alexsiri7/reli --failed
+   ```
+6. Confirm the `Validate Railway secrets` step passes; close #864 with the green run URL.
+7. (Optional but useful) Revoke the previous token in Railway after the new one verifies green, to limit overlap.
+
+### Step 4: Verify (after human rotation)
+
+- `Validate Railway secrets` step succeeds (`me.id` returned).
+- `Deploy staging image to Railway` proceeds and `serviceInstanceUpdate` returns no `errors`.
+- Health check on `RAILWAY_STAGING_URL` reports 200.
+- `railway-token-health.yml` next scheduled run is green.
+
+---
+
+## Patterns to Follow
+
+This issue's documentation pattern mirrors the prior 42 instances. Reference the most recent pair (issue #862, PR #863 — commit `cd6ecef`) for the docs-only investigation pattern — same artifact layout under `artifacts/runs/<hash>/investigation.md`.
+
+The runbook itself (`docs/RAILWAY_TOKEN_ROTATION_742.md`) is the canonical procedure — do not duplicate or fork it.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Cron re-fires #864 before rotation completes | Issue is labelled `archon:in-progress`; the pickup cron skips while that label is present. Do not strip the label until the deploy goes green. |
+| Cron re-fires #864 after PR merges (label cleared early) | Prior issues (#854, #850) saw this; harmless but wasteful. Out of scope for this fix — track separately if it recurs. |
+| Same-day repeat (3rd rotation today after #860 and #862) | Strongly suggests the post-#862 token was minted with a workspace bound (silent rejection) or with a TTL. **Re-mint with No workspace AND No expiration explicitly set in the Railway dashboard.** If the third rotation also fails within hours, escalate to Railway support — token churn this fast is not normal. |
+| New token rotates green but next deploy still fails | Likely a separate issue (e.g., revoked service ID, image registry permissions). Re-investigate from logs; do **not** assume same root cause. |
+| Human believes agent rotated the token because of a `.github/RAILWAY_TOKEN_ROTATION_*.md` file | Do **not** create such a file. The runbook is the only canonical rotation doc. |
+| Pickup cron fires for #864 after this PR — generating a duplicate investigation | Standard pattern: the next investigator should add a `(2nd pickup)` suffix and reuse the same artifact directory style as #850 (#853, #856). |
+| Three same-day rotations suggests a systemic issue with how tokens are being minted | Out of scope for this fix (per Polecat Scope Discipline). Surface as mail to mayor: a follow-up should investigate whether the runbook's "No workspace / No expiration" steps are being followed and consider adding a screenshot or copy-paste UI checklist. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# Agent-side: docs-only diff. Standard suite is vacuously passing.
+# The actual signal lives in the deploy pipeline, which only goes green
+# AFTER the human rotates the token:
+gh workflow run railway-token-health.yml --repo alexsiri7/reli   # post-rotation sanity check
+gh run rerun 25243338235 --repo alexsiri7/reli --failed
+gh run watch <new-run-id> --repo alexsiri7/reli
+```
+
+### Manual Verification (post-rotation)
+
+1. The re-run of [25243338235](https://github.com/alexsiri7/reli/actions/runs/25243338235) reaches the `Deploy staging image to Railway` step and exits 0.
+2. `RAILWAY_STAGING_URL` returns the freshly-deployed SHA (`c13e1e4` or newer) on `/api/version` (or equivalent health endpoint).
+3. `railway-token-health.yml` next scheduled run reports green.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE (agent):**
+- Investigate the failed run, identify the recurring root cause.
+- Produce this investigation artifact under `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/`.
+- Post a summary comment on issue #864 directing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating the Railway API token (human-only — railway.com access required).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker (Category 1 error per `CLAUDE.md`).
+- Editing `.github/workflows/staging-pipeline.yml`, `railway-token-health.yml`, or `docs/RAILWAY_TOKEN_ROTATION_742.md` — none are wrong; the secret is.
+- Adding the "No workspace" instruction to the runbook (separate scope — file as a follow-up issue if pursued; per Polecat Scope Discipline, surface as mail to mayor rather than expanding this PR).
+- Designing token-expiration mitigations (longer-lived tokens, automatic rotation, OIDC federation) — Railway doesn't support OIDC today; file separate issues if pursued.
+- Investigating why same-day rotations are needed 3x in one day (separate scope — surface as mail to mayor).
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02
+- **Artifact**: `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md`
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25243338235
+- **Failing SHA**: `c13e1e4db7e555c6e1830013f5442c065ca3ff6e`
+- **Prior occurrences**: 42 (this is #43; 3rd same-day rotation after #860 and #862)
+- **Runbook**: `docs/RAILWAY_TOKEN_ROTATION_742.md`

--- a/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/validation.md
+++ b/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/validation.md
@@ -28,6 +28,8 @@ artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md
 Single file added: the investigation artifact for issue #864 (43rd
 `RAILWAY_TOKEN` expiration, 3rd same-day rotation). No code, workflow,
 config, schema, dependency, or test changes.
+(Note: `validation.md` itself is also added by this PR; the diff
+above was captured before this artifact was written.)
 
 `git diff --stat origin/main...HEAD -- ':!artifacts'` returns empty —
 confirming nothing outside `artifacts/` was touched.

--- a/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/validation.md
+++ b/artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/validation.md
@@ -1,0 +1,138 @@
+# Validation Results
+
+**Generated**: 2026-05-02 05:37
+**Workflow ID**: 77b1f5b8afaaa30e0fb5a4d0402d70b7
+**Status**: ALL_PASS (vacuous — docs-only branch)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | ✅ (n/a) | No source/types changed vs `origin/main` |
+| Lint | ✅ (n/a) | No source/config changed vs `origin/main` |
+| Format | ✅ (n/a) | Markdown artifact only; no formatter coverage |
+| Tests | ✅ (n/a) | No test or production code changed vs `origin/main` |
+| Build | ✅ (n/a) | No backend/frontend source changed vs `origin/main` |
+
+---
+
+## Diff Scope
+
+```
+$ git diff --name-only origin/main...HEAD
+artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md
+```
+
+Single file added: the investigation artifact for issue #864 (43rd
+`RAILWAY_TOKEN` expiration, 3rd same-day rotation). No code, workflow,
+config, schema, dependency, or test changes.
+
+`git diff --stat origin/main...HEAD -- ':!artifacts'` returns empty —
+confirming nothing outside `artifacts/` was touched.
+
+---
+
+## Why the validation suite was not run
+
+Per `CLAUDE.md` § "Railway Token Rotation" and the investigation's
+"Scope Boundaries" section, agents cannot rotate the Railway API
+token; the only valid agent output for this issue is a documentation
+artifact under `artifacts/runs/<hash>/`. The investigation explicitly
+flags the standard suite as **vacuously passing** for a docs-only
+diff:
+
+> Agent-side: docs-only diff. Standard suite is vacuously passing.
+> The actual signal lives in the deploy pipeline, which only goes
+> green AFTER the human rotates the token.
+> — `investigation.md` § Validation › Automated Checks
+
+Running `npm run build` / pytest / lint against an unchanged tree
+exercises `origin/main`, not this branch — it would produce a green
+result that says nothing about the change in this PR. The signal that
+matters here is the **post-rotation** Railway pipeline re-run, which
+is gated on a human action and tracked in the investigation's "Manual
+Verification" section.
+
+---
+
+## Type Check
+
+**Command**: `npm --prefix frontend run type-check` / `mypy backend` (not run)
+**Result**: ✅ Pass (vacuous)
+
+No `.ts`, `.tsx`, `.py` files modified vs `origin/main`. The compiled
+output of this branch is byte-identical to `origin/main`.
+
+---
+
+## Lint
+
+**Command**: `npm --prefix frontend run lint` / `ruff check backend` (not run)
+**Result**: ✅ Pass (vacuous)
+
+No source files modified. Markdown is not in any linter's coverage
+configuration in this repo.
+
+---
+
+## Format
+
+**Command**: `npm --prefix frontend run format:check` / `ruff format --check` (not run)
+**Result**: ✅ Pass (vacuous)
+
+The added file is a Markdown artifact (`artifacts/**/*.md`), which is
+outside Prettier and Ruff format scope.
+
+---
+
+## Tests
+
+**Command**: `npm --prefix frontend test` / `pytest backend` (not run)
+**Result**: ✅ Pass (vacuous)
+
+No production or test code changed. Test outcome on this branch is
+identical to `origin/main`.
+
+---
+
+## Build
+
+**Command**: `npm --prefix frontend run build` / `docker compose build` (not run)
+**Result**: ✅ Pass (vacuous)
+
+No frontend, backend, Dockerfile, or dependency manifest changed.
+Build artifacts on this branch are identical to `origin/main`.
+
+---
+
+## Files Modified During Validation
+
+None — no fixes were necessary; nothing outside `artifacts/` was
+edited.
+
+---
+
+## Real Validation (Post-Rotation, Human-Owned)
+
+The actual signal for this issue cannot be produced by an agent. Per
+the investigation's "Manual Verification" section, after the human
+rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`:
+
+1. Re-run [25243338235](https://github.com/alexsiri7/reli/actions/runs/25243338235)
+   reaches `Deploy staging image to Railway` and exits 0.
+2. `RAILWAY_STAGING_URL` returns the freshly-deployed SHA on the
+   health endpoint.
+3. `railway-token-health.yml` next scheduled run reports green.
+
+These checks belong to the human runbook, not this validation step.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update PR and mark ready for
+review. The PR body should reference issue #864 (e.g.,
+`Fixes #864` once the human rotation is also complete, or
+`Part of #864` if landing the docs alone before rotation).


### PR DESCRIPTION
## Summary

- Documents the 43rd `RAILWAY_TOKEN` expiration (3rd same-day rotation on 2026-05-02, after #860 and #862).
- Adds the investigation and validation artifacts under `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/`.
- No source/workflow/runbook changes — per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate the token. Recovery is a human action via `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Root cause

The `Validate Railway secrets` pre-flight in `Deploy to staging` (run [25243338235](https://github.com/alexsiri7/reli/actions/runs/25243338235)) failed at `2026-05-02T04:04:50Z`:

```
##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized
##[error]Process completed with exit code 1.
```

Railway's GraphQL API rejected the `{ me { id } }` probe with `Not Authorized`. The validator code (`.github/workflows/staging-pipeline.yml:49-58`) is unchanged since `0040535` (#744) — this is recurring secret-rotation toil, not a regression.

The same-day repeat (3rd rotation today) strongly suggests the post-#862 token was minted with a workspace bound (silent rejection) or a TTL. Re-mint with **No workspace AND No expiration** explicitly set.

## Changes

| File | Action |
|------|--------|
| `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/investigation.md` | CREATE (+193) |
| `artifacts/runs/77b1f5b8afaaa30e0fb5a4d0402d70b7/validation.md` | CREATE (+138) |

`git diff --stat origin/main...HEAD -- ':!artifacts'` is empty — nothing outside `artifacts/` was touched.

## Validation

Standard suite is **vacuously passing** (docs-only diff against `origin/main`):

| Check | Result | Notes |
|-------|--------|-------|
| Type check | ✅ (n/a) | No `.ts`/`.tsx`/`.py` modified |
| Lint | ✅ (n/a) | No source/config modified |
| Format | ✅ (n/a) | Markdown artifact only |
| Tests | ✅ (n/a) | No test or production code changed |
| Build | ✅ (n/a) | No frontend/backend/Dockerfile/dependency changed |

The actual signal lives in the deploy pipeline, which can only go green **after** a human rotates `RAILWAY_TOKEN` per the runbook.

## Manual verification (post-rotation, human-owned)

1. Re-run [25243338235](https://github.com/alexsiri7/reli/actions/runs/25243338235) reaches `Deploy staging image to Railway` and exits 0.
2. `RAILWAY_STAGING_URL` returns the freshly-deployed SHA on the health endpoint.
3. `railway-token-health.yml` next scheduled run reports green.

## Test plan

- [x] Investigation artifact captures failing run URL, exact error, runbook pointer, and prior-occurrence count
- [x] Validation artifact confirms docs-only diff scope
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` "rotation done" marker created (would be a Category 1 error)
- [x] No edits to `.github/workflows/staging-pipeline.yml`, `railway-token-health.yml`, or `docs/RAILWAY_TOKEN_ROTATION_742.md`
- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (No expiration, No workspace)
- [ ] `gh run rerun 25243338235 --repo alexsiri7/reli --failed` goes green
- [ ] `railway-token-health.yml` next scheduled run reports green

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)