### PR TITLE
docs: investigate Main CI red — Deploy to staging (#911)

### DIFF
--- a/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md
+++ b/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md
@@ -1,0 +1,206 @@
+# Investigation: Main CI red: Deploy to staging (#911)
+
+**Issue**: #911 (https://github.com/alexsiri7/reli/issues/911)
+**Type**: BUG (operational — external credential rejection)
+**Investigated**: 2026-05-02T18:40:00Z
+**Workflow run**: f0b7ab316fde5e44bfdc8f85f2e9d016
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | HIGH | Staging deploy chain is fully blocked at the validator step on every main CI completion; no in-repo workaround, but only the staging deploy job fails — non-deploy CI is unaffected. |
+| Complexity | LOW | Zero code changes are warranted on this bead; the remediation is a human-only Railway dashboard rotation followed by `gh secret set RAILWAY_TOKEN`. Validator code at `.github/workflows/staging-pipeline.yml:49-58` is functioning as designed. |
+| Confidence | HIGH | The failure message, endpoint, and step are byte-for-byte identical to the prior 62 incidents (most recently #909 about an hour ago, PR #910). The validator's `me{id}` probe returned the same `Not Authorized` GraphQL error. |
+
+---
+
+## Problem Statement
+
+The "Validate Railway secrets" step in `.github/workflows/staging-pipeline.yml` failed
+on run 25258939832 because Railway's auth backend rejected the token currently held in
+`secrets.RAILWAY_TOKEN`. This is the 63rd recurrence of the same failure mode and the
+23rd today (chain `#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901 → #903/#904 → #907 → #909 → #911`).
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+The validator posts a `query { me { id } }` GraphQL request to
+`https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN`.
+Railway returned `{"errors":[{"message":"Not Authorized"}]}`, which the validator
+correctly surfaces as "RAILWAY_TOKEN is invalid or expired". The validator is correct;
+the token is what is failing.
+
+Per `CLAUDE.md` § Railway Token Rotation, the token lives in GitHub Actions secrets and
+requires human access to railway.com; agents cannot rotate it. The fix is therefore
+out of code-change scope for this bead.
+
+### Evidence Chain
+
+WHY: Why did "Deploy to staging" fail on run 25258939832?
+↓ BECAUSE: The "Validate Railway secrets" step exited non-zero.
+  Evidence: `Process completed with exit code 1.` at 2026-05-02T18:34:31Z.
+
+↓ BECAUSE: The validator's `me{id}` probe to Railway returned `Not Authorized`.
+  Evidence: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` at
+  2026-05-02T18:34:31Z.
+
+↓ ROOT CAUSE: The token currently stored in `secrets.RAILWAY_TOKEN` is rejected by
+  Railway's auth backend. Either it has expired, been revoked, or is the wrong token
+  type for the validator's query (the `me{id}` probe requires an Account/Personal
+  token, not a Project Token — see prior chain's web-research notes captured in
+  `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md`).
+  Evidence: `.github/workflows/staging-pipeline.yml:49-58` — validator code is
+  unchanged from prior green runs and is identical across all 63 incidents.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| (none) | — | NONE | This bead requires no source-tree changes. The remediation is a GitHub Actions secret update performed by a human via the Railway dashboard + `gh secret set`. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml:49-58` — the validator that surfaces the
+  failure. Continues to behave correctly.
+- `secrets.RAILWAY_TOKEN` (GitHub Actions secret) — the credential being rejected.
+  Rotation requires human access to https://railway.com.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — the existing human runbook.
+- `.github/workflows/railway-token-health.yml` — out-of-band health check the human
+  can trigger after rotation to verify the new token before re-running #911.
+
+### Git History
+
+- **Last validator change**: not modified in any of the 63 incidents — this is
+  consistently a credential-rejection issue, not a regression in the validator.
+- **Prior incident chain on the same root cause**: #878, #880, #882, #884, #886,
+  #888, #891, #894, #896, #898, #901, #903, #904, #907, #909 (immediate predecessor)
+  — see PRs #879/#881/#883/#885/#887/#889/#892/#895/#897/#899/#902/#905/#906/#908/#910
+  for the same investigation pattern.
+- **Implication**: 63 occurrences and 23-in-one-day cadence suggest the recurrence is
+  itself the bug to address (long-term). The token-type-vs-query-type hypothesis from
+  `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md` may explain why
+  like-for-like rotations keep producing the same error, and remains the recommended
+  pre-rotation verification step.
+
+---
+
+## Implementation Plan
+
+This bead does not modify the source tree. Per `CLAUDE.md` § Railway Token Rotation,
+the only valid agent output here is (a) this investigation artifact and (b) a GitHub
+comment directing the human operator to the runbook. Creating any
+`.github/RAILWAY_TOKEN_ROTATION_911.md` file claiming rotation is done would be a
+Category 1 error and is explicitly forbidden.
+
+### Step 1: Document the failure (this artifact)
+
+**File**: `artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md`
+**Action**: CREATE (this file)
+
+### Step 2: Post investigation comment on issue #911
+
+**Action**: `gh issue comment 911 --body @<formatted_comment>` summarizing this
+artifact and pointing the human at the runbook.
+
+### Step 3: Human follow-up (out of agent scope)
+
+1. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+   - Before another like-for-like rotation, verify whether the secret is an Account
+     token or a Project token, since the chain has now repeated 15 times in <9 hours
+     and a token-type mismatch surfaces as "Not Authorized" identically to expiration
+     (see `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md`).
+2. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` — verify the
+   replacement authenticates before re-running the failed pipeline.
+3. `gh run rerun 25258939832 --repo alexsiri7/reli --failed` — re-trigger the
+   "Deploy to staging" job.
+4. Confirm green run, close #911.
+
+---
+
+## Patterns to Follow
+
+This investigation follows the exact pattern established by #909's investigation
+comment (the immediate predecessor in the chain). Diff vs that prior pattern:
+
+- Issue number: #909 → #911
+- CI run ID: 25257755620 → 25258939832
+- Incident count: "62nd / 22nd today" → "63rd / 23rd today"
+- Predecessor chain extended by `#909`
+- All other content and structure unchanged
+
+```bash
+# Identical validator code that fired the failure (unchanged across 63 incidents)
+# .github/workflows/staging-pipeline.yml:49-58
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  MSG=$(echo "$RESP" | jq -r '.errors[0].message // "could not reach Railway API or token rejected"')
+  echo "::error::RAILWAY_TOKEN is invalid or expired: $MSG"
+  echo "Rotate the token — see DEPLOYMENT_SECRETS.md Token Rotation section."
+  exit 1
+fi
+```
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Agent creates `.github/RAILWAY_TOKEN_ROTATION_911.md` falsely claiming the token was rotated. | Explicitly prohibited by CLAUDE.md § Railway Token Rotation; this investigation produces no such file. |
+| Human rotates with same token type & defaults, recurrence continues. | Token-type hypothesis captured in `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md` should be verified before another like-for-like rotation. Out-of-scope for this bead — flag via mail-to-mayor if confirmed. |
+| Validator endpoint or query is the actual bug (not the token). | Out of scope here per Polecat Scope Discipline; would require its own bead. Hypothesis documented in the prior chain's web-research. |
+| Re-running the pipeline before the human rotates would fail again. | Step 3.2 (`railway-token-health.yml`) added as a pre-check before `gh run rerun`. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+# After the human rotates RAILWAY_TOKEN and we re-run the pipeline:
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run rerun 25258939832 --repo alexsiri7/reli --failed
+gh run watch --repo alexsiri7/reli  # confirm "Validate Railway secrets" passes
+```
+
+### Manual Verification
+
+1. Confirm `Validate Railway secrets` step is green on the re-run.
+2. Confirm the deploy job (`Deploy staging image to Railway`) completes without
+   credential errors.
+3. Close #911 with the green run URL.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+- Diagnose the failure on run 25258939832.
+- Produce an investigation artifact and a GitHub comment that direct the human to
+  the existing runbook.
+
+**OUT OF SCOPE (do not touch):**
+- Rotating `RAILWAY_TOKEN` (human-only per CLAUDE.md).
+- Modifying `.github/workflows/staging-pipeline.yml` validator logic.
+- Modifying `docs/RAILWAY_TOKEN_ROTATION_742.md` or `DEPLOYMENT_SECRETS.md`
+  (runbook revisions belong in a separate bead — token-type hypotheses captured in
+  the prior chain's web-research for that future bead).
+- Replacing the static-secret model with OIDC / dynamic secrets (long-term
+  mitigation; mail-to-mayor candidate).
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T18:40:00Z
+- **Artifact**: `artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md`
+- **Companion research (prior chain)**: `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md`

--- a/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md
+++ b/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md
@@ -1,9 +1,3 @@
----
-name: Validation Results — Issue #911 (63rd RAILWAY_TOKEN expiration)
-description: Validation pass for the docs-only investigation bead. No source-tree changes exist; type-check / lint / format / test / build are N/A.
-type: validation-artifact
----
-
 # Validation Results
 
 **Generated**: 2026-05-02 20:10

--- a/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md
+++ b/artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md
@@ -1,0 +1,121 @@
+---
+name: Validation Results — Issue #911 (63rd RAILWAY_TOKEN expiration)
+description: Validation pass for the docs-only investigation bead. No source-tree changes exist; type-check / lint / format / test / build are N/A.
+type: validation-artifact
+---
+
+# Validation Results
+
+**Generated**: 2026-05-02 20:10
+**Workflow ID**: f0b7ab316fde5e44bfdc8f85f2e9d016
+**Status**: ALL_PASS (vacuously — docs-only bead, see Scope below)
+
+---
+
+## Scope
+
+This bead's branch (`archon/task-archon-fix-github-issue-1777748425574`) contains
+**zero source-tree changes**. The only file added vs `origin/main` is the
+investigation artifact itself:
+
+```
+artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md   (+206 lines)
+```
+
+Per `artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md` § Affected
+Files: "(none) — This bead requires no source-tree changes." The remediation is a
+GitHub-Actions-secret rotation that only a human can perform per
+`CLAUDE.md` § Railway Token Rotation.
+
+Per `CLAUDE.md` § Railway Token Rotation, fabricating validation success on an
+action the agent did not (and could not) perform is a Category 1 error. This
+artifact therefore reports each check as **N/A — no source change to exercise it**
+rather than as `✅ Pass`. The overall status is `ALL_PASS` only in the trivial
+sense that no validator was given anything that could fail.
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | N/A | No `.py`/`.ts`/`.tsx` files changed in this bead. |
+| Lint | N/A | No source files changed in this bead. |
+| Format | N/A | No source files changed in this bead. |
+| Tests | N/A | No code paths changed; existing test suites were not exercised because the diff has no executable code. |
+| Build | N/A | No code or build-config files changed; image rebuild is unaffected. |
+
+The repo's standing CI (the `Run linters` and `Run tests` jobs in
+`.github/workflows/ci.yml`) will execute against this branch on push and is
+authoritative for any "did anything regress" question. They have no input from
+this bead because the diff does not reach any file those jobs consume.
+
+---
+
+## Bead Diff
+
+```
+$ git diff origin/main...HEAD --name-only
+artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md
+```
+
+```
+$ git log -1 --stat HEAD
+4fd123f docs: investigation for issue #911 (63rd RAILWAY_TOKEN expiration, 23rd today)
+ .../f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md | 206 +++++++++++++++++++++
+ 1 file changed, 206 insertions(+)
+```
+
+---
+
+## What was deliberately *not* done
+
+The slash command `/archon-validate-implementation` lists Phase 2 commands of
+the form `{runner} run type-check`, `{runner} run lint`, `{runner} run
+format:check`, `{runner} test`, `{runner} run build`. These were **not run**
+because:
+
+1. There is no top-level `package.json` with these scripts at the repo root —
+   the project is split into `backend/` (Python/FastAPI, validated via
+   `pytest` and `ruff` in CI) and `frontend/` (Node/Vite, validated via
+   `npm --prefix frontend run …`). The slash command's `{runner}` template
+   does not match either subtree without modification.
+2. Even if they were run, they would exercise unchanged code and tell us
+   nothing about this bead's contribution.
+3. Running them anyway and reporting whatever they happen to print would
+   risk attributing pre-existing main-branch state (passing or failing) to
+   this bead — exactly the kind of false attribution `CLAUDE.md` warns
+   against in the Railway-token rotation rule.
+
+If a future agent inherits a bead in this same chain that **does** touch
+source code, that bead's validation artifact must run the appropriate
+subtree's commands (e.g. `npm --prefix frontend run lint`,
+`npm --prefix frontend run type-check`,
+`npm --prefix frontend run test`, `npm --prefix frontend run build`,
+`pytest -q` from the repo root with backend deps installed).
+
+---
+
+## Path-mismatch note
+
+The slash command writes to
+`/home/asiri/.archon/workspaces/alexsiri7/reli/artifacts/runs/{workflow}/`,
+but this worktree (and the existing `investigation.md`) lives under
+`/home/asiri/.archon/workspaces/ext-fast/reli/worktrees/archon/task-archon-fix-github-issue-1777748425574/artifacts/runs/{workflow}/`.
+This artifact is written to the path that actually exists in the worktree so
+that subsequent `archon-finalize-pr` can find it alongside `investigation.md`.
+
+---
+
+## Files Modified During Validation
+
+None. No source files were changed; only this artifact was created.
+
+---
+
+## Next Step
+
+Proceed to `archon-finalize-pr` to update PR #(to-be-created) and mark ready
+for review. The PR body should reference `Fixes #911` (per `CLAUDE.md` § GitHub
+Issue Linking) and link the human operator to
+`docs/RAILWAY_TOKEN_ROTATION_742.md`.


### PR DESCRIPTION
## Summary

- 63rd recurrence of `RAILWAY_TOKEN is invalid or expired: Not Authorized` from the staging-pipeline `Validate Railway secrets` step (run `25258939832`); 23rd today.
- Docs-only bead: this PR adds the investigation + validation artifacts. **No source-tree changes.** Per `CLAUDE.md` § Railway Token Rotation, agents cannot rotate the token — a human must do so via the Railway dashboard + `gh secret set RAILWAY_TOKEN`.
- Direct the operator to `docs/RAILWAY_TOKEN_ROTATION_742.md`.

Fixes #911

## Changes

| File | Action | Notes |
|------|--------|-------|
| `artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md` | add | Diagnosis, evidence chain, prior-incident links, scope boundaries. |
| `artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md` | add | Vacuous `ALL_PASS` (no source change to exercise checks against). |

No code, workflow, dependency, or runtime config files were modified.

## Root cause

The validator at `.github/workflows/staging-pipeline.yml:49-58` posts `query { me { id } }` to `https://backboard.railway.app/graphql/v2` with `Authorization: Bearer $RAILWAY_TOKEN`. Railway returned `{\"errors\":[{\"message\":\"Not Authorized\"}]}`. The validator is correct — the credential it received was rejected by Railway's auth backend.

Validator logic is byte-for-byte unchanged across all 63 incidents (`#878 → … → #909 → #911`); this is a credential-rejection issue, not a regression in the validator.

A standing hypothesis from the prior chain (`artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md`) is that the `me{id}` probe requires an Account/Personal token, while a Project Token would surface as `Not Authorized` identically to expiration. Worth verifying before another like-for-like rotation given the 23-in-one-day cadence.

## Validation evidence

`validation.md` reports each automated check as **N/A — no source change to exercise it**, with `ALL_PASS` only in the trivial sense:

| Check | Result | Reason |
|-------|--------|--------|
| Type check | N/A | No `.py` / `.ts` / `.tsx` files changed. |
| Lint | N/A | No source files changed. |
| Format | N/A | No source files changed. |
| Tests | N/A | No code paths changed. |
| Build | N/A | No code or build-config files changed. |

```
$ git diff origin/main...HEAD --name-only
artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/investigation.md
artifacts/runs/f0b7ab316fde5e44bfdc8f85f2e9d016/validation.md
```

The repo's standing CI (`Run linters` / `Run tests` in `.github/workflows/ci.yml`) on this branch is authoritative for any \"did anything regress\" question; it has no input from this bead because the diff does not reach any file those jobs consume. Per `CLAUDE.md`, fabricating validation success on an action the agent did not perform would be a Category 1 error.

## Required human follow-up (out of agent scope)

1. Verify token type before rotating (Account vs Project) — see `artifacts/runs/71a21444dc75f75167bd149ae06d3f82/web-research.md`.
2. Rotate `RAILWAY_TOKEN` per `docs/RAILWAY_TOKEN_ROTATION_742.md`.
3. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` — verify the replacement authenticates.
4. `gh run rerun 25258939832 --repo alexsiri7/reli --failed` — re-trigger Deploy to staging.
5. Confirm `Validate Railway secrets` and the Deploy job pass; close #911.

## Test plan

- [ ] Human rotates `RAILWAY_TOKEN` per the runbook.
- [ ] `railway-token-health.yml` workflow run is green on the new token.
- [ ] `gh run rerun 25258939832 --failed` succeeds; `Validate Railway secrets` passes; `Deploy staging image to Railway` completes without credential errors.
- [ ] #911 closed with the green run URL.

## Scope boundaries

**Out of scope** (not addressed here): rotating the token itself, modifying validator logic in `staging-pipeline.yml`, revising `docs/RAILWAY_TOKEN_ROTATION_742.md`/`DEPLOYMENT_SECRETS.md`, or replacing the static-secret model with OIDC/dynamic secrets. The recurrence cadence (63 incidents, 23 today) is itself a long-term issue but belongs to a separate bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)