### PR TITLE
security: require auth on /metrics endpoint (SEC-022)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -395,7 +395,7 @@ def health_detailed(user_id: str = Depends(require_user)) -> dict:
     }
 
 
-@app.get("/metrics", tags=["monitoring"], include_in_schema=False)
+@app.get("/metrics", tags=["monitoring"], include_in_schema=False, dependencies=[Depends(require_user)])
 def metrics() -> StarletteResponse:
     return metrics_response()
 

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -142,8 +142,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         path = request.url.path
 
-        # Skip rate limiting for health checks, metrics, and static assets only
-        if path in ("/healthz", "/metrics") or path.startswith("/assets/"):
+        # Skip rate limiting for health checks and static assets only
+        if path == "/healthz" or path.startswith("/assets/"):
             return await call_next(request)
 
         key = self._get_rate_limit_key(request)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -41,10 +41,9 @@ class TestMetricsEndpoint:
         """The /metrics endpoint must reject unauthenticated requests."""
         from backend.main import app
 
-        with patch("backend.auth.SECRET_KEY", "test-secret-key"):
-            with TestClient(app) as c:
-                resp = c.get("/metrics")
-                assert resp.status_code == 401
+        with patch("backend.auth.SECRET_KEY", "test-secret-key"), TestClient(app) as c:
+            resp = c.get("/metrics")
+            assert resp.status_code == 401
 
 
 class TestPathNormalization:

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -37,13 +37,16 @@ class TestMetricsEndpoint:
         resp = client.get("/metrics")
         assert "db_users_total" in resp.text
 
-    def test_no_auth_required(self, patched_db):
-        """The /metrics endpoint must be accessible without a session cookie."""
+    def test_requires_auth(self, patched_db):
+        """The /metrics endpoint must reject unauthenticated requests."""
+        from unittest.mock import patch
+
         from backend.main import app
 
-        with TestClient(app) as c:
-            resp = c.get("/metrics")
-            assert resp.status_code == 200
+        with patch("backend.auth.SECRET_KEY", "test-secret-key"):
+            with TestClient(app) as c:
+                resp = c.get("/metrics")
+                assert resp.status_code == 401
 
 
 class TestPathNormalization:

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -39,8 +39,6 @@ class TestMetricsEndpoint:
 
     def test_requires_auth(self, patched_db):
         """The /metrics endpoint must reject unauthenticated requests."""
-        from unittest.mock import patch
-
         from backend.main import app
 
         with patch("backend.auth.SECRET_KEY", "test-secret-key"):

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -22,20 +22,20 @@ def _make_app() -> FastAPI:
 
 
 class TestSecurityHeadersMiddleware:
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def client(self):
-        self._client = TestClient(_make_app())
+        return TestClient(_make_app())
 
-    def test_csp_header_excludes_unsafe_inline_from_style_src(self):
+    def test_csp_header_excludes_unsafe_inline_from_style_src(self, client):
         """style-src must not contain 'unsafe-inline' (SEC-033 regression guard)."""
-        res = self._client.get("/probe")
+        res = client.get("/probe")
         csp = res.headers["Content-Security-Policy"]
         assert "style-src 'self'" in csp
         assert "'unsafe-inline'" not in csp
 
-    def test_csp_header_full_value(self):
+    def test_csp_header_full_value(self, client):
         """Pin the entire CSP string to catch any future accidental directive change."""
-        res = self._client.get("/probe")
+        res = client.get("/probe")
         expected = (
             "default-src 'self'; "
             "script-src 'self'; "
@@ -47,9 +47,9 @@ class TestSecurityHeadersMiddleware:
         )
         assert res.headers["Content-Security-Policy"] == expected
 
-    def test_other_security_headers_present(self):
+    def test_other_security_headers_present(self, client):
         """Verify all security headers are set (no header accidentally dropped)."""
-        res = self._client.get("/probe")
+        res = client.get("/probe")
         assert res.headers["X-Content-Type-Options"] == "nosniff"
         assert res.headers["X-Frame-Options"] == "DENY"
         assert "max-age=63072000" in res.headers["Strict-Transport-Security"]


### PR DESCRIPTION
## Summary

- Add `dependencies=[Depends(require_user)]` to `GET /metrics` so anonymous callers can no longer read per-path request counts, response times, and traffic patterns
- Remove `/metrics` from the rate-limit bypass (it no longer needs special-casing now that auth guards it)
- Invert `test_no_auth_required` → `test_requires_auth`, patching `SECRET_KEY` to enforce auth in the test environment

## Test plan

- [ ] `python3 -m pytest backend/tests/test_metrics.py backend/tests/test_rate_limit.py -v` — all pass
- [ ] `curl -s http://localhost:8000/metrics` (no cookie) → 401
- [ ] `curl -s -H "Cookie: session=<valid-jwt>" http://localhost:8000/metrics` → 200 with Prometheus text

Fixes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)