### PR TITLE
docs: use npm ci in CLAUDE.md deploy instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The app runs in Docker. After merging code changes, the container must be rebuil
 ```bash
 cd /home/asiri/gt/reli/mayor/rig
 git pull
-npm --prefix frontend install --legacy-peer-deps
+npm --prefix frontend ci --legacy-peer-deps
 npm --prefix frontend run build
 docker compose build && docker compose up -d
 ```


### PR DESCRIPTION
## Summary

Update CLAUDE.md deployment instructions to use `npm ci` instead of `npm install` for deterministic, repeatable builds.

## Changes

- **CLAUDE.md**: Changed deployment command from `npm --prefix frontend install --legacy-peer-deps` to `npm --prefix frontend ci --legacy-peer-deps`

## Rationale

Issue #947 flagged that frontend dependencies are caret-pinned (`^`) with no committed lock file, allowing non-deterministic builds. Investigation revealed that all automated paths (Docker, CI, staging pipeline, gates.sh) already use `npm ci` correctly and commit the lock file. The only remaining gap was the manual deployment snippet in CLAUDE.md, which still documented `npm install`. This one-line update brings the documentation into alignment with actual deployment practices.

## Validation

✅ Static analysis: `grep "npm --prefix frontend" CLAUDE.md` confirms only `ci` variant present, no `install`
✅ Full scan: `grep -n "npm install" CLAUDE.md` returns zero matches
✅ No other changes to CLAUDE.md

## Fixes

Fixes #947