### PR TITLE
fix: scope thing_relationships queries to user's thing IDs

### DIFF
--- a/backend/connection_sweep.py
+++ b/backend/connection_sweep.py
@@ -17,7 +17,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from sqlmodel import Session, select
+from sqlmodel import Session, or_, select
 
 import backend.db_engine as _engine_mod
 
@@ -87,13 +87,29 @@ def find_connection_candidates(
         if user_id:
             thing_stmt = thing_stmt.where(user_filter_clause(ThingRecord.user_id, user_id))
         things = session.exec(thing_stmt).all()
+        thing_ids = [t.id for t in things]
 
-        # Build set of existing relationships (both directions)
-        rel_rows = session.exec(select(ThingRelationshipRecord)).all()
+        # Build set of existing relationships (both directions) and parent pairs in one query
+        rel_rows = (
+            session.exec(
+                select(ThingRelationshipRecord).where(
+                    or_(
+                        ThingRelationshipRecord.from_thing_id.in_(thing_ids),
+                        ThingRelationshipRecord.to_thing_id.in_(thing_ids),
+                    )
+                )
+            ).all()
+            if thing_ids
+            else []
+        )
         existing_rels: set[tuple[str, str]] = set()
+        parent_pairs: set[tuple[str, str]] = set()
         for row in rel_rows:
             existing_rels.add((row.from_thing_id, row.to_thing_id))
             existing_rels.add((row.to_thing_id, row.from_thing_id))
+            if row.relationship_type == "parent-of":
+                parent_pairs.add((row.from_thing_id, row.to_thing_id))
+                parent_pairs.add((row.to_thing_id, row.from_thing_id))
 
         # Build set of existing pending/deferred suggestions
         sugg_rows = session.exec(
@@ -105,15 +121,6 @@ def find_connection_candidates(
         for row in sugg_rows:
             existing_suggestions.add((row.from_thing_id, row.to_thing_id))
             existing_suggestions.add((row.to_thing_id, row.from_thing_id))
-
-        # Also exclude parent-child relationships (via parent-of relationships)
-        parent_pairs: set[tuple[str, str]] = set()
-        parent_rels = session.exec(
-            select(ThingRelationshipRecord).where(ThingRelationshipRecord.relationship_type == "parent-of")
-        ).all()
-        for rel in parent_rels:
-            parent_pairs.add((rel.from_thing_id, rel.to_thing_id))
-            parent_pairs.add((rel.to_thing_id, rel.from_thing_id))
 
     thing_map = {t.id: {"id": t.id, "title": t.title, "type_hint": t.type_hint} for t in things}
     seen_pairs: set[tuple[str, str]] = set()

--- a/backend/morning_briefing.py
+++ b/backend/morning_briefing.py
@@ -152,9 +152,21 @@ def generate_morning_briefing(
             .order_by(ThingRecord.importance.asc(), ThingRecord.updated_at.desc())
         )  # type: ignore[union-attr]
         thing_rows = session.exec(thing_stmt).all()
+        thing_ids = [r.id for r in thing_rows]
 
         # Fetch relationships for blocking analysis
-        rel_rows = session.exec(select(ThingRelationshipRecord)).all()
+        rel_rows = (
+            session.exec(
+                select(ThingRelationshipRecord).where(
+                    or_(
+                        ThingRelationshipRecord.from_thing_id.in_(thing_ids),
+                        ThingRelationshipRecord.to_thing_id.in_(thing_ids),
+                    )
+                )
+            ).all()
+            if thing_ids
+            else []
+        )
 
         # Fetch active sweep findings (with thing title via join)
         now_dt = datetime.now(timezone.utc)

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -104,12 +104,22 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
             )
         ).all()
 
+        active_ids = [t.id for t in all_active]
+
         # Relationships for blocker graph
-        rel_rows = session.exec(
-            select(ThingRelationshipRecord).where(
-                ThingRelationshipRecord.relationship_type.in_(["blocks", "depends-on"])  # type: ignore[union-attr]
-            )
-        ).all()
+        rel_rows = (
+            session.exec(
+                select(ThingRelationshipRecord).where(
+                    ThingRelationshipRecord.relationship_type.in_(["blocks", "depends-on"]),  # type: ignore[union-attr]
+                    or_(
+                        ThingRelationshipRecord.from_thing_id.in_(active_ids),
+                        ThingRelationshipRecord.to_thing_id.in_(active_ids),
+                    ),
+                )
+            ).all()
+            if active_ids
+            else []
+        )
 
         # Active (not dismissed, not expired, not snoozed) sweep findings with linked Things
         finding_stmt = (

--- a/backend/routers/focus.py
+++ b/backend/routers/focus.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query
-from sqlmodel import Session, select
+from sqlmodel import Session, or_, select
 
 import backend.db_engine as _engine_mod
 
@@ -90,8 +90,20 @@ def _compute_recommendations(
             .order_by(ThingRecord.importance.asc(), ThingRecord.updated_at.desc())
         )  # type: ignore[union-attr, attr-defined]
         thing_records = session.exec(thing_stmt).all()
+        thing_ids = [r.id for r in thing_records]
 
-        rel_records = session.exec(select(ThingRelationshipRecord)).all()
+        rel_records = (
+            session.exec(
+                select(ThingRelationshipRecord).where(
+                    or_(
+                        ThingRelationshipRecord.from_thing_id.in_(thing_ids),
+                        ThingRelationshipRecord.to_thing_id.in_(thing_ids),
+                    )
+                )
+            ).all()
+            if thing_ids
+            else []
+        )
 
     things = [_record_to_thing(r) for r in thing_records]
     thing_map: dict[str, Thing] = {t.id: t for t in things}


### PR DESCRIPTION
## Summary

Fixes consecutive DB queries issue (#952) where multiple backend endpoints query the entire `thing_relationships` table without filtering by user or thing ID. This causes Sentry to flag "Consecutive DB Queries" and degrades response time as data grows.

## Changes

Scoped `ThingRelationshipRecord` queries in 4 files to only fetch relationships involving the user's active things:

- `backend/routers/focus.py` (line 94) — scope to active_ids
- `backend/morning_briefing.py` (line 157) — scope to thing_ids  
- `backend/connection_sweep.py` (lines 92, 112) — scope + merge two separate queries into one
- `backend/routers/briefing.py` (lines 109-111) — add thing_id scope alongside type filter

All changes add `WHERE or_(from_thing_id.in_(thing_ids), to_thing_id.in_(thing_ids))` clause, following the existing pattern in `backend/routers/things.py:351-362`.

## Validation

- ✅ All 4 files pass syntax checks
- ✅ Backend tests: 974 passed
- ✅ Frontend tests: 373 passed  
- ✅ Linting (ruff): 0 errors in changed files
- ✅ Build: successful
- ✅ Type check: no new errors

## Issue Link

Fixes #952

🤖 Generated with Claude Code