### PR TITLE
docs: add Lachesis-format requirement files

### DIFF
--- a/requirements/001-multi-stage-agent-pipeline.md
+++ b/requirements/001-multi-stage-agent-pipeline.md
@@ -1,0 +1,13 @@
+---
+id: "001"
+title: "Multi-stage agent pipeline"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+A single-shot LLM call lacks the context-awareness and reasoning depth needed for a personal assistant. A pipeline where each stage has a focused role produces better results.
+
+## What
+A three-stage pipeline: Context Agent (retrieves relevant Things from the knowledge graph), Reasoning Agent (decides what to create/update/link and extracts preferences), and Response Agent (generates a natural reply shaped by learned preferences).

--- a/requirements/002-knowledge-graph-things.md
+++ b/requirements/002-knowledge-graph-things.md
@@ -1,0 +1,13 @@
+---
+id: "002"
+title: "Knowledge graph (Things)"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+User data needs structured representation beyond plain text to support semantic queries, relationship traversal, and preference tracking over time.
+
+## What
+A typed knowledge graph where all stored information (tasks, notes, people, projects, places) becomes a "Thing" with relationships to other Things. Backed by SQLite + ChromaDB vector embeddings. CRUD API at `/api/things`.

--- a/requirements/003-preference-learning.md
+++ b/requirements/003-preference-learning.md
@@ -1,0 +1,13 @@
+---
+id: "003"
+title: "Preference learning"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+A personal assistant should learn how you operate — patterns, preferences, habits — and surface or apply them without being explicitly told each time.
+
+## What
+First-class preference Things with confidence levels that strengthen or decay based on user behavior. Extracted by the Reasoning Agent from user messages and interactions.

--- a/requirements/004-google-oauth-authentication.md
+++ b/requirements/004-google-oauth-authentication.md
@@ -1,0 +1,13 @@
+---
+id: "004"
+title: "Google OAuth authentication"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Reli stores personal data and needs to restrict access to the authenticated user.
+
+## What
+Google OAuth flow (`/api/auth`) issuing JWTs. The app is deployed behind authentication; only the signed-in user's data is accessible.

--- a/requirements/005-google-calendar-integration.md
+++ b/requirements/005-google-calendar-integration.md
@@ -1,0 +1,13 @@
+---
+id: "005"
+title: "Google Calendar integration"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Proactive assistance requires awareness of the user's schedule. Calendar data enriches context for reminders and suggestions.
+
+## What
+Read-only Google Calendar integration (`/api/calendar`). Calendar events are accessible to the agent pipeline as context. Requires `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.

--- a/requirements/006-gmail-integration.md
+++ b/requirements/006-gmail-integration.md
@@ -1,0 +1,13 @@
+---
+id: "006"
+title: "Gmail integration"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Email is a major channel of life context. An assistant that can see relevant emails can surface actions and information proactively.
+
+## What
+Gmail integration (`/api/gmail`) allowing the agent to read emails as part of context retrieval. Scoped read access, not write.

--- a/requirements/007-google-search-integration.md
+++ b/requirements/007-google-search-integration.md
@@ -1,0 +1,13 @@
+---
+id: "007"
+title: "Google Search integration"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+The assistant needs to answer questions that require current web information, not just stored personal data.
+
+## What
+Google Search API integration (via `GOOGLE_SEARCH_API_KEY` + `GOOGLE_SEARCH_CX`) exposed to the agent pipeline for web lookups.

--- a/requirements/008-nightly-sweep.md
+++ b/requirements/008-nightly-sweep.md
@@ -1,0 +1,13 @@
+---
+id: "008"
+title: "Nightly sweep"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Proactive assistance requires a background analysis pass — not just responding to messages, but identifying gaps and patterns the user hasn't asked about.
+
+## What
+A nightly sweep job (`/api/sweep`) that performs gap detection, pattern aggregation, and generates a briefing. Runs on a schedule.

--- a/requirements/009-multi-model-configuration.md
+++ b/requirements/009-multi-model-configuration.md
@@ -1,0 +1,13 @@
+---
+id: "009"
+title: "Multi-model configuration"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Different pipeline stages have different latency/cost tradeoffs. Allowing per-stage model selection keeps costs low while preserving quality where it matters.
+
+## What
+`config.yaml` specifying independent models for context, reasoning, and response stages. All routed through Requesty (OpenAI-compatible gateway). Overridable via environment variables.

--- a/requirements/010-docker-production-deployment.md
+++ b/requirements/010-docker-production-deployment.md
@@ -1,0 +1,13 @@
+---
+id: "010"
+title: "Docker production deployment"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Reproducible, isolated deployment to Railway (staging + prod) with persistent data volumes.
+
+## What
+Multi-stage Dockerfile (Node build + Python runtime), Docker Compose for local prod simulation, Cloudflare Tunnel for public access. Data persists in `./data/` volume. CI via GitHub Actions.

--- a/requirements/011-vector-search-chromadb.md
+++ b/requirements/011-vector-search-chromadb.md
@@ -1,0 +1,13 @@
+---
+id: "011"
+title: "Vector search (ChromaDB)"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+Semantic retrieval of Things requires embedding-based search, not just SQL keyword matching.
+
+## What
+ChromaDB integration storing `text-embedding-3-small` embeddings for all Things. The Context Agent uses cosine similarity search to find relevant Things for each message.

--- a/requirements/012-settings-api.md
+++ b/requirements/012-settings-api.md
@@ -1,0 +1,13 @@
+---
+id: "012"
+title: "Settings API"
+status: "done"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+User-configurable settings (model preferences, feature flags) need a persistent store accessible to both frontend and backend.
+
+## What
+`/api/settings` endpoint for reading and writing user settings stored in SQLite.

--- a/requirements/013-concerns-modular-life-domains.md
+++ b/requirements/013-concerns-modular-life-domains.md
@@ -1,0 +1,13 @@
+---
+id: "013"
+title: "Concerns (modular life domains)"
+status: "idea"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+To scale proactive assistance, Reli needs a way to monitor specific life domains (health, finance, travel) semi-autonomously rather than treating all Things equally.
+
+## What
+A Concerns system: modular domain monitors that watch relevant Things, detect open loops, and queue briefings. Described in `docs/vision.md`.

--- a/requirements/014-mcp-server.md
+++ b/requirements/014-mcp-server.md
@@ -1,0 +1,13 @@
+---
+id: "014"
+title: "MCP server (Reli as intelligence service)"
+status: "idea"
+github_issue: 955
+updated: 2026-05-12
+---
+
+## Why
+AI tools like Claude Code should be able to query the user's knowledge graph directly, not just through the Reli chat UI.
+
+## What
+An MCP server exposing Reli's knowledge graph as tools — so any MCP-capable AI client can read/write Things, query preferences, and access context.


### PR DESCRIPTION
## Summary

Adds 14 Lachesis-format requirement files (001–014) to document Reli's features and planned work.

## Changes

Created `requirements/` directory with:
- **001–012**: Features implemented and deployed (status: `done`)
  - Multi-stage agent pipeline
  - Knowledge graph (Things)
  - Preference learning
  - Google OAuth, Calendar, Gmail, Search integrations
  - Nightly sweep
  - Multi-model configuration
  - Docker production deployment
  - Vector search (ChromaDB)
  - Settings API

- **013–014**: Planned/future work (status: `idea`)
  - Concerns (modular life domains)
  - MCP server

All files follow the strict Lachesis format with frontmatter (id, title, status, github_issue, updated) and Why/What sections.

## Validation

- ✅ 14 files created
- ✅ Status values correct (12 done, 2 idea)
- ✅ IDs sequential (001–014)
- ✅ Frontmatter valid YAML

Fixes #955