### PR TITLE
fix: use constant-time comparison for API token (SEC-026)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -12,6 +12,8 @@ Two auth methods are supported:
    first user in the database (single-tenant shortcut).
 """
 
+import secrets
+
 import jwt
 from fastapi import HTTPException, Request, status
 
@@ -60,7 +62,7 @@ async def require_user(request: Request) -> str:
     auth_header = request.headers.get("authorization", "")
     if auth_header.startswith("Bearer ") and _API_TOKEN:
         provided = auth_header[7:]
-        if provided == _API_TOKEN:
+        if secrets.compare_digest(provided, _API_TOKEN):
             return _resolve_api_token_user()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## Summary

- Replace `provided == _API_TOKEN` with `secrets.compare_digest(provided, _API_TOKEN)` at `backend/auth.py:65`
- Add `import secrets` at the top of the file
- Eliminates timing side-channel on Bearer token validation

## Test plan

- [ ] `python3 -c "import backend.auth"` passes (syntax/import check)
- [ ] Valid `RELI_API_TOKEN` Bearer requests still authenticate successfully
- [ ] Invalid tokens still return 401

Fixes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)