### PR TITLE
fix: update npm install → npm ci in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The app runs in Docker. After merging code changes, the container must be rebuil
 ```bash
 cd /home/asiri/gt/reli/mayor/rig
 git pull
-npm --prefix frontend install --legacy-peer-deps
+npm --prefix frontend ci --legacy-peer-deps
 npm --prefix frontend run build
 docker compose build && docker compose up -d
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd reli
 pip install -r backend/requirements.txt
 
 # Frontend
-cd frontend && npm install --legacy-peer-deps && cd ..
+cd frontend && npm ci --legacy-peer-deps && cd ..
 ```
 
 ### 2. Configure environment


### PR DESCRIPTION
## Summary

Updates two documentation files to instruct developers to use `npm ci` instead of `npm install`. This ensures deterministic local builds that match CI/Docker environments.

Issue #947 reported non-deterministic npm builds. The critical fix (committing `package-lock.json` and updating CI/Docker to use `npm ci`) was completed in prior commits. This PR completes the work by updating the remaining documentation references.

## Changes

- `README.md:75` — Replace `npm install --legacy-peer-deps` with `npm ci --legacy-peer-deps`
- `CLAUDE.md:20` — Replace `npm install --legacy-peer-deps` with `npm ci --legacy-peer-deps`

## Validation

✅ No `npm install` references remain in documentation
✅ Both files now use `npm ci` consistently with CI/Docker patterns
✅ All documentation references updated; no source code changes

Fixes #947
