### PR TITLE
docs: investigation for issue #917 (65th RAILWAY_TOKEN expiration)

### DIFF
--- a/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/implementation.md
+++ b/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/implementation.md
@@ -1,0 +1,71 @@
+# Implementation Report
+
+**Issue**: #917 — Main CI red: Deploy to staging (65th RAILWAY_TOKEN expiration, 25th today)
+**Generated**: 2026-05-02 21:15
+**Workflow ID**: bac9855cea89d9bb2f237189ad8f26a7
+**Branch**: `archon/task-archon-fix-github-issue-1777755618721`
+**Commit**: `b7eef9e`
+
+---
+
+## Tasks Completed
+
+| # | Task | Where | Status |
+|---|------|-------|--------|
+| 1 | Create investigation artifact | `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` | ✅ |
+| 2 | Post investigation comment routing human to rotation runbook | GitHub issue #917 | ✅ (already present) |
+| 3 | Commit artifact on the worktree branch | `b7eef9e` | ✅ |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` | CREATE | +205 |
+
+No code, workflow, or runbook files were touched. The investigation explicitly defers the durable workflow fix (`.github/workflows/staging-pipeline.yml` validator + downstream call sites) and the runbook URL correction (`docs/RAILWAY_TOKEN_ROTATION_742.md`) to a separate PR — Polecat Scope Discipline.
+
+---
+
+## Deviations from Investigation
+
+Implementation matched the investigation exactly. The investigation's IN SCOPE was:
+
+1. Create the investigation artifact — done.
+2. Post a GitHub comment on #917 routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` — already posted on issue #917 (single comment by `alexsiri7` containing the full investigation body). Not duplicated.
+
+No deviation. No code touched. No `.github/RAILWAY_TOKEN_ROTATION_917.md` file created (would be a Category 1 error per `CLAUDE.md` § Railway Token Rotation).
+
+---
+
+## Validation Results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Diff is artifacts-only | ✅ | `git diff --name-only origin/main..HEAD` → `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` only |
+| GitHub comment present on #917 | ✅ | 1 comment by `alexsiri7` with `## 🔍 Investigation` heading and full Assessment / Root Cause / Plan / Validation / Next Step blocks |
+| No `.github/RAILWAY_TOKEN_ROTATION_917.md` created | ✅ | Forbidden by `CLAUDE.md`; not present |
+| No workflow / runbook edits | ✅ | Out of scope; deferred to durable-fix PR |
+| Type check / tests / lint | N/A | Docs-only bead — no code paths exercised |
+
+Manual verification (after the human rotates the token, per the artifact):
+
+```bash
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run rerun 25261266464 --repo alexsiri7/reli --failed
+```
+
+That manual step is **not** something this bead can perform — agents cannot rotate `RAILWAY_TOKEN`.
+
+---
+
+## Human Action Required (out of scope, repeated for the rotator)
+
+This is the 65th occurrence of the same failure mode (25th today). Like-for-like rotation buys ~1 hour. The recommended path is Option B from the artifact: mint a Project token in Railway dashboard → **Project Settings → Tokens**, install as `RAILWAY_TOKEN`, and land it together with the deferred workflow PR (Step 3 in the artifact) so the validator speaks the Project-token protocol (`Project-Access-Token:` header, `{ projectToken { projectId environmentId } }` query).
+
+---
+
+## Next Step
+
+Proceeding to PR creation for the investigation artifact commit.

--- a/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md
+++ b/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md
@@ -1,0 +1,205 @@
+# Investigation: Main CI red — Deploy to staging (#917, 65th RAILWAY_TOKEN expiration)
+
+**Issue**: #917 (https://github.com/alexsiri7/reli/issues/917)
+**Type**: BUG (operational — external credential rejection)
+**Investigated**: 2026-05-02T21:10:00Z
+**Run**: https://github.com/alexsiri7/reli/actions/runs/25261266464
+**SHA under test**: `7df1bfd6fa3b2e7cefa61f33652149c214a63a91` (merge of PR #916, the investigation of #915)
+
+### Assessment
+
+| Metric | Value | Reasoning |
+|--------|-------|-----------|
+| Severity | `HIGH` | Prod deploy is gated by the staging deploy job, which fails at the Railway-secret validator on every main push; no in-repo workaround for the bleeding without a human at railway.com. |
+| Complexity | `LOW` (rotation) / `MEDIUM` (durable fix) | Like-for-like rotation is zero code (human-only). The durable fix (switch `RAILWAY_TOKEN` to a Project token, change auth header on six call sites, replace `{me{id}}` validator) is contained to one workflow file plus the runbook. |
+| Confidence | `HIGH` | Failure message, endpoint, and step are byte-for-byte identical to the prior 64 incidents. The token-class hypothesis from PR #916 / `web-research.md` still applies; nothing new in this run's logs contradicts it. |
+
+---
+
+## Problem Statement
+
+The "Validate Railway secrets" step in the "Deploy to staging" job failed on run [25261266464](https://github.com/alexsiri7/reli/actions/runs/25261266464) because Railway's auth backend rejected the token currently held in `secrets.RAILWAY_TOKEN`. This is the **65th** recurrence of the same failure mode and the **25th today**.
+
+Chain: `#878 → #880 → #882 → #884 → #886 → #888 → #891 → #894 → #896 → #898 → #901 → #903/#904 → #907 → #909 → #911/#912 → #915 → #917`.
+
+The SHA under test (`7df1bfd`) is the merge of PR #916 — the investigation of #915. So a docs-only investigation merged, the next scheduled "Staging → Production Pipeline" run picked up that SHA, and predictably failed in the exact same place because the underlying token has not been rotated.
+
+---
+
+## Analysis
+
+### Root Cause / Change Rationale
+
+Two layers — unchanged from the #915 investigation:
+
+**Proximate cause** (what makes this run red): The token in `secrets.RAILWAY_TOKEN` is still rejected by Railway with `Not Authorized`. Like-for-like rotation per `docs/RAILWAY_TOKEN_ROTATION_742.md` will turn this run green.
+
+**Underlying cause** (why we're here for the 65th time): The workflow puts an **Account/Personal token** into the `RAILWAY_TOKEN` slot and calls Railway with `Authorization: Bearer`. Per Railway's own docs, `RAILWAY_TOKEN` is the slot for a **Project token**, which uses a different header (`Project-Access-Token:`). See `artifacts/runs/e05620507f1e5c5cdf1abea3cc3041b8/web-research.md` (committed in PR #916) §§1–3 for primary sources; nothing has changed since that investigation.
+
+### Evidence Chain
+
+WHY: Why did "Deploy to staging" fail on run 25261266464?
+↓ BECAUSE: The "Validate Railway secrets" step exited 1.
+  Evidence: `##[error]Process completed with exit code 1.` at 2026-05-02T20:34:52.945Z.
+
+↓ BECAUSE: The validator's `me{id}` probe to Railway returned `Not Authorized`.
+  Evidence: `##[error]RAILWAY_TOKEN is invalid or expired: Not Authorized` at 2026-05-02T20:34:52.943Z.
+
+↓ BECAUSE: The token currently in `secrets.RAILWAY_TOKEN` is still rejected by Railway's auth backend (expired, revoked, or — most likely — wrong token class). It has not been rotated since the previous failure on #915 (run 25260091455 at 2026-05-02T19:34Z, ~1 hour earlier).
+
+↓ **ROOT CAUSE (durable)**: `RAILWAY_TOKEN` only accepts a Project token. The workflow currently sends `Authorization: Bearer $RAILWAY_TOKEN` (Account-token shape) and validates with `{me{id}}` (Account-token-only query). Both must change for the rotation treadmill to stop.
+  Evidence: `.github/workflows/staging-pipeline.yml:50` (`-H "Authorization: Bearer $RAILWAY_TOKEN"`) and `:52` (`-d '{"query":"{me{id}}"}'`). Validator block unchanged across all 65 incidents.
+
+### Affected Files
+
+| File | Lines | Action | Description |
+|------|-------|--------|-------------|
+| `.github/workflows/staging-pipeline.yml` | 32-58 | UPDATE (durable fix, deferred) | Validator: swap `Authorization: Bearer` → `Project-Access-Token`, replace `{me{id}}` query with `{ projectToken { projectId environmentId } }`. |
+| `.github/workflows/staging-pipeline.yml` | 60-end | UPDATE (durable fix, deferred) | Both deploy steps (staging + prod): change auth header on every Railway API call. |
+| `docs/RAILWAY_TOKEN_ROTATION_742.md` | 24-26 | UPDATE (durable fix, deferred) | Point operators at *Project Settings → Tokens*, not `https://railway.com/account/tokens`. |
+| `secrets.RAILWAY_TOKEN` | n/a | **HUMAN ONLY** | Rotate the existing Account token like-for-like, OR mint a new Project token and reinstall as `RAILWAY_TOKEN`. |
+| `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` | NEW | CREATE | This file. |
+
+### Integration Points
+
+- `.github/workflows/staging-pipeline.yml` — the only consumer of `RAILWAY_TOKEN` in the repo.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — operator runbook; rotation is gated on this file.
+- `pipeline-health-cron.sh` — auto-files this issue on every red main run, so the bleeding shows up as one issue per failed pipeline run until the token is fixed.
+
+### Git History
+
+- The validator block at `.github/workflows/staging-pipeline.yml:32-58` is unchanged across the entire failure chain (`#878 … #917`).
+- Prior investigations: PR #916 (for #915), commit 9117b40 (#911), 1397e3d (#912), fdf6393 (#909), e4dc1c5 (#907), 3521481 (#903).
+- **Implication**: this is a long-standing class-mismatch bug, not a regression.
+
+---
+
+## Implementation Plan
+
+### Step 1 (this bead) — Investigation artifact + GitHub comment
+
+**File**: `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md`
+**Action**: CREATE (this file)
+**Why**: Documents the failure on run 25261266464 and routes the human at `docs/RAILWAY_TOKEN_ROTATION_742.md`, without claiming the agent performed the rotation.
+
+**Action on GitHub**: post a comment on issue #917 routing the human to the runbook. Per `CLAUDE.md` § Railway Token Rotation, **do not** create `.github/RAILWAY_TOKEN_ROTATION_917.md` — that would be a Category 1 error.
+
+---
+
+### Step 2 (HUMAN-ONLY) — Rotate the token
+
+The agent cannot perform this step. Two options — same as #915, repeated here for convenience:
+
+**Option A — Like-for-like (fastest, but reproduces the treadmill):**
+1. Follow `docs/RAILWAY_TOKEN_ROTATION_742.md`.
+2. `gh secret set RAILWAY_TOKEN --repo alexsiri7/reli` with the new token.
+3. `gh workflow run railway-token-health.yml --repo alexsiri7/reli` to verify it authenticates.
+4. `gh run rerun 25261266464 --repo alexsiri7/reli --failed` to retry the failed pipeline.
+
+**Option B — Durable (recommended, breaks the cycle):**
+1. In the Railway dashboard, navigate to **Project Settings → Tokens** (NOT Account → Tokens).
+2. Mint a Project token scoped to the staging environment; install as `RAILWAY_TOKEN`.
+3. Open the follow-up PR (Step 3 below) so the workflow speaks the Project-token protocol; the new token will fail the *current* validator (`{me{id}}` does not work for Project tokens), so Step 2B and Step 3 must land together.
+
+After 25 expirations in a single day, Option A is no longer a real option — it just buys ~1 hour before the next issue files itself. Option B is the only path that closes the cycle.
+
+---
+
+### Step 3 (DEFERRED — separate PR) — Make the workflow speak the Project-token protocol
+
+**Out of scope for this bead** (Polecat Scope Discipline). Captured here for the eventual implementer; identical to PR #916 § Step 3.
+
+**File**: `.github/workflows/staging-pipeline.yml` lines 32-58 (validator) plus equivalent header changes in every Railway-API call site downstream.
+
+**Current code (validator):**
+```yaml
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Authorization: Bearer $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{me{id}}"}')
+if ! echo "$RESP" | jq -e '.data.me.id' > /dev/null 2>&1; then
+  ...
+fi
+```
+
+**Required change (validator):**
+```yaml
+RESP=$(curl -sf -X POST "https://backboard.railway.app/graphql/v2" \
+  -H "Project-Access-Token: $RAILWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ projectToken { projectId environmentId } }"}')
+if ! echo "$RESP" | jq -e '.data.projectToken.projectId' > /dev/null 2>&1; then
+  ...
+fi
+```
+
+**Why**: A Project token has no associated `me` user, so the current query returns null even when the token is valid. The deploy mutations themselves accept Project tokens but require the `Project-Access-Token:` header.
+
+**File**: `docs/RAILWAY_TOKEN_ROTATION_742.md` lines 24-26 — replace the `https://railway.com/account/tokens` URL with the Project-Settings → Tokens path, plus a one-line note that `RAILWAY_TOKEN` must be a Project token.
+
+---
+
+## Patterns to Follow
+
+Mirror the prior investigation skeleton (PRs #908, #910, #913, #914, #916). The GitHub comment uses the same `## 🔍 Investigation` heading, Assessment table, Problem Statement, Root Cause Analysis, Implementation Plan table, Validation block, Next Step.
+
+---
+
+## Edge Cases & Risks
+
+| Risk/Edge Case | Mitigation |
+|----------------|------------|
+| Like-for-like rotation succeeds but expires within ~1 hour again | Has happened 25 times today. Recommend Option B (Project token) instead. |
+| Project token installed without Step 3 landing | Current validator's `{me{id}}` query rejects a healthy Project token; Step 2B and Step 3 must land in the same change window. |
+| Project token is environment-scoped (staging vs prod) | A single Project token covers one environment. Repo has separate `RAILWAY_STAGING_*` and `RAILWAY_PRODUCTION_*` secrets, so two Project tokens are likely needed. |
+| Agent accidentally creates `.github/RAILWAY_TOKEN_ROTATION_917.md` claiming rotation done | Forbidden by `CLAUDE.md` § Railway Token Rotation (Category 1 error). This bead does NOT do that. |
+| `pipeline-health-cron.sh` files yet another duplicate before rotation | #917 is tagged `archon:in-progress`, blocking re-pickup of *this* issue. The cron will keep filing new issues per failed run until the token is fixed; rotator closes them in a batch. |
+
+---
+
+## Validation
+
+### Automated checks for this bead (docs-only)
+
+```bash
+# This bead writes only an investigation artifact; no code or tests change.
+gh issue view 917 --repo alexsiri7/reli --comments
+git diff --name-only origin/main..HEAD
+# Expect: only files under artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/
+```
+
+### Manual verification (after the human rotates the token)
+
+```bash
+gh workflow run railway-token-health.yml --repo alexsiri7/reli
+gh run watch --repo alexsiri7/reli
+gh run rerun 25261266464 --repo alexsiri7/reli --failed
+```
+
+Expect: validator step prints no `::error::`, the staging deploy job goes green, the gated production job runs.
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE for this bead:**
+- Create `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` (this file).
+- Post a GitHub comment on #917 routing the human to `docs/RAILWAY_TOKEN_ROTATION_742.md` and surfacing the durable-fix recommendation.
+
+**OUT OF SCOPE (do NOT touch in this bead):**
+- The `RAILWAY_TOKEN` secret itself — agents cannot rotate it (`CLAUDE.md` § Railway Token Rotation).
+- `.github/workflows/staging-pipeline.yml` — the durable fix is a separate PR per Polecat Scope Discipline.
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` URL fix — same; deferred to the durable-fix PR.
+- Closing #911, #912, #915, #917 — they should be closed together once the token is rotated and CI is green; that is the rotator's call.
+- Re-running the `web-research.md` deep dive — already committed in PR #916 (`artifacts/runs/e05620507f1e5c5cdf1abea3cc3041b8/web-research.md`); referenced from this artifact rather than duplicated.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-05-02T21:10:00Z
+- **Artifact**: `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md`
+- **Companion artifact (referenced, not duplicated)**: `artifacts/runs/e05620507f1e5c5cdf1abea3cc3041b8/web-research.md` (committed in PR #916 — primary-source evidence for token-class hypothesis)
+- **Run under investigation**: 25261266464 (Staging → Production Pipeline, SHA `7df1bfd`)
+- **Failure mode**: 65th `RAILWAY_TOKEN is invalid or expired: Not Authorized`, 25th today

--- a/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
+++ b/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
@@ -1,0 +1,96 @@
+# Validation Results
+
+**Generated**: 2026-05-02 21:25
+**Workflow ID**: bac9855cea89d9bb2f237189ad8f26a7
+**Branch**: `archon/task-archon-fix-github-issue-1777755618721`
+**Commit under test**: `b7eef9e`
+**Status**: ALL_PASS (docs-only — code-suite checks N/A)
+
+---
+
+## Summary
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Diff is artifacts-only | ✅ | 1 file, +205 / -0; only `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` |
+| No forbidden rotation-claim file | ✅ | No `.github/RAILWAY_TOKEN_ROTATION_917.md` created |
+| No workflow / runbook edits | ✅ | `.github/workflows/**` and `docs/RAILWAY_TOKEN_ROTATION_742.md` untouched |
+| GitHub comment on #917 | ✅ | Investigation comment present (verified at implement-step) |
+| Type check | ⏭️ N/A | Docs-only bead — no `.py`/`.ts`/`.tsx` paths touched |
+| Lint | ⏭️ N/A | Docs-only bead — no source files touched |
+| Format | ⏭️ N/A | Docs-only bead — no source files touched |
+| Tests | ⏭️ N/A | Docs-only bead — no behavior changed |
+| Build | ⏭️ N/A | Docs-only bead — no Docker / frontend / backend artifacts changed |
+
+---
+
+## Diff Verification
+
+**Command**: `git diff --name-only origin/main..HEAD`
+
+```
+artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md
+```
+
+**Command**: `git diff --stat origin/main..HEAD`
+
+```
+ .../investigation.md  | 205 +++++++++++++++++++++
+ 1 file changed, 205 insertions(+)
+```
+
+**Command**: `git log origin/main..HEAD --oneline`
+
+```
+b7eef9e docs: investigation for issue #917 (65th RAILWAY_TOKEN expiration, 25th today)
+```
+
+✅ Single commit. Single file. Pure additive docs change. Matches the bead scope (Polecat Scope Discipline) — Out-Of-Scope code/workflow fix correctly deferred.
+
+---
+
+## Why the Code Suite is N/A
+
+Per `implementation.md`:
+
+> | Type check / tests / lint | N/A | Docs-only bead — no code paths exercised |
+
+This bead's IN-SCOPE work was:
+
+1. Create `artifacts/runs/.../investigation.md` (done — committed in `b7eef9e`).
+2. Confirm a routing comment exists on GitHub issue #917 directing the human to the rotation runbook (done — already present, not duplicated).
+
+Neither task touches Python, TypeScript, SQL, Dockerfile, GitHub Actions YAML, or any other executable surface. Running `pytest`, `npm run build`, or `npm run lint` would only re-run the suite against `main`'s code (which already passes on `main`) and tells us nothing about this bead's correctness.
+
+The bead correctly **does NOT**:
+
+- Edit `.github/workflows/staging-pipeline.yml` (the durable Project-token migration is deferred to a separate PR — out of scope).
+- Edit `docs/RAILWAY_TOKEN_ROTATION_742.md` (URL/runbook correction is deferred — out of scope).
+- Create `.github/RAILWAY_TOKEN_ROTATION_917.md` (forbidden by `CLAUDE.md` § Railway Token Rotation — Category 1 error).
+
+---
+
+## Forbidden-Path Checks
+
+**Command**: `ls .github/RAILWAY_TOKEN_ROTATION_*.md 2>/dev/null` → empty (good — only the canonical `docs/RAILWAY_TOKEN_ROTATION_742.md` exists, and this bead did not touch it).
+
+**Files NOT modified (verified by `git diff --name-only`):**
+
+- `.github/workflows/**` — not present in diff
+- `docs/RAILWAY_TOKEN_ROTATION_742.md` — not present in diff
+- `backend/**` — not present in diff
+- `frontend/**` — not present in diff
+- `data/reli.db` — not present in diff (DB safety policy honored)
+- `backend/chroma_db/**` — not present in diff
+
+---
+
+## Files Modified During Validation
+
+None. No code, lint, or format fixes were required because no executable surface was changed.
+
+---
+
+## Next Step
+
+Continue to `archon-finalize-pr` to open / update the PR for commit `b7eef9e` against `main`, with body `Fixes #917` (per CLAUDE.md § GitHub Issue Linking).

--- a/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
+++ b/artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
@@ -1,9 +1,9 @@
 # Validation Results
 
-**Generated**: 2026-05-02 21:25
+**Generated**: 2026-05-02 21:25 (refreshed 2026-05-02 22:55 to capture full PR diff)
 **Workflow ID**: bac9855cea89d9bb2f237189ad8f26a7
 **Branch**: `archon/task-archon-fix-github-issue-1777755618721`
-**Commit under test**: `b7eef9e`
+**Commit under test**: `17194dd` (PR HEAD; investigation.md added in `b7eef9e`, implementation.md + validation.md added in `17194dd`)
 **Status**: ALL_PASS (docs-only — code-suite checks N/A)
 
 ---
@@ -12,7 +12,7 @@
 
 | Check | Result | Details |
 |-------|--------|---------|
-| Diff is artifacts-only | ✅ | 1 file, +205 / -0; only `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` |
+| Diff is artifacts-only | ✅ | 3 files, +372 / -0; all under `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/` (`investigation.md`, `implementation.md`, `validation.md`) |
 | No forbidden rotation-claim file | ✅ | No `.github/RAILWAY_TOKEN_ROTATION_917.md` created |
 | No workflow / runbook edits | ✅ | `.github/workflows/**` and `docs/RAILWAY_TOKEN_ROTATION_742.md` untouched |
 | GitHub comment on #917 | ✅ | Investigation comment present (verified at implement-step) |
@@ -29,23 +29,28 @@
 **Command**: `git diff --name-only origin/main..HEAD`
 
 ```
+artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/implementation.md
 artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md
+artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
 ```
 
 **Command**: `git diff --stat origin/main..HEAD`
 
 ```
+ .../implementation.md |  71 +++++++++
  .../investigation.md  | 205 +++++++++++++++++++++
- 1 file changed, 205 insertions(+)
+ .../validation.md     |  96 +++++++++++
+ 3 files changed, 372 insertions(+)
 ```
 
 **Command**: `git log origin/main..HEAD --oneline`
 
 ```
+17194dd docs: implementation + validation artifacts for issue #917
 b7eef9e docs: investigation for issue #917 (65th RAILWAY_TOKEN expiration, 25th today)
 ```
 
-✅ Single commit. Single file. Pure additive docs change. Matches the bead scope (Polecat Scope Discipline) — Out-Of-Scope code/workflow fix correctly deferred.
+✅ Two commits, three artifacts, pure additive docs change. All paths under the bead's run dir. Matches the bead scope (Polecat Scope Discipline) — Out-Of-Scope code/workflow fix correctly deferred.
 
 ---
 
@@ -58,7 +63,8 @@ Per `implementation.md`:
 This bead's IN-SCOPE work was:
 
 1. Create `artifacts/runs/.../investigation.md` (done — committed in `b7eef9e`).
-2. Confirm a routing comment exists on GitHub issue #917 directing the human to the rotation runbook (done — already present, not duplicated).
+2. Create `artifacts/runs/.../implementation.md` and `artifacts/runs/.../validation.md` (done — committed in `17194dd`).
+3. Confirm a routing comment exists on GitHub issue #917 directing the human to the rotation runbook (done — already present, not duplicated).
 
 Neither task touches Python, TypeScript, SQL, Dockerfile, GitHub Actions YAML, or any other executable surface. Running `pytest`, `npm run build`, or `npm run lint` would only re-run the suite against `main`'s code (which already passes on `main`) and tells us nothing about this bead's correctness.
 
@@ -93,4 +99,4 @@ None. No code, lint, or format fixes were required because no executable surface
 
 ## Next Step
 
-Continue to `archon-finalize-pr` to open / update the PR for commit `b7eef9e` against `main`, with body `Fixes #917` (per CLAUDE.md § GitHub Issue Linking).
+Continue to `archon-finalize-pr` to open / update the PR for HEAD `17194dd` against `main`, with body `Fixes #917` (per CLAUDE.md § GitHub Issue Linking).


### PR DESCRIPTION
## Summary

Docs-only investigation artifact for **issue #917** — the 65th `RAILWAY_TOKEN is invalid or expired: Not Authorized` failure on the "Deploy to staging" job, and the **25th today**. Failing run: [25261266464](https://github.com/alexsiri7/reli/actions/runs/25261266464), SHA `7df1bfd`.

This PR adds the investigation/implementation/validation artifacts only. It does **not** rotate the token (agents cannot — `CLAUDE.md` § Railway Token Rotation), and it does **not** modify the workflow or runbook (deferred to a separate PR per Polecat Scope Discipline).

## Changes

| File | Action | Lines |
|------|--------|-------|
| `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md` | CREATE | +205 |
| `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/implementation.md` | CREATE | +72 |
| `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md` | CREATE | +96 |

No code, workflow, runbook, frontend, backend, or DB-schema files touched.

## Root Cause

Two-layer diagnosis (unchanged from #915 / PR #916):

- **Proximate**: the token in `secrets.RAILWAY_TOKEN` is rejected by Railway's auth backend (`Not Authorized`). Like-for-like rotation per `docs/RAILWAY_TOKEN_ROTATION_742.md` will turn this run green for ~1 hour.
- **Underlying**: the workflow puts an Account/Personal token into the `RAILWAY_TOKEN` slot and calls Railway with `Authorization: Bearer` + `{me{id}}`. Per Railway's docs, `RAILWAY_TOKEN` is reserved for a **Project token**, which uses `Project-Access-Token:` and a different validator query. Until that mismatch is fixed, every rotation will leak credentials again within hours.

Evidence: `.github/workflows/staging-pipeline.yml:50` (`-H "Authorization: Bearer $RAILWAY_TOKEN"`) and `:52` (`-d '{"query":"{me{id}}"}'`). Validator block unchanged across all 65 incidents.

## Validation Evidence

| Check | Result |
|-------|--------|
| Diff is artifacts-only | ✅ — only files under `artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/` |
| No `.github/RAILWAY_TOKEN_ROTATION_917.md` created | ✅ (forbidden by `CLAUDE.md` — Category 1 error) |
| No workflow / runbook edits | ✅ — `.github/workflows/**` and `docs/RAILWAY_TOKEN_ROTATION_742.md` untouched |
| GitHub comment routing human to runbook on #917 | ✅ — present from prior step, not duplicated |
| Type check / lint / format / tests / build | ⏭️ N/A — docs-only bead |
| DB-safety policy | ✅ — `data/reli.db` and `backend/chroma_db/` untouched |

```
$ git diff --name-only origin/main..HEAD
artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/implementation.md
artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/investigation.md
artifacts/runs/bac9855cea89d9bb2f237189ad8f26a7/validation.md
```

## Human Action Required (out of scope for this PR)

Agent cannot perform either step:

1. **Rotate `RAILWAY_TOKEN`** — follow `docs/RAILWAY_TOKEN_ROTATION_742.md`. After 25 expirations today, like-for-like rotation buys ~1 hour. Recommended: mint a **Project token** at Railway dashboard → *Project Settings → Tokens* and install as `RAILWAY_TOKEN`.
2. **Land the durable workflow fix** in a follow-up PR: switch `.github/workflows/staging-pipeline.yml` to use the `Project-Access-Token:` header and the `{ projectToken { projectId environmentId } }` validator query, and update `docs/RAILWAY_TOKEN_ROTATION_742.md` to point at *Project Settings → Tokens*.

After rotation: `gh workflow run railway-token-health.yml --repo alexsiri7/reli` then `gh run rerun 25261266464 --repo alexsiri7/reli --failed`.

## Test plan

- [x] `git diff --name-only origin/main..HEAD` shows only artifact files
- [x] No `.github/RAILWAY_TOKEN_ROTATION_*.md` claim-of-rotation file present
- [x] `.github/workflows/staging-pipeline.yml` byte-identical to `main`
- [x] `docs/RAILWAY_TOKEN_ROTATION_742.md` byte-identical to `main`
- [ ] *(human, after token rotation)* `railway-token-health.yml` workflow goes green
- [ ] *(human, after token rotation)* `gh run rerun 25261266464 --failed` turns the staging deploy job green and unblocks the gated production job

Fixes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)