### PR TITLE
security: raise in production instead of /tmp fallback for token key (SEC-029)

### DIFF
--- a/backend/tests/test_token_encryption.py
+++ b/backend/tests/test_token_encryption.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import unittest.mock
+from pathlib import Path
 
 import pytest
 
@@ -113,3 +115,36 @@ class TestKeyPersistence:
         # The key file should NOT have been created
         key_file = tmp_path / ".token_key_env"
         assert not key_file.exists()
+
+
+class TestProductionSafety:
+    def test_raises_in_production_when_data_dir_not_writable(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.token_encryption._PRIMARY_KEY_FILE",
+            Path("/nonexistent_cannot_create/.token_key"),
+        )
+        monkeypatch.setenv("PRODUCTION", "true")
+        reset_for_testing()
+        with pytest.raises(RuntimeError, match="TOKEN_ENCRYPTION_KEY"):
+            encrypt("test")
+
+    def test_raises_in_production_on_write_oserror(self, tmp_path, monkeypatch):
+        key_file = tmp_path / "subdir" / ".token_key"
+        monkeypatch.setattr("backend.token_encryption._PRIMARY_KEY_FILE", key_file)
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "production")
+        reset_for_testing()
+        key_file.parent.mkdir(parents=True)
+        with unittest.mock.patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            with pytest.raises(RuntimeError, match="TOKEN_ENCRYPTION_KEY"):
+                encrypt("test")
+
+    def test_non_production_falls_back_to_tmp(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.token_encryption._PRIMARY_KEY_FILE",
+            Path("/nonexistent_cannot_create/.token_key"),
+        )
+        monkeypatch.delenv("PRODUCTION", raising=False)
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        reset_for_testing()
+        result = encrypt("test")
+        assert result

--- a/backend/tests/test_token_encryption.py
+++ b/backend/tests/test_token_encryption.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from backend.token_encryption import (
+    _is_production,
     decrypt,
     decrypt_json_or_plaintext,
     decrypt_or_plaintext,
@@ -148,3 +149,36 @@ class TestProductionSafety:
         reset_for_testing()
         result = encrypt("test")
         assert result
+        # Verify the ciphertext is valid and the fallback key works end-to-end
+        assert decrypt(result) == "test"
+
+
+class TestIsProduction:
+    """Direct unit tests for the _is_production() helper."""
+
+    def test_false_when_both_env_vars_unset(self, monkeypatch):
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        monkeypatch.delenv("PRODUCTION", raising=False)
+        assert _is_production() is False
+
+    def test_true_when_production_env_var_set(self, monkeypatch):
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        monkeypatch.setenv("PRODUCTION", "true")
+        assert _is_production() is True
+
+    def test_true_when_railway_environment_name_is_production(self, monkeypatch):
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "production")
+        monkeypatch.delenv("PRODUCTION", raising=False)
+        assert _is_production() is True
+
+    def test_true_when_railway_environment_name_is_staging(self, monkeypatch):
+        # Any non-empty RAILWAY_ENVIRONMENT_NAME is treated as production —
+        # staging should behave like production for key security.
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "staging")
+        monkeypatch.delenv("PRODUCTION", raising=False)
+        assert _is_production() is True
+
+    def test_true_when_railway_environment_name_is_any_nonempty_value(self, monkeypatch):
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "preview")
+        monkeypatch.delenv("PRODUCTION", raising=False)
+        assert _is_production() is True

--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -30,6 +30,10 @@ _FALLBACK_KEY_FILE = _FALLBACK_KEY_DIR / ".token_key"
 _fernet: Fernet | None = None
 
 
+def _is_production() -> bool:
+    return bool(os.getenv("RAILWAY_ENVIRONMENT_NAME") or os.getenv("PRODUCTION"))
+
+
 def _key_file_path() -> Path:
     """Return a writable key-file path, preferring DATA_DIR, falling back to /tmp."""
     if _PRIMARY_KEY_FILE.exists():
@@ -41,6 +45,17 @@ def _key_file_path() -> Path:
             return _PRIMARY_KEY_FILE
     except OSError:
         pass
+    if _is_production():
+        logger.critical(
+            "TOKEN_ENCRYPTION_KEY is not set and DATA_DIR (%s) is not writable. "
+            "Refusing to fall back to world-readable /tmp in production. "
+            "Set the TOKEN_ENCRYPTION_KEY environment variable.",
+            _PRIMARY_KEY_FILE.parent,
+        )
+        raise RuntimeError(
+            "Cannot store token encryption key securely: DATA_DIR is not writable "
+            "and TOKEN_ENCRYPTION_KEY is not set. Set TOKEN_ENCRYPTION_KEY env var."
+        )
     return _FALLBACK_KEY_FILE
 
 
@@ -70,7 +85,17 @@ def _get_fernet() -> Fernet:
             key_file.chmod(0o600)
             logger.info("Generated new token encryption key at %s", key_file)
         except OSError:
-            # Last resort: use /tmp fallback if even the chosen path fails
+            if _is_production():
+                logger.critical(
+                    "Could not write token encryption key to %s in production. "
+                    "Set TOKEN_ENCRYPTION_KEY environment variable.",
+                    key_file,
+                )
+                raise RuntimeError(
+                    f"Cannot write token encryption key to {key_file}. "
+                    "Set TOKEN_ENCRYPTION_KEY env var in production."
+                )
+            # Non-production only: fall back to /tmp
             _FALLBACK_KEY_DIR.mkdir(parents=True, exist_ok=True)
             _FALLBACK_KEY_FILE.write_text(key)
             _FALLBACK_KEY_FILE.chmod(0o600)

--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -92,8 +92,7 @@ def _get_fernet() -> Fernet:
                     key_file,
                 )
                 raise RuntimeError(
-                    f"Cannot write token encryption key to {key_file}. "
-                    "Set TOKEN_ENCRYPTION_KEY env var in production."
+                    f"Cannot write token encryption key to {key_file}. Set TOKEN_ENCRYPTION_KEY env var in production."
                 )
             # Non-production only: fall back to /tmp
             _FALLBACK_KEY_DIR.mkdir(parents=True, exist_ok=True)

--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -137,7 +137,7 @@ def decrypt_or_plaintext(value: str) -> tuple[str, bool]:
     """
     try:
         return decrypt(value), True
-    except (InvalidToken, Exception):
+    except Exception:
         return value, False
 
 

--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -95,14 +95,23 @@ def _get_fernet() -> Fernet:
                     f"Cannot write token encryption key to {key_file}. Set TOKEN_ENCRYPTION_KEY env var in production."
                 )
             # Non-production only: fall back to /tmp
-            _FALLBACK_KEY_DIR.mkdir(parents=True, exist_ok=True)
-            _FALLBACK_KEY_FILE.write_text(key)
-            _FALLBACK_KEY_FILE.chmod(0o600)
-            logger.warning(
-                "Could not write key to %s, using fallback %s",
-                key_file,
-                _FALLBACK_KEY_FILE,
-            )
+            try:
+                _FALLBACK_KEY_DIR.mkdir(parents=True, exist_ok=True)
+                _FALLBACK_KEY_FILE.write_text(key)
+                _FALLBACK_KEY_FILE.chmod(0o600)
+                logger.warning(
+                    "Could not write key to %s, using fallback %s",
+                    key_file,
+                    _FALLBACK_KEY_FILE,
+                )
+            except OSError as fallback_err:
+                logger.error(
+                    "Could not write token encryption key to fallback %s either: %s. "
+                    "Set TOKEN_ENCRYPTION_KEY environment variable.",
+                    _FALLBACK_KEY_FILE,
+                    fallback_err,
+                )
+                raise
 
     _fernet = Fernet(key.encode())
     return _fernet

--- a/frontend/src/offline/sync-engine.ts
+++ b/frontend/src/offline/sync-engine.ts
@@ -128,9 +128,7 @@ export async function syncPendingOps(): Promise<void> {
  * Call once at app startup. Returns a cleanup function.
  */
 export function initSyncEngine(): () => void {
-  const handler = syncPendingOps
-
-  window.addEventListener('online', handler)
+  window.addEventListener('online', syncPendingOps)
 
   // If already online and there might be queued ops from a previous session, sync now
   if (navigator.onLine) {
@@ -138,6 +136,6 @@ export function initSyncEngine(): () => void {
   }
 
   return () => {
-    window.removeEventListener('online', handler)
+    window.removeEventListener('online', syncPendingOps)
   }
 }


### PR DESCRIPTION
## Summary

- Add `_is_production()` helper to `token_encryption.py` (mirrors `config.py:117` pattern using `RAILWAY_ENVIRONMENT_NAME` / `PRODUCTION` env vars)
- Guard both `/tmp` fallback paths: `_key_file_path()` and the `OSError` handler in `_get_fernet()` — in production, log CRITICAL and raise `RuntimeError` instead of silently writing to world-readable `/tmp`
- Add `TestProductionSafety` class (3 tests) covering: non-writable DATA_DIR in production, OSError on write in production, non-production still falls back to `/tmp`

Fixes #937

## Test plan

- [x] All 13 existing + new tests pass (`backend/tests/test_token_encryption.py`)
- [x] `test_raises_in_production_when_data_dir_not_writable` — confirms RuntimeError raised with clear message
- [x] `test_raises_in_production_on_write_oserror` — confirms OSError handler also guarded
- [x] `test_non_production_falls_back_to_tmp` — confirms /tmp fallback still works in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)