### PR TITLE
fix: URL-encode OAuth state parameter in MCP redirect

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -4,6 +4,7 @@ import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
@@ -263,7 +264,7 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
         sep = "&" if "?" in client_redirect else "?"
         location = f"{client_redirect}{sep}code={auth_code}"
         if client_state:
-            location += f"&state={client_state}"
+            location += f"&state={quote(client_state, safe='')}"
         logger.info("MCP OAuth: redirecting to client with auth code, redirect_uri=%s", client_redirect)
         return RedirectResponse(url=location, status_code=302)
 


### PR DESCRIPTION
## Summary

- URL-encode `client_state` before appending to MCP OAuth redirect URL
- Add `from urllib.parse import quote` import to `backend/routers/auth.py`
- Prevents special characters (`&`, `=`, `#`, spaces) from injecting extra query parameters

## Test plan

- [ ] Initiate MCP OAuth flow with state containing `&injected=true` — confirm state is percent-encoded in redirect URL
- [ ] Confirm normal alphanumeric state values still work correctly
- [ ] Run `python -m pytest tests/ -k "auth" -x`

Fixes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)