### PR TITLE
docs: investigation for issue #907 (61st RAILWAY_TOKEN expiration, 21st today)

### DIFF
--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md
@@ -1,0 +1,65 @@
+# Implementation Report
+
+**Issue**: #907 — Main CI red: Deploy to staging (61st `RAILWAY_TOKEN` expiration, 21st today)
+**Generated**: 2026-05-02 17:55
+**Workflow ID**: 82f3717c5ef377464cba9b91fd484398
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | Commit investigation artifact into the repo | `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md` | ✅ |
+| 2 | Commit web-research companion artifact | `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md` | ✅ |
+| 3 | Write implementation report | `artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md` | ✅ |
+| 4 | Verify no Category 1 `RAILWAY_TOKEN_ROTATION_907.md` was added | `.github/RAILWAY_TOKEN_ROTATION_907.md` | ✅ (absent) |
+| 5 | Verify diff is docs-only and scoped to this run's artifact dir | `git diff --name-only main...HEAD` | ✅ |
+
+---
+
+## Files Changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md` | CREATE | The full investigation: assessment, evidence chain, scope boundaries, validation matrix. |
+| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md` | CREATE | Railway community/docs research on No-workspace + No-expiration creation flags and `.app` vs `.com` host observations. |
+| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md` | CREATE | This file. |
+
+No source files, workflows, runbooks, or `.github/RAILWAY_TOKEN_ROTATION_*.md` files were touched (per `CLAUDE.md` § Railway Token Rotation and Polecat Scope Discipline).
+
+---
+
+## Deviations from Investigation
+
+Implementation matched the investigation exactly. The artifact prescribed a docs-only deliverable mirroring PR #906; this PR is the same shape with the chain/today counts and run/issue cross-references updated as specified in the "Patterns to Follow" section.
+
+---
+
+## Validation Results
+
+| Check | Result |
+|-------|--------|
+| Diff is docs-only and scoped to `artifacts/runs/82f3717c5ef377464cba9b91fd484398/` | ✅ |
+| No Category 1 `.github/RAILWAY_TOKEN_ROTATION_907.md` file added | ✅ |
+| `staging-pipeline.yml` validator step unchanged | ✅ |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` runbook unchanged | ✅ |
+| Markdown files render (no broken fences on first read) | ✅ |
+| Type / lint / format / test / build suites | N/A (docs-only diff) |
+| Visual regression screenshots | N/A (no UI changes) |
+
+---
+
+## What This Implementation Does NOT Do
+
+- Does **not** rotate `RAILWAY_TOKEN` (human-only — `CLAUDE.md` § Railway Token Rotation).
+- Does **not** create `.github/RAILWAY_TOKEN_ROTATION_907.md` (Category 1 error).
+- Does **not** modify the validator at `.github/workflows/staging-pipeline.yml:32-58` (correct as-is).
+- Does **not** modify `docs/RAILWAY_TOKEN_ROTATION_742.md` (out of scope; hypotheses preserved in `web-research.md` for a separate runbook-improvement bead).
+- Does **not** modify `DEPLOYMENT_SECRETS.md`, `pipeline-health-cron.sh`, or any frontend/backend code.
+
+---
+
+## Next Step
+
+PR creation: `docs: investigation for issue #907 (61st RAILWAY_TOKEN expiration, 21st today)` with `Fixes #907`.

--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
@@ -153,8 +153,8 @@ Railway's auth backend rejects the token currently held in `secrets.RAILWAY_TOKE
 
 1. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` — **with No workspace
    selected and No expiration** (see `web-research.md` § Recommendations #1–#2 in this
-   run before re-rotating like-for-like, since the chain has now repeated 12 times in
-   <8 hours).
+   run before re-rotating like-for-like, since the chain has now repeated 21 times
+   today).
 2. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` — verify the new
    token authenticates.
 3. `gh run rerun 25256579563 --repo alexsiri7/reli --failed` — re-run the failed

--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
@@ -1,0 +1,274 @@
+# Investigation: Main CI red: Deploy to staging (issue #907)
+
+**Issue**: [#907](https://github.com/alexsiri7/reli/issues/907) — Main CI red: Deploy to staging
+**Type**: BUG (operational / external-credential expiry — out-of-scope for code change)
+**Investigated**: 2026-05-02T17:35:00Z
+**Run**: [25256579563](https://github.com/alexsiri7/reli/actions/runs/25256579563)
+**SHA**: `3521481dfd3d472b63bdfa909372bcac3be5ba64`
+
+---
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | **HIGH** | The `Deploy to staging` workflow is fully blocked at the `Validate Railway secrets` step on every main-branch CI completion; staging is the gate for production, so the deploy chain is paused until the human admin rotates `RAILWAY_TOKEN`. There is no in-repo workaround and the same chain has now blocked 21 deploys in the same calendar day. |
+| Complexity | **LOW** | Zero code changes are required in this repo. The fix is a human-only Railway dashboard action followed by `gh secret set RAILWAY_TOKEN`. The investigation deliverable is docs-only (this artifact + routing comment + web-research findings already in place). |
+| Confidence | **HIGH** | The failed-job log explicitly returns `RAILWAY_TOKEN is invalid or expired: Not Authorized` from the validator block in `.github/workflows/staging-pipeline.yml:49-58`. This is the same exact failure mode and message as the previous 60 incidents in this repo's history, including the immediately prior chain link #904 (PR #906) ~1 hour ago. |
+
+---
+
+## Problem Statement
+
+The `Deploy to staging` job in `.github/workflows/staging-pipeline.yml` failed at the `Validate Railway secrets` step. The validator's `me{id}` GraphQL probe against `https://backboard.railway.app/graphql/v2` returned `Not Authorized`, so the workflow exited 1 with `RAILWAY_TOKEN is invalid or expired: Not Authorized`. This is the **61st** consecutive `RAILWAY_TOKEN` rejection in repository history and the **21st** in a single calendar day (2026-05-02), continuing the rapid-rotation chain `#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901 → #903/#904 → #907`. Per `CLAUDE.md` § "Railway Token Rotation", **agents cannot rotate this token** — the deliverable is the artifact set + a routing comment directing the human operator to `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+
+---
+
+## Analysis
+
+### First-Principles: Primitive Soundness
+
+| Primitive | File:Lines | Sound? | Notes |
+|-----------|-----------|--------|-------|
+| Railway-secrets validator (token-liveness probe) | `.github/workflows/staging-pipeline.yml:32-58` | **Yes** | Correctly fast-fails before any deploy mutation; emits a clear `::error::` and points the operator to the rotation runbook. The validator is doing exactly what it was designed to do — it is the **token** that is invalid, not the validator. |
+| `RAILWAY_TOKEN` GitHub Actions secret | (external — Repository secret) | **No — repeating failure** | A token that authenticated successfully ~1 hour ago is now `Not Authorized` again. After 60 rotations the token keeps getting rejected within minutes-to-hours of each rotation, suggesting either (a) the token is being created with a default short TTL in the Railway dashboard, (b) the wrong workspace is being selected at creation time, or (c) the token is being revoked/superseded by some external process. The systemic failure is **not in this repo** — it is in either Railway's token issuance or the operator's rotation procedure. |
+| Rotation runbook | `docs/RAILWAY_TOKEN_ROTATION_742.md` | **Possibly incomplete** | The existing runbook does not yet explicitly call out the No-workspace-selected + No-expiration creation requirements that the Railway community thread (see `web-research.md`) has flagged. This is captured in this run's `web-research.md` for a separate documentation bead, **not fixed in this PR** (Polecat scope). |
+
+**Root cause vs symptom**: The error manifests in the GitHub Actions log, but the root cause is at the credential-issuance boundary in Railway. No edit to the workflow, runbook, or any source file in this repo can resolve a `Not Authorized` response from `backboard.railway.app/graphql/v2` — that requires a fresh, valid token issued in the Railway dashboard.
+
+**Minimal change**: Zero. This investigation produces the routing comment and artifact set; the fix is a human-only dashboard action.
+
+**What this unlocks**: Once the human admin rotates the token following the runbook (with the No-workspace + No-expiration recommendations from `web-research.md` verified before re-rotating like-for-like), the entire backlog of staging deploys auto-recovers via `gh run rerun --failed`.
+
+---
+
+### Root Cause / Evidence Chain
+
+```
+WHY 1: Why did the Deploy-to-staging job fail?
+↓ BECAUSE: The "Validate Railway secrets" step exited 1 after the token-liveness probe
+   returned a `Not Authorized` GraphQL error.
+   Evidence: .github/workflows/staging-pipeline.yml:53-57
+     `if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then`
+     `  MSG=$(echo "$RESP" | jq -r '.errors[0].message // ...')`
+     `  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"`
+     `  exit 1`
+   Run log (run 25256579563):
+     `2026-05-02T16:34:55.3061519Z ##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized`
+
+↓ BECAUSE: The Railway GraphQL endpoint at https://backboard.railway.app/graphql/v2
+   returned `{"errors":[{"message":"Not Authorized"}]}` for the `{me{id}}` query against
+   the Bearer token supplied via `secrets.RAILWAY_TOKEN`.
+   Evidence: validator probe at staging-pipeline.yml:49-52 — POSTs `{me{id}}` with the
+   secret as `Authorization: Bearer …`. A `Not Authorized` from `me{id}` means the token
+   itself is rejected (not a permission scope issue, not a missing variable — those would
+   produce different errors).
+
+↓ BECAUSE: The current value of the GitHub Actions repository secret `RAILWAY_TOKEN` is
+   no longer accepted by Railway as a valid identity. Either it was revoked, expired,
+   re-rotated externally, or was created with a wrong-workspace scope that has since
+   become invalid for this account.
+   Evidence: identical failure mode and message has occurred 60 times before in this
+   repo's history (see commit log `git log --grep="RAILWAY_TOKEN expiration"`), with the
+   immediately prior chain link #904 occurring ~1 hour ago at 16:12Z (PR #906) and
+   #903 at the same window. The chain shows that even after each successful rotation,
+   the next deploy attempt within minutes-to-hours rejects again with the same message.
+
+ROOT CAUSE: Railway's auth backend rejects the token currently held in
+`secrets.RAILWAY_TOKEN`. Resolution requires a human admin to rotate the secret in the
+Railway dashboard and update the GitHub Actions secret. **This is explicitly out of
+scope for any agent per `CLAUDE.md` § Railway Token Rotation.**
+```
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| _(none — code-side fix)_ | — | — | No source code, workflow, runbook, or `.github/RAILWAY_TOKEN_ROTATION_*.md` file is to be modified. The validator is correct; the runbook is the human's responsibility; creating a `RAILWAY_TOKEN_ROTATION_907.md` claiming success on a human-only action is a Category 1 error per `CLAUDE.md`. |
+| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md` | NEW | CREATE | This file. |
+| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md` | EXISTING | (already present) | Captures Railway community/docs evidence for No-workspace + No-expiration token-creation requirements and `.app` vs `.com` host observations. Read by the implementing agent (and surfaced in the routing comment) so the human admin can verify both checkboxes before re-rotating like-for-like. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:32-58` — `Validate Railway secrets` step. **Not modified.** It correctly emits the actionable error.
+- `.github/workflows/staging-pipeline.yml:60-100+` — `Deploy staging image to Railway` and downstream steps. Never reached because the validator fast-fails (correct fail-fast behaviour).
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the human-only rotation runbook referenced by the validator's error message. **Not modified** (out of scope; potential improvements are catalogued in `web-research.md` for a separate bead).
+- `pipeline-health-cron.sh` — auto-filed this issue with the `archon:in-progress` label, which is how Archon picked it up. **Not modified** (its behaviour is correct).
+
+### Git History
+
+- **Validator step introduced**: long-standing in `.github/workflows/staging-pipeline.yml` — predates this incident chain.
+- **Last RAILWAY_TOKEN rotation observed via this repo**: the human admin actions are not committed to git (they happen in the GitHub Secrets UI), so git history alone cannot timestamp them. The chain of investigation PRs (`#851 → #852 → … → #905 → #906`) is the operational record.
+- **Chain implication**: 61 rejections in repo history, 21 today alone, with the `#904 → #907` interval ~1 hour. This is well beyond a one-off expiration and points to either (i) Railway-side credential lifecycle (short TTL or external revocation) or (ii) operator-side rotation choices (wrong workspace, default expiration). See `web-research.md` for both hypotheses.
+
+---
+
+## Implementation Plan
+
+This is a **docs-only investigation deliverable**. The implementing agent's job is to produce the artifact set, post the routing comment, and open a PR with `Fixes #907` — **not** to modify code, the workflow, the runbook, or any `.github/RAILWAY_TOKEN_ROTATION_*.md` file.
+
+### Step 1: Write the investigation artifact
+
+**File**: `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md`
+**Action**: CREATE (this file)
+**Why**: It IS the specification. The implementing agent reads it to know what to produce.
+
+### Step 2: Reference (do not duplicate) `web-research.md`
+
+**File**: `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md`
+**Action**: ALREADY PRESENT — link from the routing comment and the investigation artifact.
+**Why**: Polecat Scope Discipline. The systemic hypotheses (No-workspace, No-expiration, `.app` vs `.com`) belong in their own doc and a separate bead targeting the runbook; they are out of scope for #907 itself.
+
+### Step 3: Post a routing comment on issue #907
+
+**Channel**: `gh issue comment 907 --body …`
+**Content** (verbatim, including the four-step human checklist):
+
+```markdown
+## 🔍 Investigation: Main CI red: Deploy to staging
+
+**Type**: `BUG` (operational — external credential expiry)
+**61st `RAILWAY_TOKEN` rejection / 21st today** — chain `#878 → … → #903/#904 → #907`.
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | `HIGH` | Staging deploy chain blocked at validator step; no in-repo workaround. |
+| Complexity | `LOW` | Zero code changes; fix is a human-only Railway dashboard rotation. |
+| Confidence | `HIGH` | Identical message + step + endpoint as the prior 60 incidents (most recently #904 ~1h ago). |
+
+### Root cause (one line)
+
+Railway's auth backend rejects the token currently held in `secrets.RAILWAY_TOKEN`
+(`{"errors":[{"message":"Not Authorized"}]}` from `{me{id}}`). The validator at
+`.github/workflows/staging-pipeline.yml:49-58` is correct; the token is not.
+
+### Per `CLAUDE.md` § Railway Token Rotation
+
+> Agents cannot rotate the Railway API token. The token lives in GitHub Actions secrets
+> (`RAILWAY_TOKEN`) and requires human access to railway.com.
+
+### Human follow-up required
+
+1. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` — **with No workspace
+   selected and No expiration** (see `web-research.md` § Recommendations #1–#2 in this
+   run before re-rotating like-for-like, since the chain has now repeated 12 times in
+   <8 hours).
+2. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` — verify the new
+   token authenticates.
+3. `gh run rerun 25256579563 --repo alexsiri7/reli --failed` — re-run the failed
+   pipeline.
+4. Confirm `Validate Railway secrets` passes; close #907 with the green run URL.
+
+### What this investigation does NOT do
+
+- Does **not** rotate the token (human-only).
+- Does **not** create a `.github/RAILWAY_TOKEN_ROTATION_907.md` claiming success on a
+  human-only action (Category 1 error per `CLAUDE.md`).
+- Does **not** modify the validator, the runbook, or `DEPLOYMENT_SECRETS.md` (Polecat
+  scope; runbook revisions belong in a separate bead — hypotheses captured in
+  `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md`).
+
+### Artifact
+
+📄 `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md`
+📄 `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md`
+
+---
+*Investigated by Claude • 2026-05-02T17:35:00Z*
+```
+
+### Step 4: Open the PR
+
+**Branch**: `archon/task-archon-fix-github-issue-1777741225437` (current)
+**Title**: `docs: investigation for issue #907 (61st RAILWAY_TOKEN expiration, 21st today)`
+**Body**: PR description mirroring the routing comment, with `Fixes #907`.
+**Why**: Per `CLAUDE.md` § GitHub Issue Linking, every PR must link the issue it
+contributes to.
+
+---
+
+## Patterns to Follow
+
+**Mirror the prior chain link verbatim** — same artifact layout, same routing-comment
+shape, same Polecat scope guards. The implementing agent should follow PR #906
+(`docs: investigation for #904 (60th RAILWAY_TOKEN expiration)`) as the canonical
+template for this incident class. Diff vs that PR should be:
+
+- chain count: `60th → 61st`
+- today count: `20th → 21st`
+- run ID: `25255409159 → 25256579563`
+- issue/PR cross-references: `#904 → #907`
+- artifact run hash: `75b15c4… → 82f3717c…`
+- chain history line: append `→ #907`
+
+Everything else (scope guards, validation matrix, "what this PR does NOT do" section)
+should be **identical** to PR #906.
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| The implementing agent fabricates a "rotation done" file (`.github/RAILWAY_TOKEN_ROTATION_907.md`) | Explicit Category 1 guard in the implementation plan + repeated reminders in routing comment, PR body, and `CLAUDE.md`. The validation step must explicitly check that no such file was added to the diff. |
+| The implementing agent edits the validator step to soften the failure | Out of scope per Polecat. The validator is doing the right thing — fail fast with an actionable error. Any change to it would mask the underlying token problem. |
+| The implementing agent edits `docs/RAILWAY_TOKEN_ROTATION_742.md` to add the No-workspace / No-expiration guidance from `web-research.md` | Out of scope for #907 — that is a separate runbook-improvement bead. The hypotheses are documented in `web-research.md` so a future bead can pick them up without re-doing the research. |
+| Rotation chain continues after this PR merges (i.e., #908 / #909 / …) | Each new issue gets its own investigation artifact + routing comment. The chain count line in the PR title makes the systemic pattern visible to the human admin so they escalate to Railway support if the No-workspace / No-expiration verification doesn't break the loop. |
+| Issue #907 is closed by the human admin before the PR merges | PR still merges with `Fixes #907` (or `Refs #907` if already closed). Artifact remains as historical record. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+This is a docs-only diff. The standard suites (type / lint / format / tests / build) are
+non-applicable. The implementing agent should verify:
+
+```bash
+# Diff is docs-only (no code, no workflow, no runbook, no .github/RAILWAY_TOKEN_ROTATION_*.md)
+git diff --name-only main...HEAD | grep -vE '^artifacts/runs/82f3717c5ef377464cba9b91fd484398/' && echo "OUT OF SCOPE FILE FOUND" || echo "OK"
+
+# Markdown files render (basic sanity — no broken fences)
+for f in artifacts/runs/82f3717c5ef377464cba9b91fd484398/*.md; do head -1 "$f"; done
+
+# No Category 1 file
+test -f .github/RAILWAY_TOKEN_ROTATION_907.md && echo "CATEGORY 1 VIOLATION" || echo "OK"
+```
+
+### Manual Verification (post-merge, human-only)
+
+1. Human admin completes the four-step rotation checklist in the routing comment.
+2. `Validate Railway secrets` passes on a re-run of run `25256579563` (or the next main
+   CI completion).
+3. Issue #907 is closed by the human with the green run URL.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Create `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md` (this file).
+- Reference the existing `web-research.md` from the routing comment and PR body.
+- Post the routing comment on #907.
+- Open a PR titled `docs: investigation for issue #907 (61st RAILWAY_TOKEN expiration, 21st today)` with `Fixes #907`.
+
+**OUT OF SCOPE (do not touch):**
+- `RAILWAY_TOKEN` itself (human-only).
+- `.github/workflows/staging-pipeline.yml` — the validator is correct.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — runbook revisions are a separate bead; hypotheses captured in `web-research.md`.
+- `DEPLOYMENT_SECRETS.md`, `pipeline-health-cron.sh`, any frontend/backend code.
+- Creating a `.github/RAILWAY_TOKEN_ROTATION_907.md` (Category 1 error).
+- Producing screenshot updates (`frontend/e2e/visual.spec.ts-snapshots/`) — no UI changes.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T17:35:00Z
+- **Artifact**: `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md`
+- **Companion**: `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md`
+- **Chain**: 61st `RAILWAY_TOKEN` rejection in repo history, 21st in calendar day 2026-05-02 — `#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901 → #903/#904 → #907`.

--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/validation.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/validation.md
@@ -1,0 +1,98 @@
+# Validation Results
+
+**Generated**: 2026-05-02 18:10
+**Workflow ID**: 82f3717c5ef377464cba9b91fd484398
+**Issue**: #907 — Main CI red: Deploy to staging (61st `RAILWAY_TOKEN` expiration, 21st today)
+**Status**: ALL_PASS (docs-only diff — code suites N/A)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Diff scope (docs-only) | ✅ | All 3 changed paths are under `artifacts/runs/82f3717c5ef377464cba9b91fd484398/` |
+| No Category 1 rotation file | ✅ | `.github/RAILWAY_TOKEN_ROTATION_907.md` absent |
+| Type check | N/A | No source files touched |
+| Lint | N/A | No source files touched |
+| Format | N/A | No source files touched |
+| Tests | N/A | No source files touched |
+| Build | N/A | No source files touched |
+| Visual regression | N/A | No frontend changes |
+
+---
+
+## Diff Inspection
+
+**Command**: `git diff --name-only origin/main..HEAD`
+
+```
+artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md
+artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
+artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
+```
+
+**Stats** (`git diff --stat origin/main..HEAD`):
+
+```
+ .../implementation.md     |  65 +++++
+ .../investigation.md      | 274 +++++++++++++++++++++
+ .../web-research.md       | 173 +++++++++++++
+ 3 files changed, 512 insertions(+)
+```
+
+All paths are confined to this run's artifact directory. No `backend/`, `frontend/`, `.github/workflows/`, `docs/`, or `data/` paths are touched — matches the scope declared in `implementation.md` and the Polecat Scope Discipline rule in `CLAUDE.md`.
+
+---
+
+## Category 1 Guardrail (Railway Token Rotation)
+
+**Command**: existence check on `.github/RAILWAY_TOKEN_ROTATION_907.md`
+**Result**: ✅ Pass — file does not exist
+
+`CLAUDE.md` § Railway Token Rotation: "Do NOT create a `.github/RAILWAY_TOKEN_ROTATION_*.md` file claiming rotation is done." The runbook for humans remains at `docs/RAILWAY_TOKEN_ROTATION_742.md` (untouched).
+
+---
+
+## Code Suites
+
+**Command**: N/A
+**Result**: N/A
+
+Per `implementation.md` § Validation Results: type / lint / format / test / build suites are not run because the diff contains no source files. The repository's CI is configured to run those suites on changes under `backend/` and `frontend/`; documentation-only PRs do not meaningfully exercise them.
+
+If a future maintainer wants belt-and-suspenders coverage, the safe commands in this repo are:
+
+| Suite | Command | Why N/A here |
+|-------|---------|--------------|
+| Backend tests | `cd backend && pytest` | No `.py` files changed |
+| Frontend type-check | `npm --prefix frontend run type-check` (or `tsc --noEmit`) | No `.ts`/`.tsx` files changed |
+| Frontend lint | `npm --prefix frontend run lint` | No `.ts`/`.tsx` files changed |
+| Frontend build | `npm --prefix frontend run build` | No `.ts`/`.tsx`/`.css` files changed |
+| Visual regression | `npm --prefix frontend run test:screenshots` | No UI changes |
+
+---
+
+## Markdown Sanity Check
+
+**Files inspected**:
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `investigation.md` | 274 | Frontmatter, sections, fenced code blocks all balanced |
+| `web-research.md` | 173 | Frontmatter, sections, fenced code blocks all balanced |
+| `implementation.md` | 65 | Tables, sections balanced |
+
+No broken code fences; tables render; cross-references between artifacts (investigation ↔ web-research ↔ implementation) are consistent.
+
+---
+
+## Files Modified During Validation
+
+None. Validation was inspection-only — no fixes were required.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to update the PR (commit `9442bca`, branch `archon/task-archon-fix-github-issue-1777741225437`) and mark it ready for review. The PR body should include `Fixes #907`.

--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
@@ -1,0 +1,173 @@
+# Web Research: fix #907
+
+**Researched**: 2026-05-02T00:00:00Z
+**Workflow ID**: 82f3717c5ef377464cba9b91fd484398
+**Issue**: [#907 — Main CI red: Deploy to staging](https://github.com/alexsiri7/reli/issues/907)
+
+---
+
+## Summary
+
+Issue #907 is the latest in a long string of `RAILWAY_TOKEN is invalid or expired: Not Authorized` failures (61st by commit count, 19th today as of recent issues #903/#904/#906). Per `CLAUDE.md`, agents cannot rotate this token — that requires human access to railway.com. Web research confirms the GitHub Actions workflow at `.github/workflows/staging-pipeline.yml` uses an `Authorization: Bearer` style token (account or workspace token, not a project token, which would use `Project-Access-Token`). The recurring nature plus Railway community evidence points to either a short-TTL token being re-issued each rotation **or** the token being created with the wrong workspace scope; Railway's official docs do not publish a TTL for non-OAuth tokens, so the existing runbook's "No expiration" advice cannot be verified from public docs.
+
+---
+
+## Findings
+
+### 1. Railway has four token types with different headers and scopes
+
+**Source**: [Public API — Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Diagnosing whether the workflow uses the right token type
+
+**Key Information**:
+
+- Four token types: **account**, **workspace**, **project**, **OAuth**.
+- **Account, workspace, OAuth** tokens authenticate with: `Authorization: Bearer <TOKEN>`.
+- **Project** tokens authenticate with: `Project-Access-Token: <TOKEN>` (different header).
+- Best-use guidance:
+  - Account → personal scripts, local dev (don't share)
+  - Workspace → team CI/CD, shared automation (sharable)
+  - Project → deployments, service-specific automation
+- Reli's failing step uses `Authorization: ***` (Bearer) → so it is an **account or workspace token**, not a project token. This is consistent with reaching the `{me{id}}` GraphQL query (which a project token cannot answer).
+
+---
+
+### 2. Railway's official docs do NOT publish a TTL for non-OAuth tokens
+
+**Sources**:
+- [Login & Tokens — Railway Docs](https://docs.railway.com/integrations/oauth/login-and-tokens)
+- [Public API — Railway Docs](https://docs.railway.com/integrations/api)
+
+**Authority**: Official Railway documentation
+**Relevant to**: Whether "No expiration" is actually selectable, and whether account/workspace tokens silently expire
+
+**Key Information**:
+
+- **OAuth access tokens** expire after **1 hour**; **refresh tokens** last **1 year** with rotation.
+- The OAuth doc explicitly does NOT cover account, workspace, or project tokens — those are described in `integrations/api`, which gives no expiration timing or TTL options.
+- The internal runbook (`docs/RAILWAY_TOKEN_ROTATION_742.md`) claims tokens have a default short TTL ("1 day or 7 days") and that "No expiration" must be selected. **This claim is not corroborated by Railway's public documentation** as of 2026-05-02 — it may be accurate (UI-only guidance not in docs) or stale.
+- **Gap**: Without an authoritative TTL document, we cannot tell whether the token is timing out, being revoked, or being created incorrectly.
+
+---
+
+### 3. "Not Authorized" is often a token *scope/creation* problem, not pure expiration
+
+**Source**: [API Token "Not Authorized" Error for Public API and MCP — Railway Help Station](https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1)
+**Authority**: Railway community help (resolution accepted)
+**Relevant to**: Whether the recurring failure is caused by re-creating tokens at the wrong scope
+
+**Key Information**:
+
+- The accepted resolution: tokens **must** be created from **Account Settings → Tokens** via the user banner sidebar, with the workspace field set to **"No workspace"**.
+- Tokens created from project or team settings pages are reported to fail with `Not Authorized` even when fresh.
+- This matches Reli's symptom (`Not Authorized` in `{me{id}}`) and would explain why every rotation fails again after some interval if the rotator picks the wrong creation flow.
+
+---
+
+### 4. Project tokens cannot answer `{me{id}}` — they cannot be the fix here
+
+**Source**: [Unable to Generate API Token with Deployment Permissions — Railway Help](https://station.railway.com/questions/unable-to-generate-api-token-with-deploy-4d2ccc12)
+**Authority**: Railway community help
+**Relevant to**: Choosing token type for `staging-pipeline.yml`
+
+**Key Information**:
+
+- Project tokens (UUID format) "can read project information but cannot trigger deployments".
+- For mutations (deploys, env changes) the **account token** (or team/workspace token) is needed — and it must use the `Authorization: Bearer` header.
+- Reli's preflight (`{me{id}}`) requires the Bearer/account-style token by design — switching to a project token would break the preflight.
+
+---
+
+### 5. Railway officially recommends project tokens for GitHub Actions deploys
+
+**Sources**:
+- [Using GitHub Actions with Railway — Railway Blog](https://blog.railway.com/p/github-actions)
+- [Token for GitHub Action — Railway Help Station](https://station.railway.com/questions/token-for-git-hub-action-53342720)
+
+**Authority**: Official Railway blog + community help
+**Relevant to**: Long-term architecture — could the deployment step use a project token to escape this loop?
+
+**Key Information**:
+
+- Railway recommends a **project token** in `RAILWAY_TOKEN` for deploys (not for `me` queries).
+- "If you are using a team project, you need to ensure that the token specified is scoped to your account, not a workspace" — but for *just* a deploy step (`railway up` etc.) a project token is enough.
+- **Implication for Reli**: the preflight that calls `{me{id}}` is what *requires* an account/workspace token (and therefore the rotation loop). The deploy itself could in principle run on a project token, which is harder to misconfigure and never queries `me`.
+
+---
+
+### 6. Endpoint domain consistency
+
+**Source**: [Public API — Railway Docs](https://docs.railway.com/integrations/api)
+**Authority**: Official Railway documentation
+**Relevant to**: Sanity-check the workflow URL
+
+**Key Information**:
+
+- The current canonical GraphQL endpoint is `https://backboard.railway.com/graphql/v2`.
+- Reli's workflow uses `https://backboard.railway.app/graphql/v2`. Community reports note `.app` vs `.com` confusion has surfaced 401-style failures historically. This is **not the root cause here** (the request reaches the API and returns a structured `Not Authorized`, so the host is responding), but worth flagging on the next rotation.
+
+---
+
+## Code Examples
+
+```yaml
+# Current Reli preflight (from .github/workflows/staging-pipeline.yml; failing in run 25256579563)
+# Source: log excerpt fetched via `gh run view 25256579563 --log-failed`
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: ***" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  exit 1
+fi
+```
+
+The `{me{id}}` query is the constraint — only account/workspace tokens can satisfy it. From [Public API — Railway Docs](https://docs.railway.com/integrations/api):
+
+```
+Authorization: Bearer <ACCOUNT_OR_WORKSPACE_TOKEN>   # required for {me{id}}
+Project-Access-Token: <PROJECT_TOKEN>                # cannot answer {me{id}}
+```
+
+---
+
+## Gaps and Conflicts
+
+- **Gap (authoritative TTL)**: Railway's public docs do not publish an expiration policy for account/workspace/project tokens. Only OAuth access tokens (1 h) and refresh tokens (1 y) are documented. We therefore cannot independently verify the existing runbook's claim that the UI defaults to a short TTL.
+- **Gap (root cause of recurrence)**: 19+ failures in a single day suggest something more aggressive than a TTL — possibilities include (a) automatic revocation when a workspace token is rotated elsewhere, (b) a scheduled/external rotator stepping on the secret, (c) repeated creation under the wrong scope. None of these can be confirmed without Railway dashboard access.
+- **Conflict (token recommendation vs current design)**: Railway's blog recommends a project token for GitHub Actions, but Reli's preflight (`{me{id}}`) explicitly cannot work with a project token. The two are reconcilable only by changing the preflight.
+- **Outdated content**: A community thread referenced `backboard.railway.app` while current docs use `backboard.railway.com`. Either still resolves, but mixing them invites future surprise.
+
+---
+
+## Recommendations
+
+These are research-level recommendations for the human implementer (per `CLAUDE.md`, agents must not perform the rotation):
+
+1. **For this incident (#907)**: human rotates `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`. When creating the new token in Railway dashboard, follow the community-validated steps from the "Not Authorized" thread: navigate via the **user banner sidebar → Account Settings → Tokens**, set workspace to **"No workspace"** (or to a stable workspace if intentionally team-scoped). Avoid creating from project or team settings pages.
+2. **Structural fix to escape the loop**: split the preflight from the deploy.
+   - Keep the `me`-query preflight only if you need to verify the human's account token.
+   - Consider switching the *deploy* step to a **project token** (`Project-Access-Token` header), which is purpose-built for deployment automation and avoids account-level reauthorization. The preflight could then be dropped or weakened to a project-scoped query, eliminating the `{me{id}}` dependency.
+3. **Update `staging-pipeline.yml`** to call `https://backboard.railway.com/graphql/v2` instead of `.app`, matching current Railway docs. Cosmetic but removes a known footgun.
+4. **Do not** create yet another `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming the rotation has been done — `CLAUDE.md` flags this as a Category 1 error. The action for this PR is to file/escalate, not to claim completion.
+5. **Track the recurrence**: 19 occurrences in one day is a system-level anomaly, not a token-lifetime issue. Worth a separate mail-to-mayor flagging that the rotation cadence has gone from "occasional" to "hourly" — something changed.
+
+---
+
+## Sources
+
+| # | Source | URL | Relevance |
+|---|--------|-----|-----------|
+| 1 | Railway Docs — Public API | https://docs.railway.com/integrations/api | Token types, headers, scopes |
+| 2 | Railway Docs — Login & Tokens | https://docs.railway.com/integrations/oauth/login-and-tokens | OAuth token TTLs (1 h / 1 y); silence on other tokens |
+| 3 | Railway Blog — GitHub Actions | https://blog.railway.com/p/github-actions | Recommended token type for CI/CD deploys |
+| 4 | Railway Help — "Not Authorized" for Public API/MCP | https://station.railway.com/questions/api-token-not-authorized-error-for-pub-82b4ccf1 | Resolution: create from Account Settings, "No workspace" |
+| 5 | Railway Help — Unable to generate token with deploy permissions | https://station.railway.com/questions/unable-to-generate-api-token-with-deploy-4d2ccc12 | Project tokens can't perform mutations / `me` queries |
+| 6 | Railway Help — Token for GitHub Action | https://station.railway.com/questions/token-for-git-hub-action-53342720 | Account vs workspace scoping for team projects |
+| 7 | Railway Help — Deploy from GitHub "Not Authorized" | https://station.railway.com/questions/when-trying-to-deploy-from-github-i-jus-d6b9f03a | Symptom corroboration |
+| 8 | GitHub — railwayapp/cli #699 | https://github.com/railwayapp/cli/issues/699 | Linux CLI auth failures with valid tokens (background) |
+| 9 | GitHub — railwayapp/cli #105 | https://github.com/railwayapp/cli/issues/105 | RAILWAY_TOKEN scope limitations (background) |
+| 10 | Internal runbook | `docs/RAILWAY_TOKEN_ROTATION_742.md` | Project's existing rotation procedure |

--- a/artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
+++ b/artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-Issue #907 is the latest in a long string of `RAILWAY_TOKEN is invalid or expired: Not Authorized` failures (61st by commit count, 19th today as of recent issues #903/#904/#906). Per `CLAUDE.md`, agents cannot rotate this token — that requires human access to railway.com. Web research confirms the GitHub Actions workflow at `.github/workflows/staging-pipeline.yml` uses an `Authorization: Bearer` style token (account or workspace token, not a project token, which would use `Project-Access-Token`). The recurring nature plus Railway community evidence points to either a short-TTL token being re-issued each rotation **or** the token being created with the wrong workspace scope; Railway's official docs do not publish a TTL for non-OAuth tokens, so the existing runbook's "No expiration" advice cannot be verified from public docs.
+Issue #907 is the latest in a long string of `RAILWAY_TOKEN is invalid or expired: Not Authorized` failures (61st by commit count, 21st today, most recently #903/#904). Per `CLAUDE.md`, agents cannot rotate this token — that requires human access to railway.com. Web research confirms the GitHub Actions workflow at `.github/workflows/staging-pipeline.yml` uses an `Authorization: Bearer` style token (account or workspace token, not a project token, which would use `Project-Access-Token`). The recurring nature plus Railway community evidence points to either a short-TTL token being re-issued each rotation **or** the token being created with the wrong workspace scope; Railway's official docs do not publish a TTL for non-OAuth tokens, so the existing runbook's "No expiration" advice cannot be verified from public docs.
 
 ---
 
@@ -137,7 +137,7 @@ Project-Access-Token: <PROJECT_TOKEN>                # cannot answer {me{id}}
 ## Gaps and Conflicts
 
 - **Gap (authoritative TTL)**: Railway's public docs do not publish an expiration policy for account/workspace/project tokens. Only OAuth access tokens (1 h) and refresh tokens (1 y) are documented. We therefore cannot independently verify the existing runbook's claim that the UI defaults to a short TTL.
-- **Gap (root cause of recurrence)**: 19+ failures in a single day suggest something more aggressive than a TTL — possibilities include (a) automatic revocation when a workspace token is rotated elsewhere, (b) a scheduled/external rotator stepping on the secret, (c) repeated creation under the wrong scope. None of these can be confirmed without Railway dashboard access.
+- **Gap (root cause of recurrence)**: 21+ failures in a single day suggest something more aggressive than a TTL — possibilities include (a) automatic revocation when a workspace token is rotated elsewhere, (b) a scheduled/external rotator stepping on the secret, (c) repeated creation under the wrong scope. None of these can be confirmed without Railway dashboard access.
 - **Conflict (token recommendation vs current design)**: Railway's blog recommends a project token for GitHub Actions, but Reli's preflight (`{me{id}}`) explicitly cannot work with a project token. The two are reconcilable only by changing the preflight.
 - **Outdated content**: A community thread referenced `backboard.railway.app` while current docs use `backboard.railway.com`. Either still resolves, but mixing them invites future surprise.
 
@@ -153,7 +153,7 @@ These are research-level recommendations for the human implementer (per `CLAUDE.
    - Consider switching the *deploy* step to a **project token** (`Project-Access-Token` header), which is purpose-built for deployment automation and avoids account-level reauthorization. The preflight could then be dropped or weakened to a project-scoped query, eliminating the `{me{id}}` dependency.
 3. **Update `staging-pipeline.yml`** to call `https://backboard.railway.com/graphql/v2` instead of `.app`, matching current Railway docs. Cosmetic but removes a known footgun.
 4. **Do not** create yet another `.github/RAILWAY_TOKEN_ROTATION_*.md` claiming the rotation has been done — `CLAUDE.md` flags this as a Category 1 error. The action for this PR is to file/escalate, not to claim completion.
-5. **Track the recurrence**: 19 occurrences in one day is a system-level anomaly, not a token-lifetime issue. Worth a separate mail-to-mayor flagging that the rotation cadence has gone from "occasional" to "hourly" — something changed.
+5. **Track the recurrence**: 21 occurrences in one day is a system-level anomaly, not a token-lifetime issue. Worth a separate mail-to-mayor flagging that the rotation cadence has gone from "occasional" to "hourly" — something changed.
 
 ---
 


### PR DESCRIPTION
## Summary

Investigation-only PR for #907 — `Deploy to staging` is red because Railway rejected the `RAILWAY_TOKEN` GitHub Actions secret with `Not Authorized` from `{me{id}}` against `https://backboard.railway.app/graphql/v2`. This is the **61st `RAILWAY_TOKEN` rejection in repo history and the 21st today**, continuing the chain `#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901 → #903/#904 → #907`.

Per `CLAUDE.md` § Railway Token Rotation, **agents cannot rotate this token** — the deliverable is docs-only (artifact set + routing comment). The fix is a human-only Railway dashboard rotation followed by `gh secret set RAILWAY_TOKEN`.

## Assessment

| Metric | Value | Reasoning |
|--------|-------|-----------|
| Severity | **HIGH** | Staging deploy chain blocked at the validator step; staging gates production. |
| Complexity | **LOW** | Zero code changes — fix is a human-only Railway dashboard action. |
| Confidence | **HIGH** | Identical message + step + endpoint as the prior 60 incidents (most recently #904 ~1h ago). |

## Root cause (one line)

Railway's auth backend rejects the token currently held in `secrets.RAILWAY_TOKEN`
(`{"errors":[{"message":"Not Authorized"}]}` from `{me{id}}`). The validator at
`.github/workflows/staging-pipeline.yml:49-58` is correct; the token is not.

Failed run: [25256579563](https://github.com/alexsiri7/reli/actions/runs/25256579563) (SHA `3521481`).

## Changes

Docs-only — all changes are inside `artifacts/runs/82f3717c5ef377464cba9b91fd484398/`:

| File | Action | Notes |
|------|--------|-------|
| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md` | CREATE | Full assessment, evidence chain, scope boundaries, validation matrix. |
| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md` | CREATE | Railway community/docs research on No-workspace + No-expiration creation flags and `.app` vs `.com` host observations. |
| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md` | CREATE | Implementation report. |
| `artifacts/runs/82f3717c5ef377464cba9b91fd484398/validation.md` | CREATE | Validation report (docs-only diff; code suites N/A). |

No source files, workflows, runbooks, or `.github/RAILWAY_TOKEN_ROTATION_*.md` files were touched.

## Validation

| Check | Result |
|-------|--------|
| Diff is docs-only and scoped to `artifacts/runs/82f3717c5ef377464cba9b91fd484398/` | ✅ |
| No Category 1 `.github/RAILWAY_TOKEN_ROTATION_907.md` file added | ✅ |
| `.github/workflows/staging-pipeline.yml` validator step unchanged | ✅ |
| `docs/RAILWAY_TOKEN_ROTATION_742.md` runbook unchanged | ✅ |
| Markdown files render (no broken fences) | ✅ |
| Type / lint / format / test / build suites | N/A (docs-only diff) |
| Visual regression screenshots | N/A (no UI changes) |

`git diff --name-only origin/main..HEAD`:

```
artifacts/runs/82f3717c5ef377464cba9b91fd484398/implementation.md
artifacts/runs/82f3717c5ef377464cba9b91fd484398/investigation.md
artifacts/runs/82f3717c5ef377464cba9b91fd484398/validation.md
artifacts/runs/82f3717c5ef377464cba9b91fd484398/web-research.md
```

## Human follow-up required (post-merge)

1. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md` — **with No workspace selected and No expiration** (see `web-research.md` § Recommendations #1–#2 in this run before re-rotating like-for-like; the chain has now repeated 21 times today).
2. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` — verify the new token authenticates.
3. `gh run rerun 25256579563 --repo alexsiri7/reli --failed` — re-run the failed pipeline.
4. Confirm `Validate Railway secrets` passes; close #907 with the green run URL.

## What this PR does NOT do

- Does **not** rotate `RAILWAY_TOKEN` (human-only — `CLAUDE.md` § Railway Token Rotation).
- Does **not** create `.github/RAILWAY_TOKEN_ROTATION_907.md` (Category 1 error).
- Does **not** modify the validator at `.github/workflows/staging-pipeline.yml:32-58` (correct as-is).
- Does **not** modify `docs/RAILWAY_TOKEN_ROTATION_742.md` (out of scope; runbook revisions belong in a separate bead — hypotheses captured in `web-research.md`).
- Does **not** modify `DEPLOYMENT_SECRETS.md`, `pipeline-health-cron.sh`, or any frontend/backend code.

Fixes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
