### PR TITLE
fix: auth-gate /api/health endpoint (SEC-036)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -356,7 +356,7 @@ def health() -> dict[str, str]:
 
 
 @app.get("/api/health", tags=["health"])
-def health_detailed() -> dict:
+def health_detailed(user_id: str = Depends(require_user)) -> dict:
     """Detailed health check with DB, pgvector, and performance metrics."""
     from sqlalchemy import text
 


### PR DESCRIPTION
## Summary

- Adds `Depends(require_user)` to the `health_detailed` endpoint so unauthenticated requests return 401 instead of internal metrics
- `/healthz` liveness probe is intentionally left public
- `require_user` was already imported at `main.py:34` — no new imports needed

## Test plan

- [ ] `curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/health` returns `401`
- [ ] `curl -s -b "reli_session=<token>" http://localhost:8000/api/health` returns full metrics JSON
- [ ] `curl -s http://localhost:8000/healthz` returns `{"status": "ok", "service": "reli"}`

Fixes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)