### PR TITLE
security: abort OAuth callback on missing code_verifier (SEC-028)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -206,8 +206,9 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
         mcp_session = cleanup_and_get(mcp_oauth_sessions, state)
         if mcp_session:
             code_verifier = mcp_session.get("google_code_verifier", "")
-    if code_verifier:
-        flow.code_verifier = code_verifier
+    if not code_verifier:
+        raise HTTPException(status_code=400, detail="Invalid or expired OAuth state.")
+    flow.code_verifier = code_verifier
 
     # Google returns scopes in expanded URI form; tell oauthlib to accept it
     import os as _os


### PR DESCRIPTION
## Summary

- Raises HTTP 400 in the Google OAuth callback when `code_verifier` is `None` after both PKCE lookup paths fail
- Prevents silent continuation without PKCE on forged or expired OAuth state (defense-in-depth)

## Test plan

- [ ] Normal Google login flow still completes successfully
- [ ] Request to `/auth/google/callback?code=fake&state=nonexistent` returns HTTP 400 with "Invalid or expired OAuth state."

Fixes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)