### PR TITLE
docs: investigation for issue #903 (60th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md
+++ b/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md
@@ -1,0 +1,102 @@
+---
+name: Implementation report — issue #903 (RAILWAY_TOKEN, 60th occurrence)
+description: Docs-only delivery for the 60th RAILWAY_TOKEN rejection (~20th today, 2026-05-02); scope-guard verifications; routing comment recorded as posted in investigation phase.
+type: implementation
+---
+
+# Implementation Report
+
+**Issue**: #903 — Main CI red: Deploy to staging (RAILWAY_TOKEN rejected — 60th occurrence, ~20th today)
+**Generated**: 2026-05-02 17:08
+**Workflow ID**: 20f0bd115fe4c3a0d2dd10f737e6f8e5
+**Branch**: `archon/task-archon-fix-github-issue-1777737626122`
+**Predecessor pattern**: #901 / PR #902 (commit `86aca5c`)
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Place investigation artifact in committable path | `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` | ✅ |
+| 2 | Place web-research artifact in committable path | `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md` | ✅ |
+| 3 | Write implementation report | `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md` | ✅ |
+| 4 | Verify Category 1 guard (no `.github/RAILWAY_TOKEN_ROTATION_903.md`) | n/a | ✅ |
+| 5 | Verify Polecat scope (workflow / runbook / `DEPLOYMENT_SECRETS.md` unmodified) | n/a | ✅ |
+| 6 | Routing comment on issue #903 | GitHub issue #903 | ✅ (posted in investigation phase) |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` | CREATE | +256 |
+| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md` | CREATE | (companion artifact) |
+| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md` | CREATE | +this file |
+
+No source code, workflow, runbook, or `.github/RAILWAY_TOKEN_ROTATION_*.md` files were modified — per `CLAUDE.md` § "Railway Token Rotation" and Polecat Scope Discipline.
+
+---
+
+## Scope-Guard Verifications
+
+| Guard | Method | Result |
+|-------|--------|--------|
+| No `.github/RAILWAY_TOKEN_ROTATION_903.md` | `ls .github/RAILWAY_TOKEN_ROTATION_*.md` → not found | ✅ |
+| `.github/workflows/staging-pipeline.yml` unmodified | `git status --porcelain` shows no entry | ✅ |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` unmodified | `git status --porcelain` shows no entry | ✅ |
+| `DEPLOYMENT_SECRETS.md` unmodified | `git status --porcelain` shows no entry | ✅ |
+| Only artifact files staged | `git status --porcelain` shows only `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/` | ✅ |
+
+---
+
+## Deviations from Investigation
+
+### Deviation 1: Routing comment was posted during the investigation phase, not implementation
+
+**Expected** (Implementation Plan, Step 1): Implementation agent posts routing comment on issue #903.
+**Actual**: Routing comment was already posted by the investigation phase (consistent with predecessor pattern #901 / PR #902).
+**Reason**: This matches the established pattern — the routing comment is part of the investigation deliverable, posted at investigation time. No second comment posted to avoid noise.
+
+No other deviations.
+
+---
+
+## Validation Results
+
+This bead is docs-only — there is no code to type-check, test, or lint in the produced diff. The validation steps in the investigation artifact (`gh workflow run railway-token-health.yml`, `gh run rerun 25255409159 --failed`) are **post-rotation human steps** and cannot be executed by an agent (per `CLAUDE.md` § "Railway Token Rotation").
+
+| Check | Result |
+|-------|--------|
+| Type check | n/a (no code changes) |
+| Tests | n/a (no code changes) |
+| Lint | n/a (no code changes) |
+| Markdown well-formed | ✅ (artifacts render in GitHub) |
+| Scope guards | ✅ (see table above) |
+
+---
+
+## What This PR Does Not Do
+
+Per `CLAUDE.md` § "Railway Token Rotation":
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets (`RAILWAY_TOKEN`) and requires human access to railway.com.
+
+This PR therefore:
+- Does **not** rotate `RAILWAY_TOKEN`.
+- Does **not** create a `.github/RAILWAY_TOKEN_ROTATION_903.md` claiming success on a human-only action (Category 1 error).
+- Does **not** modify the workflow validator or the runbook (Polecat scope; the runbook-revision hypothesis is captured in `web-research.md` for a separate bead).
+
+Resolution requires the human admin to execute the rotation steps recorded in the routing comment on issue #903 and the investigation artifact (Steps 3–4).
+
+---
+
+## Metadata
+
+- **Implemented by**: Claude (Opus 4.7)
+- **Timestamp**: 2026-05-02T17:08:00Z
+- **Artifact dir**: `/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/`
+- **Companion artifacts**: `investigation.md`, `web-research.md` (both this run dir)
+- **Failing run**: https://github.com/alexsiri7/reli/actions/runs/25255409159
+- **Predecessor**: PR #902 (commit `86aca5c`) for issue #901

--- a/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md
+++ b/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md
@@ -31,7 +31,7 @@ type: implementation
 
 | File | Action | Lines |
 |------|--------|-------|
-| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` | CREATE | +256 |
+| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` | CREATE | +255 |
 | `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md` | CREATE | (companion artifact) |
 | `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md` | CREATE | +this file |
 

--- a/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md
+++ b/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md
@@ -1,0 +1,255 @@
+---
+name: Investigation — Issue #903
+description: 60th RAILWAY_TOKEN expiration (~20th today, 2026-05-02). Validator at .github/workflows/staging-pipeline.yml:49-58 rejects token; per CLAUDE.md only a human can rotate.
+type: project
+---
+
+# Investigation: Main CI red: Deploy to staging (60th RAILWAY_TOKEN expiration)
+
+**Issue**: #903 (https://github.com/alexsiri7/reli/issues/903)
+**Type**: BUG (infra/secret expiry — not a code defect)
+**Investigated**: 2026-05-02T16:35:00Z
+**Workflow ID**: 20f0bd115fe4c3a0d2dd10f737e6f8e5
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Staging deploys are blocked on every push to `main`, but no production data is at risk and a documented manual rotation path exists for the human admin (`docs/RAILWAY_TOKEN_ROTATION_742.md`); not CRITICAL because the failure is gated at the validation step before any deploy mutation runs. |
+| Complexity | LOW | Zero code changes are in the agent's scope — the only valid agent actions are routing the human admin to the runbook and recording the investigation; the actual fix is a single dashboard action on railway.com performed by a human. |
+| Confidence | HIGH | The failed-step log is unambiguous (`RAILWAY_TOKEN is invalid or expired: Not Authorized`), the validator script that produced it is the exact one at `.github/workflows/staging-pipeline.yml:49-58`, and this is the 60th identical occurrence with the same evidence chain — there is no diagnostic uncertainty left. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in run [25255409159](https://github.com/alexsiri7/reli/actions/runs/25255409159) (SHA `86aca5c`) fails at the `Validate Railway secrets` step with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. The Railway GraphQL API rejects the bearer token stored in the `RAILWAY_TOKEN` GitHub Actions secret, so the workflow exits 1 before any deploy mutation runs. This is the **60th** recurrence of this exact failure mode and approximately the **20th** instance filed today (2026-05-02) — direct successor to #901 (PR #902), which was the 59th.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+Railway has invalidated (or expired) the bearer token currently stored in the `RAILWAY_TOKEN` GitHub Actions secret. The workflow's validator step posts `{me{id}}` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN`; Railway responded with a structured `{"errors":[{"message":"Not Authorized"}]}` payload, the `jq -e '.data.me.id'` test failed, and the step exited 1. **No code, workflow, or runbook change can fix this** — the secret value held by GitHub Actions is the broken artifact, and rotating it requires dashboard access at https://railway.com/account/tokens, which only the human admin holds.
+
+Per `CLAUDE.md` § "Railway Token Rotation":
+
+> **Agents cannot rotate the Railway API token.** […] Creating documentation that claims success on an action you cannot perform is a Category 1 error.
+
+So the agent's scope is strictly: file the issue / route the human, record the investigation, and **not** create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file or modify the runbook.
+
+### Evidence Chain
+
+WHY: `Deploy to staging` job failed in run 25255409159
+↓ BECAUSE: the `Validate Railway secrets` step exited 1
+  Evidence: failed-job log line `2026-05-02T15:34:37.3175772Z ##[error]Process completed with exit code 1.`
+
+↓ BECAUSE: the validator's `jq -e '.data.me.id'` test failed because Railway returned `Not Authorized`
+  Evidence: failed-job log line `2026-05-02T15:34:37.3162996Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: the bearer token submitted from the secret was rejected by the Railway GraphQL API
+  Evidence: `.github/workflows/staging-pipeline.yml:49-52`
+  ```
+  RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+    -H "Authorization: Bearer $RAILWAY_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"{me{id}}"}')
+  ```
+
+↓ ROOT CAUSE: the secret value of `RAILWAY_TOKEN` (a GitHub Actions repo secret) is no longer accepted by Railway
+  Evidence: identical failure mode in 59 prior occurrences (#742 → … → #898 → #901). The most recent predecessor PR #902 documented the same evidence chain at `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md`.
+
+  Resolution requires a human to mint a new token at https://railway.com/account/tokens and update the GitHub Actions `RAILWAY_TOKEN` secret per `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none — agent-side) | — | — | Polecat scope discipline: the failure is a secret-rotation problem, not a code defect. The only changes appropriate from the agent are the artifact files in `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/`. |
+| GitHub Actions secret `RAILWAY_TOKEN` | n/a | UPDATE (human-only) | Rotate per `docs/RAILWAY_TOKEN_ROTATION_742.md`; cannot be touched by an agent. |
+
+**Files explicitly NOT changed (Category 1 guard):**
+- `.github/RAILWAY_TOKEN_ROTATION_903.md` — must NOT be created (CLAUDE.md forbids documentation that claims rotation success on an action the agent cannot perform).
+- `.github/workflows/staging-pipeline.yml` — unchanged. The validator is doing its job correctly; the token, not the workflow, is broken.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — unchanged. Updates to this runbook (e.g., re: the "No expiration" option flagged in the predecessor PR's web research) are out of scope for #903 and would be a separate bead routed via mail to mayor.
+- `DEPLOYMENT_SECRETS.md` — unchanged.
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:49-58` — the validator step that produced the error.
+- `.github/workflows/staging-pipeline.yml:60-88` — the deploy mutations that would have run had the validator passed; they use the same `RAILWAY_TOKEN` and would also have failed.
+- `.github/workflows/railway-token-health.yml` — a standalone health-check workflow the human admin can run after rotation to confirm the new token is accepted before re-running #903's failed run.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the rotation runbook.
+- `pipeline-health-cron.sh` — the cron that auto-files these issues.
+
+### Git History
+
+- **Validator step introduced**: long-standing (well before #742). The current shape of the validator was already in place at the time of the very first rotation runbook.
+- **Last modified**: `git log` on `.github/workflows/staging-pipeline.yml` shows no changes touching the validator block since the runbook was written.
+- **Implication**: This is **not** a regression caused by recent code changes. It is a recurring infra issue — the secret value expires (or is invalidated) on Railway's side and the workflow correctly catches it.
+- **Recent investigation precedents**:
+  - 13bf51e — docs: investigation for issue #898 (58th, 18th today)
+  - cce4362 — docs: investigation for issue #896 (57th, 17th today)
+  - ed436e2 — docs: investigation for issue #889 (55th)
+  - 1e48dc5 — docs: investigation for issue #894 (56th)
+  - 86aca5c — docs: investigation for issue #901 (59th, 19th today)
+  - **(this PR will be)** docs: investigation for issue #903 (60th, ~20th today)
+
+---
+
+## Implementation Plan
+
+> **Scope reminder**: per `CLAUDE.md`, the agent's only valid output here is the routing comment on the issue + this investigation artifact. The implementation plan below is for the **human admin**, not the agent.
+
+### Step 1 (agent): post a routing comment on #903
+
+**File**: n/a (GitHub comment)
+**Action**: POST
+
+Comment body summarises the failure, identifies it as the 60th recurrence, and routes the human admin to `docs/RAILWAY_TOKEN_ROTATION_742.md`. (This is what `/investigate-issue` Phase 5 does — content templated below.)
+
+**Why**: Visible signal on the issue that the agent has triaged it and identified the action owner.
+
+---
+
+### Step 2 (agent): commit this artifact + open the docs-only PR
+
+**File**: `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` (this file) plus the existing `web-research.md`.
+**Action**: CREATE / COMMIT
+
+Mirror the PR #902 shape: title `docs: investigation for issue #903 (60th RAILWAY_TOKEN expiration, ~20th today)`, body with `Fixes #903`, no source/workflow/runbook changes.
+
+**Why**: Persists the audit trail (per the established pattern of one artifact bundle per occurrence) and fulfils the "file the issue / send mail to mayor" branch of the CLAUDE.md guidance with concrete written context for the human rotator.
+
+---
+
+### Step 3 (human admin, NOT agent): rotate `RAILWAY_TOKEN`
+
+**File**: GitHub Actions repo secret + `https://railway.com/account/tokens`
+**Action**: UPDATE (manual, dashboard-only)
+
+Follow `docs/RAILWAY_TOKEN_ROTATION_742.md`. Before doing so, the human admin should also read `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md` § Recommendations — predecessor research raises three open items (account-vs-project token type, the runbook's "No expiration" claim, and possible secret rename to `RAILWAY_API_TOKEN`) that are worth a dashboard verification on this rotation.
+
+**Why**: The expired secret is the only thing actually broken; rotating it is the only thing that fixes #903.
+
+---
+
+### Step 4 (human admin, NOT agent): verify and close
+
+**File**: n/a (CI re-run)
+**Action**: VERIFY
+
+```bash
+# 1. Sanity-check the new token via the standalone health workflow
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+
+# 2. Re-run the failed staging deploy
+gh run rerun 25255409159 --repo alexsiri7/reli --failed
+
+# 3. Close the issue with the green run URL
+gh issue close 903 --repo alexsiri7/reli --comment "Rotated and verified — run <new-run-url> green."
+```
+
+**Why**: Closes the loop and ensures `archon:in-progress` is cleared on a green signal, not on the docs PR alone.
+
+---
+
+### Step 5 (agent, optional): mail mayor about deeper hypotheses
+
+**File**: n/a (Graphite mail)
+**Action**: SEND
+
+If predecessor mail to mayor about the account-token-vs-project-token mismatch hasn't already produced a separate bead, send a follow-up: 60 consecutive expirations is well past the threshold where it stops being plausible that the runbook's "No expiration" instruction is being followed end-to-end. Do **not** action it inside #903 — Polecat Scope Discipline.
+
+**Why**: The bead pattern keeps the recurring symptom (this issue) and the deeper investigation (a separate bead) properly separated.
+
+---
+
+## Patterns to Follow
+
+**Mirror PR #902 exactly** — same structure, same Polecat boundaries, same Category 1 guard:
+
+- Three artifact files only: `investigation.md`, `web-research.md`, `implementation.md` (the latter two already exist or will be created by the implementation phase).
+- PR title format: `docs: investigation for issue #903 (60th RAILWAY_TOKEN expiration, ~20th today)`.
+- PR body uses the same "Changes" table, "Root Cause (surface)", "Deeper hypothesis (escalated, not actioned here)", and "Validation" sections as #902.
+- PR body must include `Fixes #903`.
+- No `.github/RAILWAY_TOKEN_ROTATION_903.md`, no edits to the workflow, runbook, or `DEPLOYMENT_SECRETS.md`.
+
+Reference: PR #902 body and file list (already on disk at HEAD `86aca5c`):
+
+```
+artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/investigation.md     (+179)
+artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/web-research.md      (+152)
+artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/implementation.md    (+102)
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| Agent is tempted to "fix" by editing the workflow (e.g., adding retries). | Out of scope — the API explicitly returned `Not Authorized`; retries on a rejected token will not help. Polecat-mail to mayor instead, do not change the workflow. |
+| Agent is tempted to create `.github/RAILWAY_TOKEN_ROTATION_903.md` mirroring the runbook to "show progress". | Forbidden by CLAUDE.md (Category 1 error). The investigation artifact under `artifacts/runs/.../` is the correct, allowed record. |
+| Agent is tempted to amend `docs/RAILWAY_TOKEN_ROTATION_742.md` based on the web-research findings. | Out of scope for #903. The runbook update is itself a bead — route to mayor via mail, do not bundle. |
+| Issue auto-pickup cron double-fires while the docs PR is open. | The issue is already labelled `archon:in-progress`; per its body the regular pickup cron will not double-fire. The docs PR's `Fixes #903` will close the issue once merged, preventing a third firing. (Note: merging the docs PR does not actually fix CI — only token rotation does. The human admin still needs to do Step 3 above. The issue may need to be reopened if rotation hasn't happened by merge time.) |
+| The investigation artifact misstates the "Nth recurrence" or "Nth today" count. | Counts derived from: (a) predecessor PR #902 says #901 was "59th overall, 19th today, 2026-05-02"; (b) #903 is filed after #901 with no intervening RAILWAY rotation evidence, so it is the **60th overall** and approximately the **20th today** (#904 was filed at the same time but is a "Prod deploy failed" issue, likely a sibling symptom of the same broken secret). The "approximately" hedge guards against an off-by-one if a sibling RAILWAY-tagged issue was filed between #901 and #903 that I haven't accounted for. |
+| Endpoint `backboard.railway.app` vs `backboard.railway.com`. | Web research confirms the `.app` host is still routing — the `Not Authorized` response proves the request reached Railway. Do not change the endpoint as part of this fix. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+This is a docs-only artifact PR. Code-level checks are **N/A** — there are no source, workflow, or runbook edits to validate. The PR's own CI will exercise the unrelated `Deploy to staging` job again and is expected to fail at the **same** validator step until the human admin completes Step 3 above. That expected-failure is acceptable for the docs PR; merging the docs PR does not depend on staging being green (it cannot be, by design).
+
+### Manual Verification
+
+For the agent (after PR open):
+
+1. Confirm only the three artifact files are staged in the PR (use `gh pr view <n> --json files`).
+2. Confirm `.github/RAILWAY_TOKEN_ROTATION_903.md` does NOT exist (`ls .github/RAILWAY_TOKEN_ROTATION_*.md` should show only the legacy file from #742, if any).
+3. Confirm `.github/workflows/staging-pipeline.yml`, `docs/RAILWAY_TOKEN_ROTATION_742.md`, and `DEPLOYMENT_SECRETS.md` are unmodified (`git diff main -- <path>` empty for each).
+4. Confirm the PR body contains `Fixes #903`.
+
+For the human admin (after Step 3 rotation):
+
+1. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` returns green.
+2. `gh run rerun 25255409159 --repo alexsiri7/reli --failed` — `Validate Railway secrets` passes; deploy proceeds; staging health check goes green.
+3. `gh issue close 903` with the green run URL.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE for the agent on #903:**
+- Post a routing comment on issue #903 directing the human admin to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+- Create `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` (this file).
+- Open a docs-only PR titled `docs: investigation for issue #903 (60th RAILWAY_TOKEN expiration, ~20th today)` with `Fixes #903`, mirroring PR #902.
+- (Optional) Send mail to mayor only if no follow-up bead has yet been opened on the deeper account-vs-project-token hypothesis from web research.
+
+**OUT OF SCOPE — do not touch:**
+- The `RAILWAY_TOKEN` GitHub Actions secret itself (agent has no access; only a human admin can rotate via railway.com).
+- `.github/workflows/staging-pipeline.yml` (the validator is correct; the secret is the broken artifact).
+- `.github/RAILWAY_TOKEN_ROTATION_903.md` — **must not be created** (CLAUDE.md Category 1 error).
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` (runbook updates re: web-research findings are a separate bead).
+- `DEPLOYMENT_SECRETS.md` (unchanged).
+- Renaming the secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN` (would require a coordinated workflow + secret update, separate bead).
+- Switching to OAuth + refresh-token rotation (large refactor, separate bead).
+- Endpoint change `backboard.railway.app` → `backboard.railway.com` (unrelated to the failure; out of scope).
+- Closing or commenting on sibling issue #904 ("Prod deploy failed on main") even if it shares the same root cause — that's its own bead.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude (Opus 4.7)
+- **Timestamp**: 2026-05-02T16:35:00Z
+- **Workflow ID**: 20f0bd115fe4c3a0d2dd10f737e6f8e5
+- **Artifact**: `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md`
+- **Companion artifact**: `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md`
+- **Source issue**: https://github.com/alexsiri7/reli/issues/903
+- **Source run**: https://github.com/alexsiri7/reli/actions/runs/25255409159
+- **Predecessor**: #901 / PR #902 / artifact `artifacts/runs/ff852270fcf951e842e7b9d076dc1e0a/` (59th occurrence)

--- a/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md
+++ b/artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md
@@ -1,0 +1,160 @@
+---
+name: Web Research — Issue #903
+description: Web research for issue #903 (Railway token expiration, 60th occurrence) — what Railway's docs and community say about token types, expiration behavior, and CI integration
+type: project
+---
+
+# Web Research: fix #903
+
+**Researched**: 2026-05-02T16:30:00Z
+**Workflow ID**: 20f0bd115fe4c3a0d2dd10f737e6f8e5
+**Issue**: Main CI red — `RAILWAY_TOKEN is invalid or expired: Not Authorized` on Deploy to staging job (run 25255409159, SHA 86aca5c)
+
+---
+
+## Summary
+
+Issue #903 is the 60th recurrence of the Railway token expiration problem. Per `CLAUDE.md`, **agents cannot rotate this token** — it lives in GitHub Actions secrets and requires human access to railway.com. The web research below is therefore aimed at the **underlying question** of why this keeps recurring: it surfaces three concrete findings that the existing runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) does not capture, and which a human rotator may want to act on next time. Headline finding: the workflow uses `Authorization: Bearer` with the `{me{id}}` query — that combination requires a **personal/account token**, not a project or workspace token, and Railway's public docs do **not** document a "no expiration" option for these tokens, contradicting the existing runbook's "Expiration: No expiration (critical)" instruction.
+
+---
+
+## Findings
+
+### 1. Railway has three distinct token types, with different headers and capabilities
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Choosing the correct token type for the staging-pipeline workflow
+
+**Key Information**:
+
+- **Account (personal) tokens** — broadest scope, tied to a Railway account, "access across all resources and workspaces"; created at https://railway.com/account/tokens. Use `Authorization: Bearer <token>` header.
+- **Workspace tokens** — scoped to a single workspace, "ideal for team CI/CD and shared automation". Use `Authorization: Bearer <token>` header.
+- **Project tokens** — limited to "a specific environment within a project", created from project settings (not account settings). Use the **`Project-Access-Token`** header (NOT `Authorization: Bearer`).
+- The CLI environment variables map: `RAILWAY_TOKEN` is for project-level actions, `RAILWAY_API_TOKEN` is for account-level actions ([CLI docs](https://docs.railway.com/guides/cli)). When both are set, `RAILWAY_TOKEN` takes precedence.
+
+---
+
+### 2. The `{me{id}}` validation query requires a personal access token
+
+**Source**: [GraphQL requests returning "Not Authorized" for PAT — Railway Help Station](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52)
+**Authority**: Railway community moderator response
+**Relevant to**: The exact validation query in `.github/workflows/staging-pipeline.yml:52`
+
+**Key Information**:
+
+- Direct quote: *"The `query { me { id email } }` query specifically requires a personal access token (PAT)."*
+- Project tokens cannot query `me` — they will return "Not Authorized" even when freshly issued.
+- Workspace tokens reportedly can't access `me` or `teams` queries either; "you need to generate a personal token from your Railway account settings."
+- Project tokens can read project info but can return "Not Authorized" for deployment-triggering mutations as well — see [Railway API Token Permissions Issue](https://station.railway.com/questions/railway-api-token-permissions-issue-4dfeffde).
+
+**Implication for our workflow**: Our validation step (`{me{id}}`) and our deployment mutation (`serviceInstanceUpdate`) are both run with `Authorization: Bearer $RAILWAY_TOKEN`. This is the **personal/account token pattern**, not the project token pattern. The secret name `RAILWAY_TOKEN` is misleading — Railway CLI semantics reserve that name for project tokens, but our raw curl-based workflow is using it as a personal/account token. The secret should arguably be renamed `RAILWAY_API_TOKEN` to match Railway's own conventions, or the rotation runbook should make explicit that the rotator must create an **account token** (not a project token).
+
+---
+
+### 3. Railway's public docs do NOT document a "No expiration" option for API tokens
+
+**Source**: [Public API | Railway Docs](https://docs.railway.com/integrations/api), [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens), [CLI | Railway Docs](https://docs.railway.com/cli)
+**Authority**: Official Railway documentation (multiple pages)
+**Relevant to**: The existing runbook's claim that "Expiration: No expiration" is a selectable option
+
+**Key Information**:
+
+- The Public API page documents account/workspace/project token types and creation procedure but **does not specify token expiration behavior, TTL, default expiration, or any "no expiration" option**.
+- The CLI page does not mention token TTL.
+- The Login & Tokens (OAuth) page documents OAuth-flow tokens only: OAuth access tokens expire after 1 hour, refresh tokens last 1 year and rotate. This is unrelated to dashboard-issued API tokens.
+- Multiple targeted searches for "Railway API token TTL", "no expiration", "30/90 days" returned no official guidance on configurable expiration.
+
+**Implication**: `docs/RAILWAY_TOKEN_ROTATION_742.md` instructs the rotator to "Expiration: No expiration (critical — do not accept default TTL)". If Railway's dashboard no longer (or never) offered that option, every rotation since #742 has been creating a token that will expire on whatever default Railway applies. This is consistent with the recurrence pattern (60 expirations). **A human with dashboard access should verify on https://railway.com/account/tokens whether a "No expiration" option still exists, and if not, the runbook needs to be updated to reflect reality** — possibly switching to a scheduled rotation cadence rather than promising perpetual tokens.
+
+---
+
+### 4. Railway provides no API-side automated refresh / rotation for dashboard tokens
+
+**Source**: [Login & Tokens | Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens), [Ability to run all railway commands with RAILWAY_TOKEN · Issue #105](https://github.com/railwayapp/cli/issues/105)
+**Authority**: Official Railway docs and the official Railway CLI repo
+**Relevant to**: Whether automation (an Action, a cron) could rotate the token without a human
+
+**Key Information**:
+
+- Refresh-token rotation exists **only inside the OAuth 2.0 flow** (requiring `offline_access` scope and a registered OAuth app).
+- Dashboard-created account/workspace/project tokens have no documented refresh endpoint.
+- There is no publicly documented API for *creating* a new account-level API token programmatically — token creation is a dashboard-only action.
+
+**Implication**: The CLAUDE.md restriction ("Agents cannot rotate the Railway API token") is correct and is a property of Railway's design, not just our policy. The only paths to reduce recurrence are: (a) ensure a non-expiring token type is used if available, (b) move to OAuth + refresh-token rotation (requires registering an OAuth app and refactoring the workflow), or (c) accept the cadence and schedule a calendar reminder ahead of expected expiry.
+
+---
+
+### 5. The Railway API endpoint in the workflow may be on the legacy host
+
+**Source**: [Railway GraphQL API documentation (Postman)](https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api), Help Station threads
+**Authority**: Community documentation
+**Relevant to**: The endpoint string in `.github/workflows/staging-pipeline.yml:49`
+
+**Key Information**:
+
+- The current workflow targets `https://backboard.railway.app/graphql/v2`.
+- One community source asserts the correct endpoint is now `https://backboard.railway.com/graphql/v2` (matching Railway's domain rebrand from `.app` to `.com`).
+- This is **not** likely the cause of issue #903 — the API returned a structured `{"errors":[{"message":"Not Authorized"}]}` payload, which means the endpoint accepted the request but rejected the token. So the host is at minimum still routing.
+- Worth flagging only as an aside; do not change as part of fixing #903.
+
+---
+
+## Code Examples
+
+The validation step in the workflow exactly matches the "personal access token" pattern from Railway's community — including the bearer header and the `{me{id}}` query:
+
+```yaml
+# From .github/workflows/staging-pipeline.yml:49-52
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+```
+
+Railway community guidance ([source](https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52)):
+
+> "The `query { me { id email } }` query specifically requires a personal access token."
+
+So the secret currently labelled `RAILWAY_TOKEN` must in fact be a **personal/account token from https://railway.com/account/tokens**, and the CLAUDE.md / runbook guidance directing the rotator there is correct.
+
+---
+
+## Gaps and Conflicts
+
+- **Gap (most important)**: No official Railway documentation describes API token expiration semantics. We cannot confirm from public sources whether "No expiration" is or ever was an option in the dashboard. The runbook's claim relies on this — a human rotator should confirm directly in the dashboard on the next rotation.
+- **Gap**: No public Railway communication about whether token TTL defaults changed at any point — which would explain why this has cascaded to 60 occurrences after the #742 runbook was written.
+- **Conflict**: One Help Station thread says `RAILWAY_TOKEN` "must be a project token" (CLI semantics); another says use a "personal account token" via `RAILWAY_API_TOKEN`. The conflict resolves because **our workflow does not use the CLI** — it makes raw GraphQL calls and uses the env-var name as a label, so the semantics are governed by the GraphQL request shape (Bearer + `{me{id}}` → personal token), not by the CLI's interpretation of the variable name.
+- **Gap**: Whether the new `backboard.railway.com` host should be preferred over `backboard.railway.app` is unconfirmed; the latter clearly still works (it returns structured GraphQL errors).
+
+---
+
+## Recommendations
+
+These are recommendations for the human rotator (per CLAUDE.md, the agent must not rotate the token itself, must not write a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming it did, and should file an issue / mail mayor instead):
+
+1. **At next rotation, confirm whether "No expiration" is still an offered option on https://railway.com/account/tokens.** If it is, use it. If it is **not**, update `docs/RAILWAY_TOKEN_ROTATION_742.md` to remove the false promise and replace it with a `/schedule`-based reminder cadence sized to the longest TTL the dashboard offers.
+2. **Confirm the rotated token is a personal/account token** (created from account settings, not project settings). The `Authorization: Bearer` + `{me{id}}` validation requires this; project tokens will return "Not Authorized" even when fresh.
+3. **Consider renaming the GitHub secret `RAILWAY_TOKEN` → `RAILWAY_API_TOKEN`** to align with Railway's own CLI naming conventions and reduce future confusion about which token type is required. (Out of scope for fixing #903 — would require a coordinated workflow + secret update; flag to mayor rather than acting.)
+4. **Do not change the API endpoint** as part of this fix. The `.app` host is still routing requests; the `Not Authorized` response proves the request reached Railway and was rejected by auth, not by routing.
+5. **Do not attempt OAuth-based refresh rotation** as part of this fix. It would require registering an OAuth app and refactoring the workflow — a separate piece of work that should be proposed via mail to mayor, not bundled in.
+
+For this specific bead — **the agent's only valid action is to file an issue or send mail to mayor with the error details and direct the human to `docs/RAILWAY_TOKEN_ROTATION_742.md`**. The research above gives the human additional context for the rotation conversation.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Public API docs | https://docs.railway.com/integrations/api | Authoritative on token types (account/workspace/project) and headers |
+| 2 | Railway CLI docs | https://docs.railway.com/cli | `RAILWAY_TOKEN` vs `RAILWAY_API_TOKEN` env-var semantics |
+| 3 | Railway CLI guide | https://docs.railway.com/guides/cli | CI/CD usage of the env vars |
+| 4 | Railway Login & Tokens (OAuth) | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth token expiration (different from dashboard tokens) |
+| 5 | Help Station — GraphQL "Not Authorized" for PAT | https://station.railway.com/questions/graph-ql-requests-returning-not-authoriz-56dacb52 | `{me{id}}` requires a personal access token |
+| 6 | Help Station — RAILWAY_TOKEN invalid or expired | https://station.railway.com/questions/railway-token-invalid-or-expired-59011e20 | Common cause of the exact error in #903 |
+| 7 | Help Station — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | "use a Railway API token scoped to the user account, not a project token" |
+| 8 | Help Station — Authentication not working with RAILWAY_TOKEN | https://station.railway.com/questions/authentication-not-working-with-railway-b3f522c7 | Resolution required switching to account token via `RAILWAY_API_TOKEN` |
+| 9 | Help Station — Railway API Token Permissions Issue | https://station.railway.com/questions/railway-api-token-permissions-issue-4dfeffde | Project tokens return "Not Authorized" for deployment mutations |
+| 10 | Railway CLI Issue #105 | https://github.com/railwayapp/cli/issues/105 | Long-standing gap: no programmatic way to refresh dashboard tokens |
+| 11 | Railway GraphQL API (Postman) | https://www.postman.com/railway-4865/railway/documentation/adgthpg/railway-graphql-api | GraphQL endpoint reference |


### PR DESCRIPTION
## Summary

Docs-only investigation for the **60th** `RAILWAY_TOKEN` rejection (approximately the **20th today**, 2026-05-02). Failing run [25255409159](https://github.com/alexsiri7/reli/actions/runs/25255409159) `Deploy to staging` exited 1 at the `Validate Railway secrets` step with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. Identical pattern to predecessor #901 / PR #902.

Per `CLAUDE.md` § "Railway Token Rotation", agents cannot rotate this token — it requires human access to railway.com. This PR records the investigation only and routes the human admin to `docs/RAILWAY_TOKEN_ROTATION_742.md`.

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/investigation.md` | CREATE | +255 |
| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/web-research.md` | CREATE | +160 |
| `artifacts/runs/20f0bd115fe4c3a0d2dd10f737e6f8e5/implementation.md` | CREATE | +102 |

No source, workflow, runbook, or `.github/RAILWAY_TOKEN_ROTATION_*.md` changes — Polecat scope and Category 1 guard both satisfied.

## Root Cause (surface)

The `RAILWAY_TOKEN` GitHub Actions secret holds a token Railway no longer accepts. Validator at `.github/workflows/staging-pipeline.yml:49-58` posts `{me{id}}` to `backboard.railway.app/graphql/v2`; response lacks `.data.me.id`, so `jq -e` fails and the step exits 1.

## Deeper hypothesis (escalated, not actioned here)

Sixty consecutive rejections (#742 → … → #898 → #901 → #903), with ~20 filed in a single day, is well past the threshold for plausible TTL expiration. Railway reserves the env-var name `RAILWAY_TOKEN` for **project tokens** (used with `Project-Access-Token` header), while account/workspace tokens (which the validator's `Authorization: Bearer` + `{me{id}}` probe requires) belong in `RAILWAY_API_TOKEN`. If the runbook directs the human to mint a project token, every rotation will fail-on-arrival. Captured in `web-research.md` § Recommendations; mailed to mayor for a separate bead — **out of scope for #903** (Polecat Scope Discipline).

## Validation

Code-level validation is N/A (docs-only). Scope-guard verifications all pass:

| Guard | Result |
|-------|--------|
| No `.github/RAILWAY_TOKEN_ROTATION_903.md` | ✅ |
| `.github/workflows/staging-pipeline.yml` unmodified | ✅ |
| `docs/RAILWAY_TOKEN_ROTATION_742.md` unmodified | ✅ |
| `DEPLOYMENT_SECRETS.md` unmodified | ✅ |
| Only artifact files staged | ✅ |
| Markdown well-formed | ✅ |

The actual remediation (rotating `RAILWAY_TOKEN`) requires a human admin and is recorded in the routing comment on issue #903.

## Test plan

- [ ] Human admin: rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` (first read `web-research.md` § Recommendations re: project-token vs account-token mismatch)
- [ ] Human admin: `gh workflow run railway-token-health.yml --repo alexsiri7/reli` → green
- [ ] Human admin: `gh run rerun 25255409159 --repo alexsiri7/reli --failed` → `Validate Railway secrets` passes, deploy proceeds
- [ ] Human admin: close #903 with the green run URL

Fixes #903