### PR TITLE
docs: investigation for issue #886 (53rd RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/implementation.md
+++ b/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/implementation.md
@@ -1,0 +1,111 @@
+# Implementation Report
+
+**Issue**: #886 — Prod deploy failed on main (53rd RAILWAY_TOKEN expiration, 13th today)
+**Generated**: 2026-05-02 09:45
+**Workflow ID**: e91bc4fa93b72a9e8e01cfa3db770a5d
+**Worktree**: `/home/asiri/.archon/workspaces/ext-fast/reli/worktrees/archon/task-archon-fix-github-issue-1777714225340`
+**Branch**: `archon/task-archon-fix-github-issue-1777714225340`
+
+---
+
+## Outcome
+
+**No code changes were made.** The investigation artifact and `CLAUDE.md` both state — unambiguously — that this issue cannot be resolved by an agent. The only commit on this branch is the docs-only artifact bundle (this report, the validation report, and the investigation copy under `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/`).
+
+The agent-side deliverables defined in the investigation's Scope Boundaries (`investigation.md` Scope Boundaries section) are:
+
+1. Diagnose the deploy failure on run 25248500899 — **done in `investigation.md`**.
+2. Produce the investigation artifact — **done** (copied into the repo at `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md`).
+3. Post a GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` — **already posted** on issue #886 at 2026-05-02T09:36:37Z (verified via `gh issue view 886 --json comments`).
+
+All three are complete. There is no remaining code work this agent can legitimately perform.
+
+---
+
+## Why no code changes
+
+From `investigation.md` (Affected Files):
+
+> | File | Lines | Action | Description |
+> |------|-------|--------|-------------|
+> | (none) | — | — | No code changes required. Fix is a GitHub Actions **secret value** rotation performed in repo Settings → Secrets and variables → Actions. |
+
+From `CLAUDE.md` (Railway Token Rotation):
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+> 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+> 2. File a GitHub issue or send mail to mayor with the error details.
+> 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+Fabricating any code change, lint-trivial diff, or rotation doc here to satisfy the `/fix-issue` workflow's "must commit code" expectation would itself be a Category 1 error. The correct response is to record the no-op outcome in this artifact and stop.
+
+---
+
+## Tasks Completed
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Load investigation artifact from workspace path | ✅ |
+| 2 | Verify investigation marks the repo as code-correct (zero affected files) | ✅ |
+| 3 | Verify the GitHub comment routing the human to the runbook is already posted | ✅ (posted 2026-05-02T09:36:37Z) |
+| 4 | Confirm `.github/workflows/staging-pipeline.yml` and `docs/RAILWAY_TOKEN_ROTATION_742.md` exist (artifact integration points are accurate) | ✅ |
+| 5 | Confirm no `.github/RAILWAY_TOKEN_ROTATION_886.md` was created | ✅ (would be Category 1 error) |
+| 6 | Copy investigation.md into the repo at `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/` | ✅ |
+| 7 | Write this implementation report explaining the no-op | ✅ |
+| 8 | Write `validation.md` recording n/a for every code-level check | ✅ |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md` | CREATE | (full investigation copy) |
+| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/implementation.md` | CREATE | (this file) |
+| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/validation.md` | CREATE | (sibling) |
+
+No source code, no workflow YAML, no config, no tests, no migrations were touched.
+
+---
+
+## Deviations from Investigation
+
+None. The investigation explicitly stated that no code changes would be made, and none were made. The `/fix-issue` workflow's default expectation of "implement the plan and commit code" is itself the deviation that this report declines to perform — for the documented reasons above.
+
+---
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check | n/a — no code changed |
+| Tests | n/a — no code changed |
+| Lint | n/a — no code changed |
+| Manual: investigation comment posted on #886 | ✅ |
+| Manual: no `RAILWAY_TOKEN_ROTATION_886.md` fabricated | ✅ |
+| Manual: artifact paths in investigation match repo reality (`staging-pipeline.yml`, runbook 742) | ✅ |
+
+See `validation.md` for the full breakdown.
+
+---
+
+## What the human still needs to do
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` and Step 1 of `investigation.md`:
+
+1. Open https://railway.com/account/tokens and mint a new API token.
+2. **If "No expiration" is missing or silently downgraded** — screenshot the dialog and report on issue #886 before creating any short-TTL token. The 13-per-day cadence (5 consecutive ~30-minute incidents: #878 → #880 → #882 → #884 → #886) suggests the upstream TTL is the structural problem rotation alone cannot fix.
+3. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the new token.
+4. `gh run rerun 25248500899 --repo alexsiri7/reli --failed`.
+5. Confirm the next staging deploy goes green and close #886.
+6. **Recommended**: Send mail to mayor recommending a separate investigation into a project-scoped Railway token or service-account credential. The 53rd occurrence (13th today) makes it clear that simple personal-token rotation is no longer keeping the pipeline green.
+
+---
+
+## Next Step
+
+Continue to the PR-creation step. The PR will be a docs-only bundle (`artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/*.md`) mirroring the resolution path of prior identical incidents (#876, #878, #880, #882, #884). There is no source code to validate or push.

--- a/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md
+++ b/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md
@@ -1,0 +1,159 @@
+# Investigation: Prod deploy failed on main (RAILWAY_TOKEN expired — 53rd occurrence)
+
+**Issue**: #886 (https://github.com/alexsiri7/reli/issues/886)
+**Type**: BUG (infrastructure / secret rotation)
+**Investigated**: 2026-05-02T09:15:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Prod deploy is fully blocked (no workaround) but no data loss/security exposure; a known recurring infrastructure issue with a documented fix path. |
+| Complexity | LOW | Zero code changes required — a single GitHub Actions secret value must be replaced by a human. |
+| Confidence | HIGH | Deploy log shows the exact failure (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) at the `Validate Railway secrets` step on run 25248500899; identical signature to 52 prior incidents. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in run [25248500899](https://github.com/alexsiri7/reli/actions/runs/25248500899) failed at the **Validate Railway secrets** step. Railway's GraphQL API responded `Not Authorized` to the validation probe, meaning the `RAILWAY_TOKEN` GitHub Actions secret is expired or revoked. No subsequent build/deploy steps ran. This is the 53rd RAILWAY_TOKEN expiration tracked on this repo and the 13th today (2026-05-02), arriving ~30 minutes after #884.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+Railway API tokens have a finite lifetime. When the active `RAILWAY_TOKEN` GitHub Actions secret expires (or is revoked), the CI validator step (which probes `https://backboard.railway.app/graphql/v2` with `{me{id}}`) receives `Not Authorized` and halts the deploy. The fix is **secret rotation**, not a code change.
+
+### Evidence Chain
+
+WHY: Prod deploy failed on commit `6d1e9ce` at 2026-05-02T09:05:06Z.
+↓ BECAUSE: The `Deploy to staging` workflow exited 1 at the `Validate Railway secrets` step.
+  Evidence: run log `2026-05-02T09:05:03.5810644Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: The validator's GraphQL probe to `backboard.railway.app/graphql/v2` returned `Not Authorized` — the token is rejected by Railway.
+  Evidence: validator step in `.github/workflows/staging-pipeline.yml` posts `{"query":"{me{id}}"}` and exits 1 if `.data.me.id` is missing.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret holds an expired/revoked Railway API token.
+  Evidence: identical failure signature to issues #884, #882, #880, #878, #876, …, #742 — all resolved by rotating the secret value via railway.com.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none) | — | — | No code changes required. Fix is a GitHub Actions **secret value** rotation performed in repo Settings → Secrets and variables → Actions. |
+
+### Integration Points
+
+- **GitHub Actions secret**: `RAILWAY_TOKEN` (consumed by every deploy workflow at the `Validate Railway secrets` step).
+- **Railway API**: `https://backboard.railway.app/graphql/v2` — issues and validates the token.
+- **Workflow**: `.github/workflows/staging-pipeline.yml` — the failing validator lives here.
+- **Runbook**: `docs/RAILWAY_TOKEN_ROTATION_742.md` — step-by-step rotation procedure.
+- **Repo policy**: `CLAUDE.md` "Railway Token Rotation" — agents MUST NOT claim to rotate the token.
+
+### Git History
+
+- **First occurrence on file**: tracked back to issue #742 (the runbook is named for it).
+- **Today's volume**: 13 expirations as of 2026-05-02 (#886 is the 13th today, the 53rd overall).
+- **Inter-arrival**: ~30 minutes from #884 (run 25248009761 → 25248500899). The accelerated cadence has now held for at least 5 consecutive incidents (#878 → #880 → #882 → #884 → #886).
+- **Implication**: Personal-token rotation alone is no longer keeping the pipeline green. **Out of scope for this fix** — but escalation to mayor for a structural fix (project-scoped Railway token, service account, or longer-TTL credential) is increasingly urgent.
+
+---
+
+## Implementation Plan
+
+This investigation produces **no code changes**. The required action is human secret rotation.
+
+### Step 1: Human rotates `RAILWAY_TOKEN`
+
+**Actor**: A repo admin with railway.com access (agents cannot perform this step).
+**Action**: Follow `docs/RAILWAY_TOKEN_ROTATION_742.md`:
+
+1. Log into railway.com.
+2. Generate a new API token under Account Settings → Tokens.
+3. In GitHub: repo Settings → Secrets and variables → Actions → update `RAILWAY_TOKEN` with the new value.
+4. Re-run the failed workflow at https://github.com/alexsiri7/reli/actions/runs/25248500899 (or wait for next push to `main`).
+5. Confirm the next deploy goes green.
+6. Close issue #886.
+
+### Step 2 (DO NOT DO): Create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is complete
+
+Per `CLAUDE.md` Railway Token Rotation policy:
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+The implementing agent for this issue MUST NOT create such a file. The only correct outcome from an agent is **filing/updating this issue and waiting for a human**.
+
+### Step 3 (Optional follow-up, OUT OF SCOPE): Escalate the rotation cadence to mayor
+
+13 expirations in one day with a steady ~30-minute inter-arrival is no longer a transient symptom — it is a structural problem. A separate follow-up should:
+- Send mail to mayor summarising the trend (#878 → #880 → #882 → #884 → #886, all today, all RAILWAY_TOKEN).
+- Recommend evaluating: project-scoped Railway token, Railway service account, long-lived deploy credential, or alternate hosting.
+- Track the work as its own issue, not bundled with this incident.
+
+Do **not** address this in the current bead.
+
+---
+
+## Patterns to Follow
+
+**From repo history — mirror the resolution path of prior identical incidents (e.g., #742, #876, #878, #880, #882, #884):**
+
+- The fix commit/PR for those issues was a **docs-only investigation note**, not a code change.
+- The token rotation itself was performed by a human admin out-of-band.
+- The issue was closed only after the next deploy ran green.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent tries to "fix" by creating a `RAILWAY_TOKEN_ROTATION_886.md` claiming success | Explicitly forbidden by `CLAUDE.md`; reject any such PR. |
+| Agent tries to read the secret value | Impossible — GitHub masks secrets. |
+| New token leaks into logs | Validator only echoes `***`; no change needed. |
+| Multiple in-flight deploy jobs after rotation | Re-run only the most recent failed run; older runs will have stale workflow definitions but will succeed if token is now valid. |
+| The 13-per-day cadence indicates a deeper issue | File a separate follow-up issue / mail mayor (see Step 3). Do not bundle with this fix. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# After human rotates the secret, re-run the failed workflow:
+gh run rerun 25248500899
+gh run watch 25248500899
+```
+
+### Manual Verification
+
+1. Confirm the `Validate Railway secrets` step reports success (no `Not Authorized`).
+2. Confirm subsequent deploy steps complete and the staging URL responds.
+3. Confirm the next push to `main` triggers a green deploy.
+4. Close issue #886 with a comment linking the green run.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Diagnosing the failure as a `RAILWAY_TOKEN` expiration.
+- Producing this investigation artifact.
+- Posting a comment on issue #886 directing a human to the rotation runbook.
+
+**OUT OF SCOPE (do not touch):**
+- The token rotation itself (humans only — `CLAUDE.md` policy).
+- Creating a `.github/RAILWAY_TOKEN_ROTATION_886.md` file (Category 1 error per `CLAUDE.md`).
+- Modifying the validator workflow.
+- Escalating the 13/day cadence to mayor (file separate issue / mail).
+- Any frontend, backend, or DB changes — this is purely a secret-rotation incident.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T09:15:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md`

--- a/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/validation.md
+++ b/artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/validation.md
@@ -1,0 +1,72 @@
+# Validation Results
+
+**Generated**: 2026-05-02 09:50
+**Workflow ID**: e91bc4fa93b72a9e8e01cfa3db770a5d
+**Status**: NO_OP (nothing to validate)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | n/a | No code changed |
+| Lint | n/a | No code changed |
+| Format | n/a | No code changed |
+| Tests | n/a | No code changed |
+| Build | n/a | No code changed |
+| Screenshot tests | n/a | No UI changed |
+
+---
+
+## Why every check is `n/a`
+
+Per `implementation.md` and `investigation.md`, this `/fix-issue` invocation produced **zero source-code changes**. Issue #886 is the 53rd recurrence of the `RAILWAY_TOKEN is invalid or expired` failure — a problem that lives in GitHub Actions secrets and the Railway dashboard, not in this repository's code.
+
+`git status --porcelain` snapshot taken before staging the artifact files (the only files that exist are the docs-only investigation/implementation/validation triple under `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/`):
+
+```
+?? artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/
+```
+
+(Snapshot taken before this file, `implementation.md`, and `investigation.md` were committed; after the commit, `git status` is clean and `git diff --stat HEAD~1 HEAD` shows three docs-only additions.)
+
+The only files produced are markdown reports. There is no source code to type-check, lint, format, test, screenshot, or build.
+
+Running the full validation suite anyway would:
+
+1. Burn CI cycles re-verifying the already-green state of `HEAD~1` (the prior #884 docs commit on `main`).
+2. Risk introducing false-failure noise from unrelated transient flakiness, which could be misread as caused by this bead.
+3. Violate `CLAUDE.md`'s guidance against fabricating work to satisfy a workflow's default expectations:
+
+   > Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+   The same principle applies to running checks that have no work to validate.
+
+The implementation report's own "Validation Results" table already records `n/a — no code changed` for every applicable check; this artifact mirrors that determination explicitly.
+
+---
+
+## Files Modified During Validation
+
+None.
+
+---
+
+## What was actually validated
+
+The manual checks that **are** appropriate for a no-op secret-rotation incident — all passing, all already recorded in `implementation.md`:
+
+| Manual Check | Result |
+|--------------|--------|
+| GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` is posted on issue #886 | ✅ (posted 2026-05-02T09:36:37Z) |
+| No `.github/RAILWAY_TOKEN_ROTATION_886.md` was fabricated | ✅ (would be a Category 1 error per CLAUDE.md) |
+| Investigation's referenced files exist in the repo (`.github/workflows/staging-pipeline.yml`, `docs/RAILWAY_TOKEN_ROTATION_742.md`) | ✅ |
+| Investigation copy at `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md` matches the workspace artifact byte-for-byte | ✅ |
+| No source files, workflow YAML, package manifests, or DB migrations touched | ✅ |
+
+---
+
+## Next Step
+
+Continue to PR creation. **Note**: there is one docs-only commit to push (the `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/*.md` bundle). The PR diff will contain only the three artifact markdown files, mirroring prior identical incidents (#876, #878, #880, #882, #884). There is no production-code surface for the PR to put at risk.


### PR DESCRIPTION
## Summary

Issue #886 is the **53rd** `RAILWAY_TOKEN is invalid or expired` failure on this repo, and the **13th today** (2026-05-02). This PR is a docs-only investigation bundle mirroring the resolution path of prior identical incidents (#876, #878, #880, #882, #884). **No source code, workflow YAML, or config is changed.** The fix is human secret rotation per `docs/RAILWAY_TOKEN_ROTATION_742.md` — agents cannot perform it.

## Root cause

Run [25248500899](https://github.com/alexsiri7/reli/actions/runs/25248500899) failed at the `Validate Railway secrets` step with:

```
##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized
```

The validator probes `https://backboard.railway.app/graphql/v2` with `{me{id}}` and exits 1 when the token is rejected. The `RAILWAY_TOKEN` GitHub Actions secret holds an expired/revoked Railway API token.

## Changes

| File | Action |
|------|--------|
| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md` | CREATE (full diagnosis + plan) |
| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/implementation.md` | CREATE (no-op rationale) |
| `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/validation.md` | CREATE (n/a checks + manual verification) |

No source code, workflow YAML, package manifests, or DB migrations touched.

## What the human still needs to do

1. Open https://railway.com/account/tokens and mint a new API token (request **No expiration**).
2. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the new token.
3. `gh run rerun 25248500899 --repo alexsiri7/reli --failed`.
4. Confirm the next staging deploy goes green and close #886.

## Why no `.github/RAILWAY_TOKEN_ROTATION_886.md`

Per `CLAUDE.md` — Railway Token Rotation:

> Creating documentation that claims success on an action you cannot perform is a Category 1 error.

The implementing agent did not fabricate such a file. A GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` was posted on issue #886 at 2026-05-02T09:36:37Z.

## Validation

| Check | Result |
|-------|--------|
| Type check | n/a — no code changed |
| Lint | n/a — no code changed |
| Tests | n/a — no code changed |
| Build | n/a — no code changed |
| Screenshot tests | n/a — no UI changed |
| Manual: investigation comment posted on #886 | ✅ |
| Manual: no `RAILWAY_TOKEN_ROTATION_886.md` fabricated | ✅ |
| Manual: investigation references real files (`staging-pipeline.yml`, runbook 742) | ✅ |

## Trend (out of scope for this fix)

5 consecutive ~30-minute incidents today (#878 → #880 → #882 → #884 → #886) suggest personal-token rotation alone is no longer keeping the pipeline green. A separate follow-up should evaluate a project-scoped Railway token, service account, or longer-TTL credential. **Not bundled into this PR** — Polecat scope discipline.

## Test plan

- [x] Branch pushed; PR opens against `main` as draft
- [x] PR diff contains only the three `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/*.md` files
- [ ] Human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`
- [ ] `gh run rerun 25248500899 --failed` goes green
- [ ] Issue #886 closed with a link to the green run

Fixes #886
