### PR TITLE
docs: investigation for #888 (54th RAILWAY_TOKEN expiration, 14th today)

### DIFF
--- a/artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/implementation.md
+++ b/artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/implementation.md
@@ -1,0 +1,106 @@
+# Implementation Report
+
+**Issue**: #888 — Prod deploy failed on main (54th RAILWAY_TOKEN expiration, 14th today)
+**Generated**: 2026-05-02 10:15
+**Workflow ID**: 1de35348acc7c51029dcba9e2d07e4dc
+**Worktree**: `/home/asiri/.archon/workspaces/ext-fast/reli/worktrees/archon/task-archon-fix-github-issue-1777716027418`
+**Branch**: `archon/task-archon-fix-github-issue-1777716027418`
+
+---
+
+## Outcome
+
+**No code changes were made.** The investigation artifact and `CLAUDE.md` both state — unambiguously — that this issue cannot be resolved by an agent. The only commit on this branch is the docs-only artifact bundle (this report and the investigation copy under `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/`).
+
+The agent-side deliverables defined in the investigation's Scope Boundaries (`investigation.md` Scope Boundaries section) are:
+
+1. Diagnose the deploy failure on run 25249000514 — **done in `investigation.md`**.
+2. Produce the investigation artifact — **done** (committed at `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md`).
+3. Post a GitHub comment routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` — **already posted** on issue #888 at 2026-05-02T10:07:13Z (verified via `gh issue view 888 --json comments`).
+
+All three are complete. There is no remaining code work this agent can legitimately perform.
+
+---
+
+## Why no code changes
+
+From `investigation.md` (Affected Files):
+
+> | File | Lines | Action | Description |
+> |------|-------|--------|-------------|
+> | (none) | — | — | No code changes required. Fix is a GitHub Actions **secret value** rotation performed in repo Settings → Secrets and variables → Actions. |
+
+From `CLAUDE.md` (Railway Token Rotation):
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+>
+> When CI fails with `RAILWAY_TOKEN is invalid or expired`:
+> 1. Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+> 2. File a GitHub issue or send mail to mayor with the error details.
+> 3. Direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` for the rotation runbook.
+>
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+Fabricating any code change, lint-trivial diff, or rotation doc here to satisfy the `/fix-issue` workflow's "must commit code" expectation would itself be a Category 1 error. The correct response is to record the no-op outcome in this artifact and stop.
+
+---
+
+## Tasks Completed
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Load investigation artifact from worktree path | ✅ |
+| 2 | Verify investigation marks the repo as code-correct (zero affected files) | ✅ |
+| 3 | Verify the GitHub comment routing the human to the runbook is already posted on #888 | ✅ (posted 2026-05-02T10:07:13Z) |
+| 4 | Confirm `.github/workflows/staging-pipeline.yml` and `docs/RAILWAY_TOKEN_ROTATION_742.md` exist (artifact integration points are accurate) | ✅ |
+| 5 | Confirm no `.github/RAILWAY_TOKEN_ROTATION_888.md` was created | ✅ (would be Category 1 error) |
+| 6 | Write this implementation report explaining the no-op | ✅ |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md` | CREATE | (full investigation, +163) |
+| `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/implementation.md` | CREATE | (this file) |
+
+No source code, no workflow YAML, no config, no tests, no migrations were touched.
+
+---
+
+## Deviations from Investigation
+
+None. The investigation explicitly stated that no code changes would be made, and none were made. The `/fix-issue` workflow's default expectation of "implement the plan and commit code" is itself the deviation that this report declines to perform — for the documented reasons above.
+
+---
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Type check | n/a — no code changed |
+| Tests | n/a — no code changed |
+| Lint | n/a — no code changed |
+| Manual: investigation comment posted on #888 | ✅ (2026-05-02T10:07:13Z) |
+| Manual: no `RAILWAY_TOKEN_ROTATION_888.md` fabricated | ✅ |
+| Manual: artifact paths in investigation match repo reality (`staging-pipeline.yml`, runbook 742) | ✅ |
+
+---
+
+## What the human still needs to do
+
+Per `docs/RAILWAY_TOKEN_ROTATION_742.md` and Step 1 of `investigation.md`:
+
+1. Open https://railway.com/account/tokens and mint a new API token.
+2. **If "No expiration" is missing or silently downgraded** — screenshot the dialog and report on issue #888 before creating any short-TTL token. The 14-per-day cadence (six consecutive ~30-minute incidents: #878 → #880 → #882 → #884 → #886 → #888) makes the upstream TTL the structural problem that rotation alone cannot fix.
+3. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and paste the new token.
+4. `gh run rerun 25249000514 --repo alexsiri7/reli --failed`.
+5. Confirm the next staging deploy goes green and close #888.
+6. **Recommended (urgent — was already recommended on #886)**: Send mail to mayor recommending a separate investigation into a project-scoped Railway token, Railway service account, or longer-TTL credential. The 54th occurrence (14th today, six consecutive ~30-minute intervals) makes it clear that simple personal-token rotation is no longer keeping the pipeline green and the previous recommendation should now be **acted on**, not re-recommended.
+
+---
+
+## Next Step
+
+Continue to the PR-creation step. The PR will be a docs-only bundle (`artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/*.md`) mirroring the resolution path of prior identical incidents (#876, #878, #880, #882, #884, #886). There is no source code to validate or push.

--- a/artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md
+++ b/artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md
@@ -1,0 +1,162 @@
+# Investigation: Prod deploy failed on main (RAILWAY_TOKEN expired — 54th occurrence)
+
+**Issue**: #888 (https://github.com/alexsiri7/reli/issues/888)
+**Type**: BUG (infrastructure / secret rotation)
+**Investigated**: 2026-05-02T09:40:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Prod deploy is fully blocked at the validator step (no workaround), but no data loss / security exposure; a known recurring infrastructure issue with a documented fix path. |
+| Complexity | LOW | Zero code changes required — a single GitHub Actions secret value (`RAILWAY_TOKEN`) must be replaced by a human admin via railway.com → repo Settings. |
+| Confidence | HIGH | Failed run 25249000514 logs the exact failure (`RAILWAY_TOKEN is invalid or expired: Not Authorized`) at the `Validate Railway secrets` step; identical signature to 53 prior incidents (#742 → … → #886). |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in run [25249000514](https://github.com/alexsiri7/reli/actions/runs/25249000514) failed at the **Validate Railway secrets** step at 2026-05-02T09:34:37Z. Railway's GraphQL API responded `Not Authorized` to the `{me{id}}` validation probe, meaning the `RAILWAY_TOKEN` GitHub Actions secret is expired or revoked. No subsequent build/deploy steps ran. This is the **54th** RAILWAY_TOKEN expiration tracked on this repo and the **14th today** (2026-05-02), arriving ~30 minutes after #886 — the steady ~30-minute inter-arrival now holds across **six** consecutive incidents (#878 → #880 → #882 → #884 → #886 → #888).
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+Railway API tokens have a finite lifetime. When the active `RAILWAY_TOKEN` GitHub Actions secret expires (or is revoked), the CI validator step (which probes `https://backboard.railway.app/graphql/v2` with `{me{id}}`) receives `Not Authorized` and halts the deploy. The fix is **secret rotation**, not a code change.
+
+### Evidence Chain
+
+WHY: Prod deploy failed on commit `9f430110e6e49950593e20fa9bc96f3749407c03` at 2026-05-02T09:34:39Z.
+↓ BECAUSE: The `Deploy to staging` workflow exited 1 at the `Validate Railway secrets` step.
+  Evidence: run log `2026-05-02T09:34:37.0777003Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: The validator's GraphQL probe to `backboard.railway.app/graphql/v2` returned `Not Authorized` — the token is rejected by Railway.
+  Evidence: validator step in `.github/workflows/staging-pipeline.yml` posts `{"query":"{me{id}}"}` and exits 1 if `.data.me.id` is missing.
+
+↓ ROOT CAUSE: The `RAILWAY_TOKEN` GitHub Actions secret holds an expired/revoked Railway API token.
+  Evidence: identical failure signature to issues #886, #884, #882, #880, #878, #876, …, #742 — all resolved by rotating the secret value via railway.com.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none) | — | — | No code changes required. Fix is a GitHub Actions **secret value** rotation performed in repo Settings → Secrets and variables → Actions. |
+
+### Integration Points
+
+- **GitHub Actions secret**: `RAILWAY_TOKEN` (consumed by every deploy workflow at the `Validate Railway secrets` step).
+- **Railway API**: `https://backboard.railway.app/graphql/v2` — issues and validates the token.
+- **Workflow**: `.github/workflows/staging-pipeline.yml` — the failing validator lives here.
+- **Runbook**: `docs/RAILWAY_TOKEN_ROTATION_742.md` — step-by-step rotation procedure.
+- **Repo policy**: `CLAUDE.md` "Railway Token Rotation" — agents MUST NOT claim to rotate the token.
+
+### Git History
+
+- **First occurrence on file**: tracked back to issue #742 (the runbook is named for it).
+- **Today's volume**: 14 expirations as of 2026-05-02 (#888 is the 14th today, the 54th overall).
+- **Inter-arrival**: ~30 minutes from #886 (run 25248500899 → 25249000514). The accelerated cadence has now held for **six** consecutive incidents (#878 → #880 → #882 → #884 → #886 → #888).
+- **Implication**: Personal-token rotation alone is no longer keeping the pipeline green. **Out of scope for this fix** — but escalation to mayor for a structural fix (project-scoped Railway token, service account, or longer-TTL credential) is now urgent. The previous investigation (#886) recommended this; #888 is direct evidence the recommendation should be acted on rather than re-recommended.
+
+---
+
+## Implementation Plan
+
+This investigation produces **no code changes**. The required action is human secret rotation.
+
+### Step 1: Human rotates `RAILWAY_TOKEN`
+
+**Actor**: A repo admin with railway.com access (agents cannot perform this step).
+**Action**: Follow `docs/RAILWAY_TOKEN_ROTATION_742.md`:
+
+1. Log into railway.com.
+2. Generate a new API token under Account Settings → Tokens.
+3. In GitHub: repo Settings → Secrets and variables → Actions → update `RAILWAY_TOKEN` with the new value.
+4. Re-run the failed workflow at https://github.com/alexsiri7/reli/actions/runs/25249000514 (or wait for next push to `main`).
+5. Confirm the next deploy goes green.
+6. Close issue #888.
+
+### Step 2 (DO NOT DO): Create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is complete
+
+Per `CLAUDE.md` Railway Token Rotation policy:
+> Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+The implementing agent for this issue MUST NOT create such a file. The only correct outcome from an agent is **filing/updating this issue and waiting for a human**.
+
+### Step 3 (Follow-up, OUT OF SCOPE for this bead): Escalate the rotation cadence to mayor
+
+14 expirations in one day with a steady ~30-minute inter-arrival (six consecutive incidents) is a structural problem. A separate follow-up should:
+- Send mail to mayor summarising the trend (#878 → #880 → #882 → #884 → #886 → #888, all today, all RAILWAY_TOKEN, all ~30 min apart).
+- Recommend evaluating: project-scoped Railway token, Railway service account, long-lived deploy credential, or alternate hosting.
+- Track the work as its own issue, not bundled with this incident.
+
+Per "Polecat Scope Discipline" in `CLAUDE.md`, do **not** address this in the current bead.
+
+---
+
+## Patterns to Follow
+
+**From repo history — mirror the resolution path of prior identical incidents (e.g., #742, #876, #878, #880, #882, #884, #886):**
+
+- The fix commit/PR for those issues was a **docs-only investigation note**, not a code change.
+- The token rotation itself was performed by a human admin out-of-band.
+- The issue was closed only after the next deploy ran green.
+
+The most recent precedent — `artifacts/runs/e91bc4fa93b72a9e8e01cfa3db770a5d/investigation.md` (issue #886) — is the template this artifact mirrors.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent tries to "fix" by creating a `RAILWAY_TOKEN_ROTATION_888.md` claiming success | Explicitly forbidden by `CLAUDE.md`; reject any such PR. |
+| Agent tries to read the secret value | Impossible — GitHub masks secrets. |
+| New token leaks into logs | Validator only echoes `***`; no change needed. |
+| Multiple in-flight deploy jobs after rotation | Re-run only the most recent failed run; older runs will have stale workflow definitions but will succeed if token is now valid. |
+| The 14-per-day cadence indicates a deeper issue | File a separate follow-up issue / mail mayor (see Step 3). Do not bundle with this fix. |
+| #886 already routed to the operator ~30 min ago — operator may rotate once and clear both | Acceptable: a single rotation will green-light any subsequent failed run. The issue tracker still benefits from #888 having its own routed comment. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# After human rotates the secret, re-run the failed workflow:
+gh run rerun 25249000514
+gh run watch 25249000514
+```
+
+### Manual Verification
+
+1. Confirm the `Validate Railway secrets` step reports success (no `Not Authorized`).
+2. Confirm subsequent deploy steps complete and the staging URL responds.
+3. Confirm the next push to `main` triggers a green deploy.
+4. Close issue #888 with a comment linking the green run.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Diagnosing the failure as a `RAILWAY_TOKEN` expiration.
+- Producing this investigation artifact.
+- Posting a comment on issue #888 directing a human to the rotation runbook.
+
+**OUT OF SCOPE (do not touch):**
+- The token rotation itself (humans only — `CLAUDE.md` policy).
+- Creating a `.github/RAILWAY_TOKEN_ROTATION_888.md` file (Category 1 error per `CLAUDE.md`).
+- Modifying the validator workflow.
+- Escalating the 14/day cadence to mayor (file separate issue / mail).
+- Any frontend, backend, or DB changes — this is purely a secret-rotation incident.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T09:40:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md`


### PR DESCRIPTION
## Summary

Docs-only investigation/implementation artifact bundle for issue #888 — the 54th `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure on `staging-pipeline.yml` (run [25249000514](https://github.com/alexsiri7/reli/actions/runs/25249000514)), and the 14th today (2026-05-02). Six consecutive ~30-minute intervals: #878 → #880 → #882 → #884 → #886 → #888.

Per `CLAUDE.md` "Railway Token Rotation": agents cannot rotate the secret. The deliverable is the investigation artifact + an issue comment routing the human operator to `docs/RAILWAY_TOKEN_ROTATION_742.md` (already posted on #888 at 2026-05-02T10:07:13Z).

## Changes

- `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/investigation.md` — root cause, evidence chain, scope boundaries.
- `artifacts/runs/1de35348acc7c51029dcba9e2d07e4dc/implementation.md` — explicit no-op outcome with Category 1 guardrails.

No source/workflow/config/test/migration changes. No `.github/RAILWAY_TOKEN_ROTATION_888.md` fabricated (would be Category 1 error per `CLAUDE.md`).

## Validation

Per `validation.md`:

| Check | Result |
|-------|--------|
| Type check / Lint / Format / Tests / Build | ⏭ n/a — branch diff is markdown only |
| Branch diff is documentation only | ✅ `artifacts/runs/.../implementation.md` + `investigation.md` |
| No `.github/RAILWAY_TOKEN_ROTATION_888.md` fabricated | ✅ |
| Artifact files present and well-formed | ✅ |
| Integration points (`staging-pipeline.yml`, runbook 742) exist | ✅ |
| Routing comment posted on #888 | ✅ (2026-05-02T10:07:13Z) |

## What the human still needs to do

1. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`.
2. `gh run rerun 25249000514 --repo alexsiri7/reli --failed`.
3. Confirm next staging deploy goes green and close #888.
4. **Urgent recurrence escalation**: 14 expirations today, six consecutive ~30-minute intervals — personal-token rotation alone is no longer keeping the pipeline green. The recommendation made on #886 (mail mayor for project-scoped token / service-account / longer-TTL credential) should now be acted on rather than re-recommended.

Fixes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)