### PR TITLE
security: remove :- defaults for SECRET_KEY and RELI_API_TOKEN (SEC-023)

### DIFF
--- a/backend/token_encryption.py
+++ b/backend/token_encryption.py
@@ -17,7 +17,7 @@ import logging
 import os
 from pathlib import Path
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet
 
 from .config import settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI:-http://localhost:8000/api/calendar/callback}
       - GOOGLE_AUTH_REDIRECT_URI=${GOOGLE_AUTH_REDIRECT_URI:-http://localhost:8000/api/auth/google/callback}
       - RELI_BASE_URL=${RELI_BASE_URL:-}
-      - SECRET_KEY=${SECRET_KEY:-}
-      - RELI_API_TOKEN=${RELI_API_TOKEN:-}
+      - SECRET_KEY=${SECRET_KEY}
+      - RELI_API_TOKEN=${RELI_API_TOKEN}
       - SENTRY_DSN=${SENTRY_DSN:-}
       - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}
       - DATABASE_URL=${DATABASE_URL:-}


### PR DESCRIPTION
## Summary

- `docker-compose.yml` was using `${SECRET_KEY:-}` and `${RELI_API_TOKEN:-}`, silently defaulting both to empty string when env vars are unset
- Empty string is falsy, so `auth.py:57` (`if not SECRET_KEY and not _API_TOKEN`) would disable authentication for all requests
- Changed to `${SECRET_KEY}` and `${RELI_API_TOKEN}` — Docker Compose v2 emits a warning to stderr when either is unset (it does not error by itself); the actual fail-fast enforcement is in `backend/config.py` via the Pydantic `@model_validator` which raises `ValueError` if both vars are empty (unless `AUTH_DISABLED=true`), and raises unconditionally in production if `SECRET_KEY` is missing

## Test plan

- [ ] Verify `docker compose config` warns when `SECRET_KEY` is unset
- [ ] Verify the backend raises a `ValueError` on startup when both vars are unset and `AUTH_DISABLED` is not set
- [ ] Verify `docker compose config` succeeds when both vars are set
- [ ] Confirm no auth bypass when secrets are properly configured

Fixes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)