### PR TITLE
security: validate X-Forwarded-For against trusted proxy CIDRs

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     RATE_LIMIT_ENABLED: str = "true"
     RATE_LIMIT_LLM_RPM: int = 30
     RATE_LIMIT_API_RPM: int = 60
+    # Comma-separated CIDRs of trusted reverse proxies (e.g. "10.0.0.0/8,172.16.0.0/12").
+    # X-Forwarded-For is only trusted when the direct connection IP falls within one of these.
+    # Empty string (default) means never trust X-Forwarded-For.
+    RATE_LIMIT_TRUSTED_PROXY_CIDRS: str = ""
 
     # --- GitHub Feedback ---
     GITHUB_FEEDBACK_TOKEN: str = ""

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -18,6 +18,7 @@ Configurable via environment variables:
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import time
 from collections import defaultdict
@@ -69,11 +70,26 @@ class _Bucket:
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Per-user (JWT) / per-IP token-bucket rate limiter."""
 
-    def __init__(self, app, *, llm_rpm: int = 30, api_rpm: int = 60, enabled: bool = True) -> None:  # type: ignore[no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
+        self,
+        app,
+        *,
+        llm_rpm: int = 30,
+        api_rpm: int = 60,
+        enabled: bool = True,
+        trusted_proxy_cidrs: str = "",
+    ) -> None:
         super().__init__(app)
         self.enabled = enabled
         self.llm_rpm = llm_rpm
         self.api_rpm = api_rpm
+        # Parse CIDR strings into network objects once at startup
+        self._trusted_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        for cidr in (c.strip() for c in trusted_proxy_cidrs.split(",") if c.strip()):
+            try:
+                self._trusted_networks.append(ipaddress.ip_network(cidr, strict=False))
+            except ValueError:
+                log.warning("Invalid TRUSTED_PROXY_CIDR entry ignored: %r", cidr)
         # Separate buckets for LLM and general API, keyed by user id or IP
         self._llm_buckets: dict[str, _Bucket] = defaultdict(
             lambda: _Bucket(tokens=float(llm_rpm), max_tokens=float(llm_rpm), refill_rate=llm_rpm / 60.0)
@@ -83,10 +99,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         )
 
     def _get_client_ip(self, request: Request) -> str:
+        direct_ip = request.client.host if request.client else None
         forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        return request.client.host if request.client else "unknown"
+        if forwarded and direct_ip and self._trusted_networks:
+            try:
+                addr = ipaddress.ip_address(direct_ip)
+                if any(addr in net for net in self._trusted_networks):
+                    return forwarded.split(",")[0].strip()
+            except ValueError:
+                log.debug("Could not parse direct IP %r; ignoring X-Forwarded-For", direct_ip)
+        return direct_ip or "unknown"
 
     def _get_rate_limit_key(self, request: Request) -> str:
         """Derive the rate-limit key from the JWT session cookie.
@@ -159,4 +181,5 @@ def get_rate_limit_config() -> dict:
         "enabled": s.rate_limit_enabled_bool,
         "llm_rpm": max(1, s.RATE_LIMIT_LLM_RPM),
         "api_rpm": max(1, s.RATE_LIMIT_API_RPM),
+        "trusted_proxy_cidrs": s.RATE_LIMIT_TRUSTED_PROXY_CIDRS,
     }

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -227,6 +227,61 @@ class TestRateLimitMiddleware:
             res = client.post("/api/chat")
             assert res.status_code == 200
 
+    def test_x_forwarded_for_ignored_without_trusted_cidr(self):
+        """X-Forwarded-For is ignored when no trusted CIDRs are configured."""
+        app = _make_app(api_rpm=1)  # no trusted_proxy_cidrs
+        client = TestClient(app)
+        # Exhaust bucket for the real IP
+        res = client.get("/api/things")
+        assert res.status_code == 200
+        # Spoofed header should NOT get a fresh bucket
+        res = client.get("/api/things", headers={"X-Forwarded-For": "1.2.3.4"})
+        assert res.status_code == 429
+
+    def test_x_forwarded_for_trusted_from_known_proxy(self):
+        """X-Forwarded-For is used when direct IP is within a trusted CIDR."""
+        from starlette.types import ASGIApp, Receive, Scope, Send
+
+        class _FakeClientIP:
+            """ASGI middleware that overrides client IP for testing."""
+
+            def __init__(self, app: ASGIApp, ip: str = "127.0.0.1") -> None:
+                self.app = app
+                self.ip = ip
+
+            async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+                if scope["type"] == "http":
+                    scope["client"] = (self.ip, 0)
+                await self.app(scope, receive, send)
+
+        app = FastAPI()
+        # RateLimitMiddleware is added first (outermost), then _FakeClientIP
+        # wraps it so that by the time RateLimitMiddleware sees the request,
+        # client.host is "127.0.0.1" instead of "testclient".
+        app.add_middleware(
+            RateLimitMiddleware,
+            llm_rpm=3,
+            api_rpm=1,
+            enabled=True,
+            trusted_proxy_cidrs="127.0.0.0/8",
+        )
+        app.add_middleware(_FakeClientIP, ip="127.0.0.1")
+
+        @app.get("/api/things")
+        def list_things():
+            return JSONResponse({"items": []})
+
+        client = TestClient(app)
+        # First request from "1.1.1.1" via trusted proxy
+        res = client.get("/api/things", headers={"X-Forwarded-For": "1.1.1.1"})
+        assert res.status_code == 200
+        # Second request from "1.1.1.1" hits its bucket (exhausted at rpm=1)
+        res = client.get("/api/things", headers={"X-Forwarded-For": "1.1.1.1"})
+        assert res.status_code == 429
+        # Different spoofed IP gets its own fresh bucket
+        res = client.get("/api/things", headers={"X-Forwarded-For": "2.2.2.2"})
+        assert res.status_code == 200
+
     def test_warning_logged_on_rate_limit_exceeded(self):
         """log.warning is emitted with key, path, and retry_after when rate limited."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

Fixes a security vulnerability (SEC-027) where unauthenticated requests could bypass IP-based rate limiting by spoofing the `X-Forwarded-For` header. The fix adds validation to only trust the header when the direct TCP connection comes from a configured trusted proxy CIDR.

## Changes

- **backend/config.py**: Add `RATE_LIMIT_TRUSTED_PROXY_CIDRS` env var (default: empty string)
- **backend/rate_limit.py**:
  - Import `ipaddress` module
  - Parse trusted CIDRs in `RateLimitMiddleware.__init__`
  - Update `_get_client_ip()` to validate direct IP against trusted CIDRs before trusting `X-Forwarded-For`
  - Expose `trusted_proxy_cidrs` from `get_rate_limit_config()`
- **backend/tests/test_rate_limit.py**: Add tests for spoofing with/without trusted CIDRs

## Security Impact

- **Severity**: LOW — Only affects unauthenticated requests; JWT-keyed rate limit buckets are unaffected
- **Blast radius**: Isolated to rate limiting middleware; no changes to authentication or other systems
- **Default behavior**: With empty config (default), `X-Forwarded-For` is never trusted — no regression

## Validation

All tests pass (22 passed). Manual verification:
1. Without `RATE_LIMIT_TRUSTED_PROXY_CIDRS` set: spoofed `X-Forwarded-For` headers do NOT bypass rate limiting ✓
2. With `RATE_LIMIT_TRUSTED_PROXY_CIDRS=127.0.0.0/8`: trusted IPs can use the header ✓

Fixes #935