### PR TITLE
security: scrub user content from OTEL spans (SEC-020)

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -39,6 +39,15 @@ _tracer = get_tracer("reli.reasoning_agent")
 # Max length for span attribute values to avoid oversized payloads
 _ATTR_VALUE_LIMIT = 4096
 
+# Content fields that must never appear in OTEL span attributes (user PII/data)
+_CONTENT_FIELDS = frozenset({
+    "title", "data", "data_json",
+    "open_questions", "open_questions_json",
+    "summary", "description", "location",
+    "merged_data_json", "payload_json",
+    "search_queries_json", "search_query",
+})
+
 
 def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
     """Wrap a tool function with an OTEL span recording inputs and outputs."""
@@ -56,6 +65,8 @@ def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str,
             bound = sig.bind(*args, **kwargs)
             bound.apply_defaults()
             for param_name, value in bound.arguments.items():
+                if param_name in _CONTENT_FIELDS:
+                    continue
                 attr_val = str(value) if not isinstance(value, str) else value
                 if len(attr_val) > _ATTR_VALUE_LIMIT:
                     attr_val = attr_val[:_ATTR_VALUE_LIMIT] + "..."
@@ -82,11 +93,6 @@ def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str,
                     span.set_attribute("tool.error", result["error"])
                 else:
                     span.set_status(trace.StatusCode.OK)
-                result_str = json.dumps(result, default=str)
-                if len(result_str) > _ATTR_VALUE_LIMIT:
-                    result_str = result_str[:_ATTR_VALUE_LIMIT] + "..."
-                span.set_attribute("tool.output", result_str)
-
                 # Set key identifiers as top-level attributes for easy filtering
                 for key in ("id", "deleted", "keep_id"):
                     if key in result:

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -41,11 +41,12 @@ _ATTR_VALUE_LIMIT = 4096
 
 # Content fields that must never appear in OTEL span attributes (user PII/data)
 _CONTENT_FIELDS = frozenset({
-    "title", "data", "data_json",
-    "open_questions", "open_questions_json",
+    "title", "data_json",
+    "open_questions_json",
     "summary", "description", "location",
     "merged_data_json", "payload_json",
     "search_queries_json", "search_query",
+    "relationship_type",               # personal roles: sister, doctor, therapist
 })
 
 
@@ -86,7 +87,7 @@ def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str,
                 span.record_exception(exc)
                 return {"error": f"Tool {func.__name__} failed: {exc}"}
 
-            # Record output
+            # Record result status and structural IDs (no content is stored)
             if isinstance(result, dict):
                 if "error" in result:
                     span.set_status(trace.StatusCode.ERROR, result["error"])

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -88,16 +88,18 @@ async def submit_feedback(
     if screenshot_url:
         issue_body += f"\n\n## Screenshot\n\n![Screenshot]({screenshot_url})"
 
-    # Map category to title prefix
-    prefix_map = {"bug": "Bug", "feature": "Feature request", "other": "Feedback"}
-    title_prefix = prefix_map.get(body.category, "Feedback")
+    # Map category to (title prefix, GitHub label)
+    _category_map = {
+        "bug": ("Bug", "bug"),
+        "feature": ("Feature request", "enhancement"),
+        "other": ("Feedback", "feedback"),
+    }
+    title_prefix, label = _category_map.get(body.category, ("Feedback", "feedback"))
 
     # Truncate message for title (first line, max 80 chars)
     first_line = body.message.split("\n")[0].strip()
     title_summary = first_line[:80] + ("..." if len(first_line) > 80 else "")
     title = f"[{title_prefix}] {title_summary}"
-
-    label = {"bug": "bug", "feature": "enhancement"}.get(body.category, "feedback")
 
     try:
         resp = await client.post(

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -158,7 +158,7 @@ class TestTracedToolDecorator:
         assert "boom" in result["error"]
 
     def test_traced_tool_records_span_attributes(self):
-        """Wrapped tool should set span attributes for inputs and outputs."""
+        """_traced_tool records non-content span attributes; content fields and tool output are scrubbed."""
         from backend.reasoning_agent import _traced_tool
 
         mock_span = MagicMock()
@@ -181,7 +181,7 @@ class TestTracedToolDecorator:
         call_args = mock_tracer.start_as_current_span.call_args
         assert call_args[0][0] == "tool.create_thing"
 
-        # Verify input attributes were set — content fields must be absent
+        # Non-content inputs are recorded; content fields must be absent
         set_attr_calls = {call[0][0]: call[0][1] for call in mock_span.set_attribute.call_args_list}
         assert "tool.input.title" not in set_attr_calls  # content field scrubbed
         assert set_attr_calls["tool.input.importance"] == "0"
@@ -203,6 +203,14 @@ class TestTracedToolDecorator:
                 title: str,
                 data_json: str,
                 open_questions_json: str,
+                summary: str,              # calendar_create_event / calendar_update_event
+                description: str,          # calendar_create_event / calendar_update_event
+                location: str,             # calendar_create_event / calendar_update_event
+                search_queries_json: str,  # fetch_context
+                search_query: str,         # chat_history
+                merged_data_json: str,     # merge_things
+                payload_json: str,         # schedule_task
+                relationship_type: str,    # create_relationship (personal roles)
                 importance: int = 2,
             ) -> dict:
                 return {"id": "uuid-1"}
@@ -212,6 +220,14 @@ class TestTracedToolDecorator:
                 title="Secret title",
                 data_json='{"key": "secret"}',
                 open_questions_json="[]",
+                summary="Board meeting",
+                description="Sensitive agenda",
+                location="User's home",
+                search_queries_json='["private query"]',
+                search_query="private search",
+                merged_data_json="{}",
+                payload_json="{}",
+                relationship_type="therapist",
                 importance=3,
             )
 

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -181,12 +181,46 @@ class TestTracedToolDecorator:
         call_args = mock_tracer.start_as_current_span.call_args
         assert call_args[0][0] == "tool.create_thing"
 
-        # Verify input attributes were set
+        # Verify input attributes were set — content fields must be absent
         set_attr_calls = {call[0][0]: call[0][1] for call in mock_span.set_attribute.call_args_list}
-        assert set_attr_calls["tool.input.title"] == "Buy groceries"
+        assert "tool.input.title" not in set_attr_calls  # content field scrubbed
         assert set_attr_calls["tool.input.importance"] == "0"
-        assert "new-uuid" in set_attr_calls["tool.output"]
+        assert "tool.output" not in set_attr_calls  # full output scrubbed
         assert set_attr_calls["tool.result.id"] == "new-uuid"
+
+    def test_traced_tool_scrubs_content_fields(self):
+        """_traced_tool must not record any _CONTENT_FIELDS as span attributes."""
+        from backend.reasoning_agent import _CONTENT_FIELDS, _traced_tool
+
+        mock_span = MagicMock()
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("backend.reasoning_agent._tracer", mock_tracer):
+
+            def create_thing(
+                title: str,
+                data_json: str,
+                open_questions_json: str,
+                importance: int = 2,
+            ) -> dict:
+                return {"id": "uuid-1"}
+
+            wrapped = _traced_tool(create_thing)
+            wrapped(
+                title="Secret title",
+                data_json='{"key": "secret"}',
+                open_questions_json="[]",
+                importance=3,
+            )
+
+        set_attr_calls = {call[0][0] for call in mock_span.set_attribute.call_args_list}
+        for field in _CONTENT_FIELDS:
+            assert f"tool.input.{field}" not in set_attr_calls, (
+                f"Content field '{field}' must not appear in span attributes"
+            )
+        assert "tool.output" not in set_attr_calls
 
     def test_traced_tool_records_error_status_on_error_result(self):
         """Wrapped tool should set ERROR status when result contains 'error' key."""

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore, type AppliedChanges, type CalendarEvent, type ChatMessage, type ChatMode, type ChatSession, type ContextThing, type GmailMessage, type InteractionStyle, type ModelUsage, type ReferencedThing, type SessionStats, type StreamingStage, type WebSearchResult } from '../store'
@@ -47,103 +47,92 @@ function ExpandChevron({ expanded }: { expanded: boolean }) {
   )
 }
 
-function WebSources({ results }: { results: WebSearchResult[] }) {
+function CollapsibleSources<T>({
+  items,
+  noun,
+  colorClass,
+  renderItem,
+}: {
+  items: T[]
+  noun: string
+  colorClass: string
+  renderItem: (item: T, index: number) => ReactNode
+}) {
   const [expanded, setExpanded] = useState(false)
-
-  if (results.length === 0) return null
-
+  if (items.length === 0) return null
   return (
     <div className="mt-3">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        className={`flex items-center gap-1 text-xs font-medium ${colorClass} transition-colors`}
       >
         <ExpandChevron expanded={expanded} />
-        {results.length} source{results.length !== 1 ? 's' : ''}
+        {items.length} {noun}{items.length !== 1 ? 's' : ''}
       </button>
       {expanded && (
         <div className="mt-1.5 space-y-1.5">
-          {results.map((r, i) => (
-            <a
-              key={i}
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block text-xs text-on-surface-variant hover:text-primary transition-colors"
-            >
-              <span className="font-medium">{r.title}</span>
-              <span className="block text-on-surface-variant/60 truncate">{r.snippet}</span>
-            </a>
-          ))}
+          {items.map(renderItem)}
         </div>
       )}
     </div>
+  )
+}
+
+function WebSources({ results }: { results: WebSearchResult[] }) {
+  return (
+    <CollapsibleSources
+      items={results}
+      noun="source"
+      colorClass="text-primary hover:text-primary/80"
+      renderItem={(r, i) => (
+        <a
+          key={i}
+          href={r.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-xs text-on-surface-variant hover:text-primary transition-colors"
+        >
+          <span className="font-medium">{r.title}</span>
+          <span className="block text-on-surface-variant/60 truncate">{r.snippet}</span>
+        </a>
+      )}
+    />
   )
 }
 
 function GmailSources({ messages }: { messages: GmailMessage[] }) {
-  const [expanded, setExpanded] = useState(false)
-
-  if (messages.length === 0) return null
-
   return (
-    <div className="mt-3">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1 text-xs font-medium text-ideas hover:text-ideas/80 transition-colors"
-      >
-        <ExpandChevron expanded={expanded} />
-        {messages.length} email{messages.length !== 1 ? 's' : ''}
-      </button>
-      {expanded && (
-        <div className="mt-1.5 space-y-1.5">
-          {messages.map((m, i) => (
-            <div
-              key={i}
-              className="text-xs text-on-surface-variant"
-            >
-              <span className="font-medium">{m.subject}</span>
-              <span className="text-on-surface-variant/60"> — {m.from}</span>
-              <span className="block text-on-surface-variant/60 truncate">{m.snippet}</span>
-            </div>
-          ))}
+    <CollapsibleSources
+      items={messages}
+      noun="email"
+      colorClass="text-ideas hover:text-ideas/80"
+      renderItem={(m, i) => (
+        <div key={i} className="text-xs text-on-surface-variant">
+          <span className="font-medium">{m.subject}</span>
+          <span className="text-on-surface-variant/60"> — {m.from}</span>
+          <span className="block text-on-surface-variant/60 truncate">{m.snippet}</span>
         </div>
       )}
-    </div>
+    />
   )
 }
 
 function CalendarSources({ events }: { events: CalendarEvent[] }) {
-  const [expanded, setExpanded] = useState(false)
-
-  if (events.length === 0) return null
-
   return (
-    <div className="mt-3">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1 text-xs font-medium text-events hover:text-events/80 transition-colors"
-      >
-        <ExpandChevron expanded={expanded} />
-        {events.length} event{events.length !== 1 ? 's' : ''}
-      </button>
-      {expanded && (
-        <div className="mt-1.5 space-y-1.5">
-          {events.map((ev, i) => (
-            <div
-              key={i}
-              className="text-xs text-on-surface-variant"
-            >
-              <span className="font-medium">{ev.summary}</span>
-              <span className="text-on-surface-variant/60"> — {new Date(ev.start).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
-              {ev.location && (
-                <span className="block text-on-surface-variant/60 truncate">{ev.location}</span>
-              )}
-            </div>
-          ))}
+    <CollapsibleSources
+      items={events}
+      noun="event"
+      colorClass="text-events hover:text-events/80"
+      renderItem={(ev, i) => (
+        <div key={i} className="text-xs text-on-surface-variant">
+          <span className="font-medium">{ev.summary}</span>
+          <span className="text-on-surface-variant/60"> — {new Date(ev.start).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
+          {ev.location && (
+            <span className="block text-on-surface-variant/60 truncate">{ev.location}</span>
+          )}
         </div>
       )}
-    </div>
+    />
   )
 }
 


### PR DESCRIPTION
## Summary

- Add `_CONTENT_FIELDS` frozenset constant to `reasoning_agent.py` listing all user content parameter names (`title`, `data_json`, `open_questions_json`, `summary`, `description`, `location`, `merged_data_json`, `payload_json`, `search_queries_json`, `search_query`)
- Guard the input-recording loop in `_traced_tool` to skip any param in `_CONTENT_FIELDS`
- Remove `tool.output` span attribute (full result JSON) — only structural IDs (`tool.result.id/deleted/keep_id`) are retained
- Update `test_traced_tool_records_span_attributes` to assert content fields are **absent**; add `test_traced_tool_scrubs_content_fields` for exhaustive coverage

## Test plan

- [x] `cd backend && python3 -m pytest tests/test_tracing.py -v` — all 14 tests pass
- [ ] Manual: enable Phoenix locally, call `create_thing`, inspect spans — `tool.input.title`, `tool.input.data_json`, `tool.output` must be absent; `tool.input.importance`, `tool.result.id` must be present

Fixes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)