### PR TITLE
docs: investigation for issue #882 (51st RAILWAY_TOKEN expiration, 11th today)

### DIFF
--- a/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/implementation.md
+++ b/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/implementation.md
@@ -1,0 +1,103 @@
+# Implementation Report
+
+**Issue**: #882 — Prod deploy failed on main (51st RAILWAY_TOKEN expiration)
+**Generated**: 2026-05-02 09:40
+**Workflow ID**: 855aacc4054b4debf3fd138bcb1fe3c4
+**Worktree**: `/home/asiri/.archon/workspaces/ext-fast/reli/worktrees/archon/task-archon-fix-github-issue-1777710624889`
+**Branch**: `archon/task-archon-fix-github-issue-1777710624889`
+
+---
+
+## Outcome
+
+**No code changes were made. No commit was created.** The investigation artifact and CLAUDE.md both state — unambiguously — that this issue cannot be resolved by an agent.
+
+The agent-side deliverables defined in the investigation's Scope Boundaries (`investigation.md` lines 154-164) are:
+
+1. Diagnose the deploy failure on run 25247496048 — **done in investigation.md**.
+2. Produce the investigation artifact — **done** (committed in `758305b`).
+3. Post a GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` — **already posted** on issue #882 at 2026-05-02T08:36:34Z (verified via `gh api repos/alexsiri7/reli/issues/882/comments`).
+
+All three were complete before this `/fix-issue` invocation began. There is no remaining work this agent can legitimately perform.
+
+---
+
+## Why no code changes
+
+From `investigation.md` (Affected Files, line 43-45):
+
+> | File | Lines | Action | Description |
+> |------|-------|--------|-------------|
+> | _(none — repo code is correct)_ | — | NONE | The validator at `.github/workflows/staging-pipeline.yml:32-58` is working as designed; it correctly detects the bad token. The fix lives outside the repository, in GitHub Actions secrets and the Railway dashboard. |
+
+From `CLAUDE.md` (Railway Token Rotation):
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+> 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+> 2. File a GitHub issue or send mail to mayor with the error details.
+> 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+Fabricating any code change, lint-trivial diff, or rotation doc here to satisfy the `/fix-issue` workflow's "must commit" expectation would itself be a Category 1 error. The correct response is to stop and report.
+
+---
+
+## Tasks Completed
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Load investigation artifact | ✅ |
+| 2 | Verify scope: confirm investigation marks the repo as code-correct | ✅ |
+| 3 | Verify the GitHub comment routing the human to the runbook is already posted | ✅ (posted 2026-05-02T08:36:34Z) |
+| 4 | Confirm no `.github/RAILWAY_TOKEN_ROTATION_*.md` was created | ✅ (none — would be Category 1 error) |
+| 5 | Write this implementation report explaining the no-op | ✅ |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| _(none)_ | — | — |
+
+`git status --porcelain` is clean. Nothing to stage, nothing to commit.
+
+---
+
+## Deviations from Investigation
+
+None. The investigation explicitly stated that no code changes would be made, and none were made. The `/fix-issue` workflow's default expectation of "commit changes" is itself the deviation that this report declines to perform — for the documented reasons above.
+
+---
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check | n/a — no code changed |
+| Tests | n/a — no code changed |
+| Lint | n/a — no code changed |
+| Manual: investigation comment posted on #882 | ✅ |
+| Manual: no rotation doc fabricated | ✅ |
+
+---
+
+## What the human still needs to do
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` and Step 1 of `investigation.md`:
+
+1. Open https://railway.com/account/tokens and mint a new `github-actions-permanent` token with **Expiration: No expiration**.
+2. **If "No expiration" is missing or silently downgraded** — screenshot the dialog and report on issue #882 before creating any short-TTL token. This is the suspected root cause of today's 11 recurrences with consistent ~30-minute spacing.
+3. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the new token.
+4. `gh run rerun 25247496048 --repo alexsiri7/reli --failed`.
+5. Confirm the next staging deploy goes green and close #882.
+6. **Recommended**: Send mail to mayor recommending a separate investigation into a project-scoped Railway token or service-account credential. The 51st occurrence (11th today) with held inter-arrival time strongly suggests rotation alone is no longer sufficient.
+
+---
+
+## Next Step
+
+Stop. Do not create a PR. There are no changes to push.

--- a/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/investigation.md
+++ b/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/investigation.md
@@ -1,0 +1,172 @@
+# Investigation: Prod deploy failed on main (#882)
+
+**Issue**: #882 (https://github.com/alexsiri7/reli/issues/882)
+**Type**: BUG (infrastructure / secrets)
+**Investigated**: 2026-05-02T08:10:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | CRITICAL | Prod deploy pipeline is fully blocked at the `Validate Railway secrets` gate — no code can ship to staging or production until the token is rotated, and there is no in-repo workaround. |
+| Complexity | LOW | Resolution is a single GitHub secret update by a human with Railway dashboard access; zero code changes are required in this repository. |
+| Confidence | HIGH | The deploy log explicitly returns `RAILWAY_TOKEN is invalid or expired: Not Authorized` from Railway's `{me{id}}` validation query — identical signature to issues #864/#866/#868/#870/#871/#874/#876/#878/#880, all of which were resolved by token rotation. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job on workflow run [25247496048](https://github.com/alexsiri7/reli/actions/runs/25247496048) failed at the `Validate Railway secrets` step because the `RAILWAY_TOKEN` GitHub Actions secret is expired/invalid. Railway's GraphQL `{me{id}}` probe returns `Not Authorized`, so no deploy can proceed. This is the **51st** occurrence of this exact failure mode (**11th today**, ~30 minutes after #880) and the established remediation is a human-only Railway token rotation.
+
+---
+
+## Analysis
+
+### Root Cause
+
+The `RAILWAY_TOKEN` secret stored in GitHub Actions is rejected by Railway's API. The validation step in `.github/workflows/staging-pipeline.yml` performs an authenticated GraphQL request and exits non-zero when the response does not contain `data.me.id`.
+
+### Evidence Chain
+
+WHY: Prod deploy run 25247496048 failed.
+↓ BECAUSE: The `Validate Railway secrets` step exited with code 1.
+  Evidence: deploy log line `2026-05-02T08:04:40.1534862Z ##[error]Process completed with exit code 1.`
+
+↓ BECAUSE: Railway's GraphQL `{me{id}}` query returned `Not Authorized` instead of a user id.
+  Evidence: deploy log line `2026-05-02T08:04:40.1519221Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret has expired (or was revoked) and must be rotated by a human with Railway dashboard access.
+  Evidence: `docs/RAILWAY_TOKEN_ROTATION_742.md` documents this exact failure signature and notes that prior rotations (#733, #739, plus 40+ subsequent recurrences) all resolved via token rotation; recent commits (`6b231e3`, `554eb03`, `5fcc23b`, `715992e`, `bb5dfa7`) record the 46th–50th occurrences.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| _(none — repo code is correct)_ | — | NONE | The validator at `.github/workflows/staging-pipeline.yml:32-58` is working as designed; it correctly detects the bad token. The fix lives outside the repository, in GitHub Actions secrets and the Railway dashboard. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step performs the `{me{id}}` probe that detects this failure.
+- `.github/workflows/railway-token-health.yml` — daily token health check (added in `6a0d232` / `bdc2651`); operating as designed but cannot prevent mid-day token revocations.
+- GitHub Actions secret `RAILWAY_TOKEN` (org/repo level) — the value that needs rotation.
+- Railway dashboard at https://railway.com/account/tokens — where the new token must be minted.
+
+### Git History
+
+- **Pattern recognized in repo**: `docs/RAILWAY_TOKEN_ROTATION_742.md` (canonical runbook, originally for issue #742).
+- **Recent recurrences** (`git log --oneline -5`):
+  - `6b231e3` docs: investigation for issue #880 (50th expiration, 10th today)
+  - `554eb03` docs: investigation for issue #878 (49th, 9th today)
+  - `5fcc23b` docs: investigation for issue #876 (48th, 8th today)
+  - `715992e` docs: investigation for issue #874 (47th, 7th today)
+  - `bb5dfa7` docs: investigation for issue #870 (46th, 6th today)
+- **Implication**: This is a **pathologically high-frequency** recurring operational problem. Issue #880's deploy ran at 07:34:53Z; this one (#882) ran at 08:04:42Z — only **~30 minutes later**, the same inter-arrival time observed between #878 and #880. At **11 occurrences in a single calendar day** (2026-05-02) with consistent ~30-minute spacing, the rotated token's effective TTL is clearly far below the runbook's "No expiration" target. Either (a) the human is silently being given a short-TTL token by Railway's UI, (b) Railway has removed the "No expiration" option, or (c) an external process is revoking the token shortly after creation. The next rotator should screenshot the token-creation dialog and confirm the "No expiration" option still exists; if the next token also dies within ~30 minutes, the problem is structural and a different auth approach (Railway CLI + project token, or service-account credential) needs to be escalated to mayor as a separate investigation.
+
+---
+
+## Implementation Plan
+
+**No code changes are required in this repository.** Per `CLAUDE.md` "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+> 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+> 2. File a GitHub issue or send mail to mayor with the error details.
+> 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+
+### Step 1: Human rotates the token (out-of-band)
+
+Owner: a human with Railway dashboard access.
+
+1. Open https://railway.com/account/tokens.
+2. Create a new token named `github-actions-permanent` with **Expiration: No expiration**. If the option is missing or has been silently downgraded by Railway's UI, screenshot the dialog and report on the issue thread before creating any short-TTL token (this is the suspected root cause of the 11-per-day, ~30-minute recurrence rate).
+3. Update the GitHub secret:
+   ```bash
+   gh secret set RAILWAY_TOKEN --repo alexsiri7/reli
+   # paste the new token
+   ```
+4. Re-run the failed deploy:
+   ```bash
+   gh run rerun 25247496048 --repo alexsiri7/reli --failed
+   ```
+   Fallback (if the run is stale):
+   ```bash
+   gh run list --repo alexsiri7/reli --status failure --limit 1 \
+     --json databaseId --jq '.[0].databaseId' \
+     | xargs -I{} gh run rerun {} --repo alexsiri7/reli --failed
+   ```
+
+### Step 2: Confirm green deploy and close the issue
+
+Once the next staging deploy passes, close issue #882.
+
+### Step 3 (recommended): Escalate the recurrence pattern to mayor
+
+11 occurrences in one day with ~30-minute inter-arrival time strongly indicates that simple rotation is not solving the problem. Whoever rotates the token should send mail to mayor recommending a separate investigation into:
+
+- Whether Railway has removed "No expiration" from the UI (screenshot needed).
+- Whether the previous tokens are being revoked by an external process.
+- Migrating from a personal API token to a project-scoped Railway token or Railway CLI service account.
+
+This step is out of scope for the current bead but the pattern is now severe enough to warrant flagging.
+
+---
+
+## Patterns to Follow
+
+**From `CLAUDE.md` (Railway Token Rotation):**
+
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+This investigation explicitly avoids creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` artifact and avoids modifying any workflow or secret-related code. The only deliverables are this investigation note plus a GitHub comment routing the human operator to the runbook.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent fabricates a "rotation complete" doc | Forbidden by CLAUDE.md; this investigation explicitly does not. |
+| Human picks a short-TTL token again (suspected root cause of recurrence) | Runbook requires **"No expiration"** — comment calls this out and recommends screenshotting the token-creation dialog. |
+| Multiple duplicate issues (this is the 51st, 11th today) | Comment notes the recurrence count and frequency so the human can prioritize a longer-term fix (e.g., service account, monitoring, alerting on token age). |
+| Re-run hits same expired token | Step 1 must complete (secret update) before the re-run in Step 2. |
+| Sub-hourly recurrence (~30 min between #880 and #882, same as #878→#880) suggests TTL is being silently capped or token is revoked externally | Out of scope for this bead; Step 3 recommends mayor escalation now that the pattern has held for three consecutive cycles. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+None for this repo — the failure is in CI infrastructure, not code.
+
+### Manual Verification
+
+1. After the human completes Step 1, re-run workflow 25247496048 (or trigger a fresh deploy).
+2. Confirm the `Validate Railway secrets` step now succeeds (response contains `data.me.id`).
+3. Confirm the full `Deploy to staging` pipeline completes green.
+4. Close issue #882.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Diagnosing the deploy failure on run 25247496048.
+- Producing this investigation artifact.
+- Posting a GitHub comment that routes the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating the Railway token (human-only — agent has no Railway dashboard credentials).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` document (explicitly forbidden by CLAUDE.md).
+- Modifying `.github/workflows/staging-pipeline.yml` — the validator is working correctly.
+- Any longer-term remediation (token monitoring, service account migration, alerting on token age, switching to Railway CLI + project token) — would belong in a separate issue. Step 3 above flags this for mayor escalation but does not implement it.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T08:10:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/investigation.md`

--- a/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/validation.md
+++ b/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/validation.md
@@ -28,6 +28,8 @@ Per `implementation.md` and `investigation.md`, this `/fix-issue` invocation pro
 ?? artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/implementation.md
 ```
 
+(Snapshot taken before this file and `implementation.md` were committed in `93c48d8`.)
+
 `git diff --stat HEAD`: empty.
 
 The only artifact produced is a markdown investigation/implementation report. There is no source code to type-check, lint, format, test, or build.

--- a/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/validation.md
+++ b/artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/validation.md
@@ -1,0 +1,68 @@
+# Validation Results
+
+**Generated**: 2026-05-02 09:45
+**Workflow ID**: 855aacc4054b4debf3fd138bcb1fe3c4
+**Status**: NO_OP (nothing to validate)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | n/a | No code changed |
+| Lint | n/a | No code changed |
+| Format | n/a | No code changed |
+| Tests | n/a | No code changed |
+| Build | n/a | No code changed |
+
+---
+
+## Why every check is `n/a`
+
+Per `implementation.md` and `investigation.md`, this `/fix-issue` invocation produced **zero code changes**. Issue #882 is the 51st recurrence of the `RAILWAY_TOKEN is invalid or expired` failure — a problem that lives in GitHub Actions secrets and the Railway dashboard, not in this repository's code.
+
+`git status --porcelain` at the start of validation:
+
+```
+?? artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/implementation.md
+```
+
+`git diff --stat HEAD`: empty.
+
+The only artifact produced is a markdown investigation/implementation report. There is no source code to type-check, lint, format, test, or build.
+
+Running the full validation suite anyway would:
+
+1. Burn CI cycles re-verifying the already-green state of commit `758305b` (the investigation doc commit on this branch).
+2. Risk introducing false-failure noise from unrelated transient flakiness, which could be misread as caused by this bead.
+3. Violate `CLAUDE.md`'s guidance against fabricating work to satisfy a workflow's default expectations:
+
+   > Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+   The same principle applies to running checks that have no work to validate.
+
+The implementation report's own "Validation Results" table already records `n/a — no code changed` for every applicable check; this artifact mirrors that determination explicitly.
+
+---
+
+## Files Modified During Validation
+
+None.
+
+---
+
+## What was actually validated
+
+The two manual checks that **are** appropriate for this bead — both already recorded in `implementation.md`:
+
+| Manual Check | Result |
+|--------------|--------|
+| GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` is posted on issue #882 | ✅ (posted 2026-05-02T08:36:34Z) |
+| No `.github/RAILWAY_TOKEN_ROTATION_*.md` was fabricated | ✅ (would be a Category 1 error per CLAUDE.md) |
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr`. **Note for that step**: there are no code commits to push, no PR diff to produce. The finalization step should treat this run the same way the implementation step did — recognize the no-op, and not fabricate a PR for a problem that requires human action on Railway and GitHub Actions secrets.


### PR DESCRIPTION
## Summary

- Investigation artifact for issue #882 — 51st `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure (11th today, ~30 min after #880).
- No code/workflow/config changes. Per `CLAUDE.md` "Railway Token Rotation", agents cannot rotate the token — the deliverable is the investigation + a GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
- Recurrence flag: 11 occurrences in one calendar day with consistent ~30-min inter-arrival time (#878→#880→#882) strongly suggests the rotated token's effective TTL is far below the runbook's "No expiration" target. Next rotator should screenshot the Railway token-creation dialog before minting; if "No expiration" is missing or silently capped, escalate to mayor for a structural fix (project-scoped token or service-account credential).

Fixes #882

## Test plan

- [x] Investigation artifact written to `artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/investigation.md`
- [x] Implementation report (no-op) at `artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/implementation.md`
- [x] Validation report (n/a — no code changed) at `artifacts/runs/855aacc4054b4debf3fd138bcb1fe3c4/validation.md`
- [x] GitHub comment posted on issue #882 with runbook pointer (2026-05-02T08:36:34Z)
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` created (Category 1 error per CLAUDE.md)
- [x] No workflow or secret-related code changes
- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` and re-runs deploy 25247496048
- [ ] Confirm next staging deploy goes green and close #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)