### PR TITLE
fix: scope offline sync replay to current user session

### DIFF
--- a/frontend/src/__tests__/mutation-fetch.test.ts
+++ b/frontend/src/__tests__/mutation-fetch.test.ts
@@ -6,6 +6,12 @@ vi.mock('../offline/pending-ops', () => ({
   queueOperation: (...args: unknown[]) => mockQueueOperation(...args),
 }))
 
+vi.mock('../store', () => ({
+  useStore: {
+    getState: () => ({ currentUser: { id: 'test-user-id' } }),
+  },
+}))
+
 import { mutationFetch } from '../offline/mutation-fetch'
 
 beforeEach(() => {
@@ -35,7 +41,7 @@ describe('mutationFetch', () => {
 
     const res = await mutationFetch('/api/things', { method: 'POST', body: '{"title":"test"}' })
 
-    expect(mockQueueOperation).toHaveBeenCalledWith('/api/things', 'POST', { title: 'test' })
+    expect(mockQueueOperation).toHaveBeenCalledWith('/api/things', 'POST', { title: 'test' }, 'test-user-id')
     expect(res.status).toBe(202)
     const body = await res.json()
     expect(body).toEqual({ queued: true })
@@ -47,7 +53,7 @@ describe('mutationFetch', () => {
 
     await mutationFetch('/api/things', { method: 'POST', body: 'not json' })
 
-    expect(mockQueueOperation).toHaveBeenCalledWith('/api/things', 'POST', 'not json')
+    expect(mockQueueOperation).toHaveBeenCalledWith('/api/things', 'POST', 'not json', 'test-user-id')
   })
 
   it('offline: synthetic response has correct headers and status', async () => {

--- a/frontend/src/__tests__/sync-engine.test.ts
+++ b/frontend/src/__tests__/sync-engine.test.ts
@@ -13,6 +13,12 @@ vi.mock('../offline/idb', () => ({
   getDB: (...args: unknown[]) => mockGetDB(...args),
 }))
 
+vi.mock('../store', () => ({
+  useStore: {
+    getState: () => ({ currentUser: { id: 'user-1' } }),
+  },
+}))
+
 import { syncPendingOps, onSyncEvent } from '../offline/sync-engine'
 import type { PendingOp } from '../offline/idb'
 
@@ -25,6 +31,7 @@ function makeOp(overrides: Partial<PendingOp> = {}): PendingOp {
     timestamp: '2026-01-01T00:00:00Z',
     status: 'pending',
     retries: 0,
+    user_id: 'user-1',
     ...overrides,
   }
 }
@@ -129,6 +136,21 @@ describe('syncPendingOps', () => {
     expect(failEvents).toHaveLength(1)
     expect(failEvents[0]!.error).toContain('Network offline')
     expect(mockRemovePendingOp).not.toHaveBeenCalled()
+  })
+
+  it('skips ops belonging to a different user', async () => {
+    const foreignOp = makeOp({ id: 2, user_id: 'user-2' })
+    mockGetPendingOps.mockResolvedValue([foreignOp])
+
+    const events: string[] = []
+    const unsub = onSyncEvent(e => events.push(e.type))
+
+    await syncPendingOps()
+    unsub()
+
+    expect(mockRemovePendingOp).not.toHaveBeenCalled()
+    // No sync:start since filtered ops list is empty
+    expect(events).not.toContain('sync:start')
   })
 
   it('empty queue returns immediately without emitting sync:start', async () => {

--- a/frontend/src/offline/idb.ts
+++ b/frontend/src/offline/idb.ts
@@ -28,6 +28,7 @@ export interface PendingOp {
   timestamp: string
   status: PendingOpStatus
   retries: number
+  user_id: string
 }
 
 // --- IndexedDB schema ---
@@ -68,14 +69,14 @@ export interface ReliDB extends DBSchema {
 }
 
 const DB_NAME = 'reli'
-const DB_VERSION = 2
+const DB_VERSION = 3
 
 let dbPromise: Promise<IDBPDatabase<ReliDB>> | null = null
 
 export function getDB(): Promise<IDBPDatabase<ReliDB>> {
   if (!dbPromise) {
     dbPromise = openDB<ReliDB>(DB_NAME, DB_VERSION, {
-      upgrade(db, oldVersion) {
+      async upgrade(db, oldVersion, _newVersion, tx) {
         if (oldVersion < 1) {
           db.createObjectStore('things', { keyPath: 'id' })
           db.createObjectStore('thingTypes', { keyPath: 'id' })
@@ -98,6 +99,17 @@ export function getDB(): Promise<IDBPDatabase<ReliDB>> {
         }
         if (oldVersion < 2) {
           db.createObjectStore('kvCache', { keyPath: 'key' })
+        }
+        if (oldVersion < 3) {
+          // Existing queued ops have no user_id — mark them as orphaned (empty string).
+          // syncPendingOps will skip ops whose user_id doesn't match the current user.
+          const store = tx.objectStore('pendingOps')
+          const allOps = await store.getAll()
+          for (const op of allOps) {
+            if (!op.user_id) {
+              await store.put({ ...op, user_id: '' })
+            }
+          }
         }
       },
     })

--- a/frontend/src/offline/mutation-fetch.ts
+++ b/frontend/src/offline/mutation-fetch.ts
@@ -1,5 +1,6 @@
 import { queueOperation } from './pending-ops'
 import type { PendingOp } from './idb'
+import { useStore } from '../store'
 
 /**
  * A fetch wrapper for mutations that queues operations when offline.
@@ -27,7 +28,8 @@ export async function mutationFetch(
     }
   }
 
-  await queueOperation(url, init.method, body)
+  const userId = useStore.getState().currentUser?.id ?? ''
+  await queueOperation(url, init.method, body, userId)
 
   // Return a synthetic "queued" response
   return new Response(JSON.stringify({ queued: true }), {

--- a/frontend/src/offline/pending-ops.ts
+++ b/frontend/src/offline/pending-ops.ts
@@ -14,6 +14,7 @@ export async function queueOperation(
   url: string,
   method: PendingOp['method'],
   body?: unknown,
+  user_id: string = '',
 ): Promise<number> {
   return enqueuePendingOp({
     url,
@@ -22,6 +23,7 @@ export async function queueOperation(
     timestamp: new Date().toISOString(),
     status: 'pending',
     retries: 0,
+    user_id,
   })
 }
 

--- a/frontend/src/offline/sync-engine.ts
+++ b/frontend/src/offline/sync-engine.ts
@@ -1,5 +1,6 @@
 import { getPendingOps, removePendingOp, type PendingOp } from './pending-ops'
 import { getDB } from './idb'
+import { useStore } from '../store'
 
 const MAX_RETRIES = 3
 
@@ -63,7 +64,11 @@ export async function syncPendingOps(): Promise<void> {
   if (syncing) return
   syncing = true
 
-  const ops = await getPendingOps()
+  const currentUserId = useStore.getState().currentUser?.id ?? ''
+  const allOps = await getPendingOps()
+  // Only replay ops that belong to the currently authenticated user.
+  // Ops with no user_id (queued before this fix) are skipped as a safety measure.
+  const ops = allOps.filter(op => op.user_id === currentUserId && currentUserId !== '')
   if (ops.length === 0) {
     syncing = false
     return


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where offline-queued mutations are replayed without validating the current user's session. On a shared browser where multiple users log in, mutations queued by User A could be replayed under User B's auth context if B logs in before the sync triggers.

## Changes

This fix adds user-scoping to the pending operation queue:

1. **Add `user_id` to `PendingOp` interface** (`frontend/src/offline/idb.ts`)
   - New field tracks which user queued each operation
   - IDB schema bumped from v2 → v3 with migration for backward compatibility

2. **Capture current user at enqueue time** (`frontend/src/offline/pending-ops.ts`, `frontend/src/offline/mutation-fetch.ts`)
   - `queueOperation` now accepts `user_id` parameter
   - `mutationFetch` passes `useStore.getState().currentUser?.id` when queuing

3. **Filter by current user on sync** (`frontend/src/offline/sync-engine.ts`)
   - `syncPendingOps` filters queued operations to only those belonging to the currently authenticated user
   - Orphaned ops (from before the fix) are safely skipped

4. **Test coverage** 
   - Updated `sync-engine.test.ts` with cross-user filtering test
   - Updated `mutation-fetch.test.ts` to verify `user_id` is passed

## Validation

- **Type check**: ✅ Pass (0 errors)
- **Tests**: ✅ Pass (374 passed, 0 failed)
- **Lint**: ✅ Pass (0 errors, 2 pre-existing warnings)
- **Build**: ✅ Pass

## Fixes #942