### PR TITLE
docs: investigation for issue #901 (59th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md
+++ b/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md
@@ -7,7 +7,7 @@ type: implementation
 # Implementation Report
 
 **Issue**: #901 — Main CI red: Deploy to staging (RAILWAY_TOKEN rejected — 59th occurrence)
-**Generated**: 2026-05-02 16:15
+**Generated**: 2026-05-02 15:15
 **Workflow ID**: ff852270fcf951e842e7b9d076dc1e0a
 **Branch**: `archon/task-archon-fix-github-issue-1777734045651`
 **Predecessor pattern**: #898 / PR #899 (commit `13bf51e`)
@@ -95,7 +95,7 @@ Resolution requires the human admin to execute the four steps recorded in the ro
 ## Metadata
 
 - **Implemented by**: Claude (Opus 4.7)
-- **Timestamp**: 2026-05-02T16:15:00Z
+- **Timestamp**: 2026-05-02T15:15:00Z
 - **Artifact dir**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/`
 - **Companion artifacts**: `investigation.md`, `web-research.md` (both this run dir)
 - **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25252013103

--- a/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md
+++ b/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md
@@ -1,0 +1,102 @@
+---
+name: Implementation report — issue #901 (RAILWAY_TOKEN, 59th occurrence)
+description: Docs-only delivery for the 59th RAILWAY_TOKEN rejection; scope-guard verifications; routing comment recorded as posted in investigation phase.
+type: implementation
+---
+
+# Implementation Report
+
+**Issue**: #901 — Main CI red: Deploy to staging (RAILWAY_TOKEN rejected — 59th occurrence)
+**Generated**: 2026-05-02 16:15
+**Workflow ID**: ff852270fcf951e842e7b9d076dc1e0a
+**Branch**: `archon/task-archon-fix-github-issue-1777734045651`
+**Predecessor pattern**: #898 / PR #899 (commit `13bf51e`)
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Place investigation artifact in committable path | `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | ✅ |
+| 2 | Place web-research artifact in committable path | `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | ✅ |
+| 3 | Write implementation report | `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md` | ✅ |
+| 4 | Verify Category 1 guard (no `.github/RAILWAY_TOKEN_ROTATION_901.md`) | n/a | ✅ |
+| 5 | Verify Polecat scope (workflow / runbook / `DEPLOYMENT_SECRETS.md` unmodified) | n/a | ✅ |
+| 6 | Routing comment on issue #901 | GitHub issue #901 | ✅ (posted in investigation phase) |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | CREATE | +179 |
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | CREATE | +152 |
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md` | CREATE | +this file |
+
+No source code, workflow, runbook, or `.github/RAILWAY_TOKEN_ROTATION_*.md` files were modified — per `CLAUDE.md` § "Railway Token Rotation" and Polecat Scope Discipline.
+
+---
+
+## Scope-Guard Verifications
+
+| Guard | Method | Result |
+|-------|--------|--------|
+| No `.github/RAILWAY_TOKEN_ROTATION_901.md` | `ls .github/RAILWAY_TOKEN_ROTATION_901.md` → not found | ✅ |
+| `.github/workflows/staging-pipeline.yml` unmodified | `git status --porcelain` shows no entry | ✅ |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` unmodified | `git status --porcelain` shows no entry | ✅ |
+| `DEPLOYMENT_SECRETS.md` unmodified | `git status --porcelain` shows no entry | ✅ |
+| Only artifact files staged | `git status --porcelain` shows only `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/` | ✅ |
+
+---
+
+## Deviations from Investigation
+
+### Deviation 1: Routing comment was posted during the investigation phase, not implementation
+
+**Expected** (Implementation Plan, Step 2): Implementation agent posts routing comment on issue #901.
+**Actual**: Routing comment titled "🔍 Investigation: Main CI red — Deploy to staging (RAILWAY_TOKEN rejected, 59th occurrence)" was already posted by the investigation phase (verified via `gh issue view 901 --json comments`).
+**Reason**: This matches the predecessor pattern (#898 / PR #899) — the routing comment is part of the investigation deliverable, posted at investigation time. No second comment posted to avoid noise.
+
+No other deviations.
+
+---
+
+## Validation Results
+
+This bead is docs-only — there is no code to type-check, test, or lint in the produced diff. The validation steps in the investigation artifact (`gh workflow run railway-token-health.yml`, `gh run rerun 25252013103 --failed`) are **post-rotation human steps** and cannot be executed by an agent (per `CLAUDE.md` § "Railway Token Rotation").
+
+| Check | Result |
+|-------|--------|
+| Type check | n/a (no code changes) |
+| Tests | n/a (no code changes) |
+| Lint | n/a (no code changes) |
+| Markdown well-formed | ✅ (artifacts render in GitHub) |
+| Scope guards | ✅ (see table above) |
+
+---
+
+## What This PR Does Not Do
+
+Per `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+
+This PR therefore:
+- Does **not** rotate `RAILWAY_TOKEN`.
+- Does **not** create a `.github/RAILWAY_TOKEN_ROTATION_901.md` claiming success on a human-only action (Category 1 error).
+- Does **not** modify the workflow validator or the runbook (Polecat scope; the runbook-revision hypothesis is captured in `web-research.md` for a separate bead).
+
+Resolution requires the human admin to execute the four steps recorded in the routing comment on issue #901.
+
+---
+
+## Metadata
+
+- **Implemented by**: Claude (Opus 4.7)
+- **Timestamp**: 2026-05-02T16:15:00Z
+- **Artifact dir**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/`
+- **Companion artifacts**: `investigation.md`, `web-research.md` (both this run dir)
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25252013103
+- **Predecessor**: PR #899 (commit `13bf51e`) for issue #898

--- a/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md
+++ b/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md
@@ -1,0 +1,179 @@
+# Investigation: Main CI red — Deploy to staging (RAILWAY_TOKEN rejected — 59th occurrence)
+
+**Issue**: #901 (https://github.com/alexsiri7/reli/issues/901)
+**Type**: BUG (infrastructure / secret rotation — recurring)
+**Investigated**: 2026-05-02T16:10:00Z
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Staging (and downstream production + smoke-test jobs) fully blocked at the `Validate Railway secrets` pre-flight; no CI workaround; no data loss or security exposure; identical recurring pattern to 58 prior incidents. |
+| Complexity | LOW | Zero code changes for this bead — a single GitHub Actions secret value (`RAILWAY_TOKEN`) must be replaced by a human admin via railway.com → repo Settings. Per `CLAUDE.md` § "Railway Token Rotation", agents cannot perform this action. |
+| Confidence | HIGH | Run [25252013103](https://github.com/alexsiri7/reli/actions/runs/25252013103) summary logs the exact error string `RAILWAY_TOKEN is invalid or expired: Not Authorized` at the `Validate Railway secrets` step (workflow created `2026-05-02T12:34:28Z`); identical signature to 58 prior incidents (#742 → … → #898); web-research findings are already on file in this run's `web-research.md`. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in run [25252013103](https://github.com/alexsiri7/reli/actions/runs/25252013103) failed at the **Validate Railway secrets** step. Railway's GraphQL API responded `Not Authorized` to the `{me{id}}` validation probe — the `RAILWAY_TOKEN` GitHub Actions secret is rejected. The downstream `Deploy to production` and `Staging E2E smoke tests` jobs were skipped (showing `-` in the run summary).
+
+This is the **59th** RAILWAY_TOKEN rejection tracked on this repo and the **19th today** (2026-05-02). Issue #898 was the immediate predecessor; the chain has now extended to **eleven** consecutive incidents (#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901), with each prior rotation followed by another rejection at the next deploy attempt. The `web-research.md` in this run dir documents the project-token-vs-account-token hypothesis that may explain why like-for-like rotations are not breaking the chain.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+**WHY**: Run 25252013103 (`Staging → Production Pipeline` on commit `13bf51e9`) failed.
+↓ **BECAUSE**: The `Deploy to staging` job (`ID 74045436358`) exited 1 at the `Validate Railway secrets` step.
+&nbsp;&nbsp;Evidence (run summary): `X RAILWAY_TOKEN is invalid or expired: Not Authorized` followed by `X Process completed with exit code 1.`
+↓ **BECAUSE**: The validator's GraphQL probe to `backboard.railway.app/graphql/v2` returned a response without `.data.me.id`, so the `jq -e` check at line 53 failed.
+&nbsp;&nbsp;Evidence: `.github/workflows/staging-pipeline.yml:49-58` posts `{"query":"{me{id}}"}` with `Authorization: Bearer $RAILWAY_TOKEN` and exits 1 with the observed error string when `.data.me.id` is missing.
+↓ **ROOT CAUSE (surface)**: The `RAILWAY_TOKEN` GitHub Actions secret holds a token Railway no longer accepts. Identical to #898, #896, #894, #891, #888, …, #742 — all resolved (when resolved) by rotating the secret value via railway.com.
+
+> **Deeper hypothesis (already documented in this run's `web-research.md`)**: 11 rejections in a tight chain is not consistent with simple TTL expiration. Railway docs reserve the env-var name `RAILWAY_TOKEN` for **project tokens** (used with the `Project-Access-Token` header), while account/workspace tokens (which the validator's `Authorization: Bearer` + `{me{id}}` probe actually requires) belong in `RAILWAY_API_TOKEN`. If the runbook is directing humans to mint a project token at https://railway.com/account/tokens (it is not — but the secret name suggests one), the rotation would always fail-on-arrival. **This is out of scope for #901** (Polecat Scope Discipline) — escalation to mayor is captured in `web-research.md` § Recommendations #2.
+
+### Affected Files
+
+No source code, workflow, or runbook changes. This bead produces investigation artifacts only — see `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+> Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done.
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | NEW | CREATE | This document — failing run, error, runbook pointer, prior-occurrence count |
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | EXISTING | KEEP | Already on disk — captures the project-token-vs-account-token hypothesis. Do not edit. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — the failing `Validate Railway secrets` step that probes Railway with `{me{id}}` and exits 1 on rejection. **Do not modify.** It is the correct fail-fast guard.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the human-facing rotation runbook (52 lines). **Do not modify in this bead.**
+- `DEPLOYMENT_SECRETS.md` — referenced by the validator's error message (`"See DEPLOYMENT_SECRETS.md for setup instructions."`); describes the secrets the workflow expects.
+
+### Git History
+
+- **Workflow last touched**: `git log .github/workflows/staging-pipeline.yml` — the validator step is stable; the recurring failures are an environment/secret problem, not a code regression.
+- **Issue cadence**: Issue #898 was created at `2026-05-02T12:00:20Z` and closed at `2026-05-02T12:30:10Z`; #901 was filed at `2026-05-02T13:00:27Z` against run 25252013103 (`createdAt 2026-05-02T12:34:28Z`). The next deploy attempt after #898's close failed within ~4 minutes — consistent with the secret remaining rejected even after the human-cycle on #898.
+- **Most recent merged investigation**: PR #899 (commit `13bf51e`) for #898 — same docs-only pattern this bead follows.
+
+---
+
+## Implementation Plan
+
+This is a **docs-only** investigation. No source files are modified. The implementing agent's job is to:
+
+1. Confirm `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` (this file) and `web-research.md` (already on disk) are committed.
+2. Post a routing comment on issue #901 directing the human admin to `docs/RAILWAY_TOKEN_ROTATION_742.md` and to `web-research.md` for the runbook-revision hypothesis.
+3. **Not** create `.github/RAILWAY_TOKEN_ROTATION_901.md` (Category 1 error per `CLAUDE.md`).
+4. **Not** modify the workflow, the runbook, `DEPLOYMENT_SECRETS.md`, or any backend/frontend source.
+
+| Step | Actor | Action |
+|------|-------|--------|
+| 1 | **Human admin** | Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`. **Before re-rotating like-for-like, read `web-research.md` § Recommendations** — the secret name vs auth-scheme mismatch may be the actual cause. |
+| 2 | Human admin | Verify the new token: `gh workflow run railway-token-health.yml --repo alexsiri7/reli` and watch it pass before re-running staging. |
+| 3 | Human admin | Re-run the failed pipeline: `gh run rerun 25252013103 --repo alexsiri7/reli --failed`. |
+| 4 | Human admin | Confirm `Validate Railway secrets` passes; close #901 with the green run URL. |
+
+> ⚠️ **Per `CLAUDE.md` Railway Token Rotation policy, agents cannot rotate this token.** No `.github/RAILWAY_TOKEN_ROTATION_901.md` will be created — that is a Category 1 error.
+
+### Step 1: Human admin rotates the secret
+
+**Action**: Replace the value of GitHub Actions secret `RAILWAY_TOKEN` in repo Settings → Secrets and variables → Actions with a freshly minted Railway API token (per `docs/RAILWAY_TOKEN_ROTATION_742.md`, "No expiration" selected).
+
+**Why**: Railway has rejected the current token value. The validator step blocks the deploy until a token that authenticates against `backboard.railway.app/graphql/v2` is in place.
+
+### Step 2: Verify the new token before re-running the deploy
+
+```bash
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run watch <new-run-id> --repo alexsiri7/reli
+```
+
+**Why**: Catches a bad rotation (typo, wrong token type) before the staging pipeline burns another deploy slot on a token that won't authenticate.
+
+### Step 3: Re-run the failed pipeline
+
+```bash
+gh run rerun 25252013103 --repo alexsiri7/reli --failed
+gh run watch 25252013103 --repo alexsiri7/reli
+```
+
+**Why**: The original failure is in the validation step; nothing downstream ran (`Deploy to production` and `Staging E2E smoke tests` are listed with `-`). Re-running `--failed` resumes from the failed job with the new secret value.
+
+---
+
+## Patterns to Follow
+
+This investigation follows the pattern established by the immediately preceding RAILWAY_TOKEN beads — most recently #898 / PR #899:
+
+- Investigation artifact at `artifacts/runs/<workflow_id>/investigation.md` only.
+- Routing comment posted on the GitHub issue.
+- No `.github/RAILWAY_TOKEN_ROTATION_*.md` created (Category 1 guard).
+- No workflow / runbook / source modifications (Polecat Scope Discipline).
+- The runbook-revision hypothesis is already on record in `web-research.md` for this run — link to it from the routing comment, do not re-litigate it here.
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Human rotates with the same (wrong-type or short-TTL) token; chain continues to issue #903+ | Routing comment links to `web-research.md` § Recommendations #2 so the admin can consider the runbook-revision options before re-rotating like-for-like. |
+| Merging the implementation PR triggers another deploy on the still-dead token, producing a successor `Main CI red: Deploy to staging` issue | Expected — documented here. The chain only stops once the secret is rotated correctly. The `archon:in-progress` label on #901 prevents pickup-cron double-firing. |
+| Agent accidentally creates `.github/RAILWAY_TOKEN_ROTATION_901.md` | Explicit Category 1 guard above; implementer must verify no such file is staged before committing. |
+| Agent modifies the workflow or runbook beyond scope | Polecat Scope Discipline — out-of-scope ideas are mailed to mayor (`web-research.md` already records the recommended escalation), not implemented in this PR. |
+| `web-research.md` already exists in the run dir before this bead started | Treat it as authoritative for the deeper hypothesis — link to it; do not duplicate or rewrite it. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# After human rotation:
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run rerun 25252013103 --repo alexsiri7/reli --failed
+gh run watch 25252013103 --repo alexsiri7/reli
+```
+
+Expected: `Validate Railway secrets` step prints success and the downstream `Deploy staging image to Railway` step proceeds with no `Not Authorized` from `serviceInstanceUpdate`.
+
+### Manual Verification
+
+1. Confirm no `.github/RAILWAY_TOKEN_ROTATION_901.md` file exists in the PR diff (Category 1 guard).
+2. Confirm `.github/workflows/staging-pipeline.yml` and `docs/RAILWAY_TOKEN_ROTATION_742.md` are unmodified in the PR diff (Polecat scope).
+3. Confirm `DEPLOYMENT_SECRETS.md` is unmodified.
+4. Confirm the routing comment is posted on issue #901 with a link to the runbook and to `web-research.md`.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Create `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` (this document).
+- Post a routing comment on issue #901 directing the human admin to the rotation runbook.
+- Acknowledge the existing `web-research.md` (do not modify).
+
+**OUT OF SCOPE (do not touch):**
+- `.github/workflows/staging-pipeline.yml` (the validator is correct as written).
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` (runbook revision is a separate bead per `web-research.md` § Recommendations #2).
+- `DEPLOYMENT_SECRETS.md`.
+- Any backend / frontend source.
+- Performing the rotation itself (`CLAUDE.md` Category 1 error).
+- Creating any `.github/RAILWAY_TOKEN_ROTATION_*.md` (`CLAUDE.md` Category 1 error).
+- Re-publishing the project-token-vs-account-token hypothesis already captured in `web-research.md`.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7, 1M context)
+- **Timestamp**: 2026-05-02T16:10:00Z
+- **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md`
+- **Companion**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md`
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25252013103
+- **Predecessor bead**: #898 / PR #899 (commit `13bf51e`)

--- a/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md
+++ b/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md
@@ -2,7 +2,7 @@
 
 **Issue**: #901 (https://github.com/alexsiri7/reli/issues/901)
 **Type**: BUG (infrastructure / secret rotation — recurring)
-**Investigated**: 2026-05-02T16:10:00Z
+**Investigated**: 2026-05-02T15:00:00Z
 
 ### Assessment
 
@@ -44,8 +44,8 @@ No source code, workflow, or runbook changes. This bead produces investigation a
 
 | File | Lines | Action | Description |
 |------|-------|--------|-------------|
-| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | NEW | CREATE | This document — failing run, error, runbook pointer, prior-occurrence count |
-| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | EXISTING | KEEP | Already on disk — captures the project-token-vs-account-token hypothesis. Do not edit. |
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | +179 | CREATE | This document — failing run, error, runbook pointer, prior-occurrence count |
+| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | 152 | KEEP | Already on disk — captures the project-token-vs-account-token hypothesis. Do not edit. |
 
 ### Integration Points
 
@@ -172,7 +172,7 @@ Expected: `Validate Railway secrets` step prints success and the downstream `Dep
 ## Metadata
 
 - **Investigated by**: Claude (Opus 4.7, 1M context)
-- **Timestamp**: 2026-05-02T16:10:00Z
+- **Timestamp**: 2026-05-02T15:00:00Z
 - **Artifact**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md`
 - **Companion**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md`
 - **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25252013103

--- a/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md
+++ b/artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md
@@ -1,0 +1,152 @@
+# Web Research: fix #901
+
+**Researched**: 2026-05-02T16:00:00Z
+**Workflow ID**: ff852270fcf951e842e7b9d076dc1e0a
+**Issue**: alexsiri7/reli#901 — "Main CI red: Deploy to staging" (RAILWAY_TOKEN is invalid or expired: Not Authorized)
+
+---
+
+## Summary
+
+This is the 59th recurring `RAILWAY_TOKEN` expiration in alexsiri7/reli (the 19th today alone). The repo's CLAUDE.md is unambiguous: **agents cannot rotate the Railway API token** — that requires a human at https://railway.com/account/tokens. The standing remediation is to file an issue and point the human at `docs/RAILWAY_TOKEN_ROTATION_742.md`. Web research surfaces one important *non-rotation* finding: the current workflow uses `Authorization: Bearer` against the Railway GraphQL API, which is the auth scheme for **account/workspace tokens** (set as `RAILWAY_API_TOKEN`), not for **project tokens** (which Railway's docs and community reserve for the env var name `RAILWAY_TOKEN` and which use the `Project-Access-Token` header). This naming/scheme mismatch may itself be a contributor to the chronic expiration cycle and is worth flagging — but per Polecat scope discipline, that change is **out of scope for this bead** and should be raised separately with mayor.
+
+---
+
+## Findings
+
+### 1. Railway Token Types & Headers
+
+**Source**: [Using the CLI | Railway Docs](https://docs.railway.com/guides/cli)
+**Authority**: Official Railway documentation
+**Relevant to**: Why the token keeps "expiring" / failing auth even after rotation
+
+**Key Information**:
+
+- **Project Token**: Scoped to a single environment within a project. Set via `RAILWAY_TOKEN` env var. Used by the Railway CLI for project-level deploy actions.
+- **Account Token / Workspace Token**: Broader scope, can authenticate "all CLI actions across all resources and workspaces." Set via `RAILWAY_API_TOKEN` env var.
+- **Header difference (critical)**: Project tokens use the `Project-Access-Token` HTTP header. Account, workspace, and OAuth tokens use `Authorization: Bearer`.
+- Railway recommends Project Tokens for most CI/CD deploys because they have minimum-necessary scope.
+
+---
+
+### 2. "RAILWAY_TOKEN invalid or expired" Root Cause (Community Q&A)
+
+**Source**: [RAILWAY_TOKEN invalid or expired — Railway Help Station](https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20)
+**Authority**: Official Railway community help forum, with confirmed-working answer
+**Relevant to**: Whether our recurring failure is *expiration* or a *token-type mismatch*
+
+**Key Information**:
+
+- Direct quote: *"RAILWAY_TOKEN now only accepts project token; if u put the normal account token… it literally says 'invalid or expired' even if u just made it 2 seconds ago."*
+- Resolution recommended by the forum: create a **project token** (Project Settings → Tokens), not an account token, and assign it to `RAILWAY_TOKEN`.
+- Conflicting tip in the same thread: if both `RAILWAY_TOKEN` and `RAILWAY_API_TOKEN` are set, `RAILWAY_TOKEN` takes precedence — having both can mask the real failure.
+
+**Caveat**: This is community guidance, not an SLA — and it specifically applies to the **Railway CLI**. Our workflow does not use the CLI; it calls the GraphQL API directly with `Authorization: Bearer $RAILWAY_TOKEN`, which is the *account-token* auth scheme. So the forum's "use a project token" advice does not transfer 1:1 — see the Conflicts section below.
+
+---
+
+### 3. Railway GraphQL API Authentication
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: What auth scheme `.github/workflows/staging-pipeline.yml` is actually using
+
+**Key Information**:
+
+- The Railway GraphQL endpoint at `https://backboard.railway.app/graphql/v2` accepts both account and project tokens, but with different headers.
+- `{ me { id } }` (the query our workflow uses to *validate* the token at line 52 of `staging-pipeline.yml`) is an **account-scoped query**. A pure project token would not necessarily return a user from `me`.
+- For an account token used over the GraphQL API, the canonical env-var name is `RAILWAY_API_TOKEN`.
+
+---
+
+### 4. OAuth Access-Token Expiration (NOT what we hit)
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens)
+**Authority**: Official Railway documentation
+**Relevant to**: Ruling out one "obvious" hypothesis
+
+**Key Information**:
+
+- OAuth **access tokens** expire after 1 hour; OAuth **refresh tokens** expire after 1 year.
+- This is the OAuth flow only — it does **not** apply to manually-created project or account tokens from the dashboard, which is what GitHub Actions uses.
+- So: our token is not expiring on a 1-hour OAuth clock. Either it has a TTL set at creation time, the workspace was rotated/revoked, or the wrong token *type* was used (see #2 above).
+
+---
+
+### 5. Existing Rotation Runbook
+
+**Source**: `docs/RAILWAY_TOKEN_ROTATION_742.md` (in-repo)
+**Authority**: Project's own runbook, established at issue #742
+**Relevant to**: What the human should actually do
+
+**Key Information**:
+
+- Tells the operator to create a token at https://railway.com/account/tokens (account-tokens page) named `github-actions-permanent`, with **"No expiration"** selected.
+- Then `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` and re-run the failed workflow.
+- The runbook itself notes: *"Previous rotations may have used these defaults. The new token must be created with 'No expiration'."*
+- Recurrence count visible from `git log` is now ~59 — so either "No expiration" is not actually permanent, the option is being missed during rotation, or a second factor (token type / revocation) is causing this independent of TTL.
+
+---
+
+## Code Examples
+
+The current validation snippet in `.github/workflows/staging-pipeline.yml:49-58` (for context, not for change in this bead):
+
+```yaml
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  exit 1
+fi
+```
+
+The `Authorization: Bearer` + `me{id}` combination is the **account-token** pattern per Railway docs ([Public API](https://docs.railway.com/integrations/api)).
+
+---
+
+## Gaps and Conflicts
+
+- **Gap**: Railway docs do not publicly document the menu of TTL options ("No expiration", 1d, 7d, 30d, etc.) on the account-tokens page. The runbook claim that "No expiration" is available is uncorroborated by web sources reachable here. If the Railway UI silently changed (e.g., maximum TTL is now 90d on a Hobby plan), every "permanent" rotation would still expire — which would fit the observed recurrence pattern.
+- **Conflict**: Community guidance ("use a project token, not an account token, with `RAILWAY_TOKEN`") collides with the workflow's actual usage (`Authorization: Bearer` + `me{id}` query, which require an *account* token). Following the community advice naively would break deploy in a different way.
+- **Gap**: No public Railway statement was found about a token revocation/rotation event in May 2026 that would explain the 19-in-one-day clustering. The [Jan 2026 incident report](https://blog.railway.com/p/incident-report-january-26-2026) is unrelated. If Railway did mass-rotate, that should be visible on their status page or a follow-up post — could not confirm either way.
+- **Gap**: Whether `RAILWAY_API_TOKEN` is also set as a GitHub secret (which would silently break things per #2) — not visible from web search; would need `gh secret list` to confirm. Out of scope for web research.
+
+---
+
+## Recommendations
+
+Listed in increasing scope. **Only #1 is in scope for this bead** per CLAUDE.md and Polecat discipline.
+
+1. **In scope — file the issue and stop.** The fix for #901 itself is for the human to follow `docs/RAILWAY_TOKEN_ROTATION_742.md`: create a new account token at https://railway.com/account/tokens with "No expiration", set it via `gh secret set RAILWAY_TOKEN`, and re-run the failed run (`gh run rerun 25252013103 --repo alexsiri7/reli --failed`). Per CLAUDE.md, the agent must NOT create a new `RAILWAY_TOKEN_ROTATION_*.md` claiming the rotation is done, and must NOT attempt the rotation itself (Category 1 error).
+
+2. **Out of scope — escalate to mayor.** The 59-occurrence pattern strongly suggests root cause is *not* "operator forgets to pick No expiration." Two likelier candidates worth a separate bead:
+   - **Verify the "No expiration" option still exists on the Railway account-tokens UI** (and screenshot it for the runbook). If Railway has imposed a maximum TTL, the current runbook is unactionable as written.
+   - **Confirm token type matches header.** The workflow uses `Authorization: Bearer` + `{me{id}}`, which is the account-token pattern, but the secret is named `RAILWAY_TOKEN` (which the Railway CLI and community treat as project-token-only). Renaming the secret to `RAILWAY_API_TOKEN` would (a) make the intent self-documenting and (b) eliminate the risk that someone "rotates" by pasting in a project token (which would 401 immediately and look like expiration).
+   - Both should be raised via `gt mail send mayor/ --subject "Railway token: investigate root cause of 59x expiration cycle"`.
+
+3. **Out of scope — do not attempt.** Switching to a project token + `Project-Access-Token` header would require rewriting all GraphQL calls in the workflow to drop `me{id}` and use project-scoped queries instead. This is a non-trivial change and must come from a human-authored bead.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Docs — Using the CLI | https://docs.railway.com/guides/cli | Official: `RAILWAY_TOKEN` vs `RAILWAY_API_TOKEN` semantics |
+| 2 | Railway Docs — Public API | https://docs.railway.com/integrations/api | Official: GraphQL auth headers per token type |
+| 3 | Railway Docs — Login & Tokens (OAuth) | https://docs.railway.com/integrations/oauth/login-and-tokens | Rules out OAuth 1-hour expiration as the cause |
+| 4 | Railway Docs — Troubleshooting | https://docs.railway.com/integrations/oauth/troubleshooting | Official troubleshooting for auth failures |
+| 5 | Railway Docs — CLI Reference | https://docs.railway.com/cli | Confirms env-var-vs-token-type mapping |
+| 6 | Help Station — RAILWAY_TOKEN invalid or expired | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Community: "RAILWAY_TOKEN only accepts project tokens" |
+| 7 | Help Station — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Community CI/CD pattern |
+| 8 | Help Station — Authentication not working with RAILWAY_TOKEN | https://station.railway.com/questions/authentication-not-working-with-railway-b3f522c7 | Common failure modes |
+| 9 | Help Station — CLI throwing "Unauthorized" with RAILWAY_TOKEN | https://station.railway.com/questions/cli-throwing-unauthorized-with-railway-24883ba1 | Confirms "Unauthorized" is the standard error string |
+| 10 | Help Station — RAILWAY_API_TOKEN not being respected | https://station.railway.com/questions/railway-api-token-not-being-respected-364b3135 | Two-token precedence behavior |
+| 11 | railwayapp/cli#699 | https://github.com/railwayapp/cli/issues/699 | Known auth failures on Linux runners |
+| 12 | railwayapp/cli#425 | https://github.com/railwayapp/cli/issues/425 | "Not authorized" on `railway down` from Actions |
+| 13 | Railway blog — Jan 28-29 2026 incident | https://blog.railway.com/p/incident-report-january-26-2026 | Ruled out as cause (different incident) |
+| 14 | In-repo runbook | `docs/RAILWAY_TOKEN_ROTATION_742.md` | The exact remediation steps for the human |


### PR DESCRIPTION
## Summary

Docs-only investigation for the **59th** `RAILWAY_TOKEN` rejection (the **19th today**, 2026-05-02). Failing run [25252013103](https://github.com/alexsiri7/reli/actions/runs/25252013103) `Deploy to staging` exited 1 at the `Validate Railway secrets` step with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. Identical pattern to predecessor #898 / PR #899.

Per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate this token — it requires human access to railway.com. This PR records the investigation only and routes the human admin to `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md` | CREATE | +179 |
| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md` | CREATE | +152 |
| `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md` | CREATE | +102 |

No source, workflow, runbook, or `.github/RAILWAY_TOKEN_ROTATION_*.md` changes — Polecat scope and Category 1 guard both satisfied.

## Root Cause (surface)

The `RAILWAY_TOKEN` GitHub Actions secret holds a token Railway no longer accepts. Validator at `.github/workflows/staging-pipeline.yml:49-58` posts `{me{id}}` to `backboard.railway.app/graphql/v2`; response lacks `.data.me.id`, so `jq -e` fails and the step exits 1.

## Deeper hypothesis (escalated, not actioned here)

Eleven consecutive rejections (#878 → … → #898 → #901) is not consistent with simple TTL expiration. Railway reserves the env-var name `RAILWAY_TOKEN` for **project tokens** (used with `Project-Access-Token` header), while account/workspace tokens (which the validator's `Authorization: Bearer` + `{me{id}}` probe requires) belong in `RAILWAY_API_TOKEN`. If the runbook directs the human to mint a project token, every rotation will fail-on-arrival. Captured in `web-research.md` § Recommendations #2; mailed to mayor for a separate bead — **out of scope for #901** (Polecat Scope Discipline).

## Validation

Code-level validation is N/A (docs-only). Scope-guard verifications all pass:

| Guard | Result |
|-------|--------|
| No `.github/RAILWAY_TOKEN_ROTATION_901.md` | ✅ |
| `.github/workflows/staging-pipeline.yml` unmodified | ✅ |
| `docs/RAILWAY_TOKEN_ROTATION_742.md` unmodified | ✅ |
| `DEPLOYMENT_SECRETS.md` unmodified | ✅ |
| Only artifact files staged | ✅ |
| Markdown well-formed | ✅ |

The actual remediation (rotating `RAILWAY_TOKEN`) requires a human admin and is recorded in the routing comment on issue #901.

## Test plan

- [ ] Human admin: rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (first read `web-research.md` § Recommendations re: project-token vs account-token mismatch)
- [ ] Human admin: `gh workflow run railway-token-health.yml --repo alexsiri7/reli` → green
- [ ] Human admin: `gh run rerun 25252013103 --repo alexsiri7/reli --failed` → `Validate Railway secrets` passes, deploy proceeds
- [ ] Human admin: close #901 with the green run URL

Fixes #901