### PR TITLE
fix: cap merge-suggestions candidate query at 200 rows (SEC-025)

### DIFF
--- a/backend/routers/things.py
+++ b/backend/routers/things.py
@@ -591,6 +591,8 @@ def reindex_things(user_id: str = Depends(require_user)) -> dict[str, int]:
 
 # -- Merge suggestions & execution --
 
+_MERGE_CANDIDATE_LIMIT = 200
+
 
 def _normalize(title: str) -> str:
     t = title.lower().strip()
@@ -630,6 +632,7 @@ def get_merge_suggestions(
             user_filter_clause(ThingRecord.user_id, user_id),
         )
         .order_by(ThingRecord.title)
+        .limit(_MERGE_CANDIDATE_LIMIT)
     )
     records = session.exec(stmt).all()
 


### PR DESCRIPTION
## Summary

- Adds `_MERGE_CANDIDATE_LIMIT = 200` constant near the merge-suggestions section
- Applies `.limit(_MERGE_CANDIDATE_LIMIT)` to the `ThingRecord` query in `get_merge_suggestions`
- Bounds worst-case O(n²) comparisons to 200×199/2 = 19,900 instead of unbounded (e.g. 49.9M for 10,000 Things)

## Test plan

- [x] Ran `python3 -m pytest tests/ -k "merge" -x` — 31 passed, 1 skipped

Fixes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)