### PR TITLE
Fix: use Railway PORT env var in Dockerfile CMD and add health check diagnostics

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -95,11 +95,13 @@ jobs:
           sleep 90
           echo "Polling ${RAILWAY_STAGING_URL}/healthz ..."
           for i in $(seq 1 20); do
-            if curl -sf --max-time 5 "${RAILWAY_STAGING_URL}/healthz" | grep -q '"status":"ok"'; then
+            HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null || echo "000")
+            BODY=$(cat /tmp/hc_body.txt 2>/dev/null)
+            echo "Attempt $i/20: HTTP $HTTP_CODE — ${BODY:0:100}"
+            if [ "$HTTP_CODE" = "200" ] && echo "$BODY" | grep -q '"status":"ok"'; then
               echo "Staging healthy after attempt $i"
               exit 0
             fi
-            echo "Attempt $i/20 failed, waiting 30s..."
             sleep 30
           done
           echo "Staging failed to become healthy after 20 attempts"

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf 
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')" || exit 1
+  CMD python -c "import os,urllib.request; urllib.request.urlopen(f'http://localhost:{os.environ.get(\"PORT\",\"8000\")}/healthz')" || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "/app/.venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD python -c "import os,urllib.request; urllib.request.urlopen(f'http://localhost:{os.environ.get(\"PORT\",\"8000\")}/healthz')" || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["sh", "-c", "/app/.venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec /app/.venv/bin/uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -34,6 +34,14 @@ class FeedbackResponse(BaseModel):
     message: str = ""
 
 
+# Maps feedback category → (issue title prefix, GitHub label)
+_CATEGORY_MAP: dict[str, tuple[str, str]] = {
+    "bug": ("Bug", "bug"),
+    "feature": ("Feature request", "enhancement"),
+    "other": ("Feedback", "feedback"),
+}
+
+
 @router.post("", response_model=FeedbackResponse, summary="Submit feedback")
 async def submit_feedback(
     body: FeedbackRequest,
@@ -88,13 +96,7 @@ async def submit_feedback(
     if screenshot_url:
         issue_body += f"\n\n## Screenshot\n\n![Screenshot]({screenshot_url})"
 
-    # Map category to (title prefix, GitHub label)
-    _category_map = {
-        "bug": ("Bug", "bug"),
-        "feature": ("Feature request", "enhancement"),
-        "other": ("Feedback", "feedback"),
-    }
-    title_prefix, label = _category_map.get(body.category, ("Feedback", "feedback"))
+    title_prefix, label = _CATEGORY_MAP.get(body.category, ("Feedback", "feedback"))
 
     # Truncate message for title (first line, max 80 chars)
     first_line = body.message.split("\n")[0].strip()


### PR DESCRIPTION
## Summary

Staging deploy has been red since the pip→uv migration because CMD hardcodes `--port 8000` while Railway routes traffic to `$PORT`. This PR switches CMD to shell form with `${PORT:-8000}` and explicit uvicorn path, also updates the Docker HEALTHCHECK to respect PORT, and adds HTTP status/body logging to the staging health check step for faster future diagnosis.

## Changes

- **Dockerfile CMD**: use sh -c with /app/.venv/bin/uvicorn and ${PORT:-8000}
- **Dockerfile HEALTHCHECK**: read PORT env var instead of hardcoded 8000
- **.github/workflows/staging-pipeline.yml**: log HTTP code and response body on each health check attempt

## Root Cause

Since commit `6925bc3` (pip→uv migration), staging deploys fail because:
1. `uv sync` creates `/app/.venv/` despite `UV_SYSTEM_PYTHON=1`
2. Previous commit `bc721ed` added venv to PATH but deployments still failed
3. The actual issue: CMD hardcodes `--port 8000` but Railway's proxy routes to the `$PORT` environment variable, which defaults to 8080 on Railway
4. Result: health checks get "connection refused" (port mismatch)

## Validation

✅ All backend tests pass (996 passed, 0 failed, 13 skipped)
✅ Dockerfile syntax reviewed
✅ CI pipeline YAML syntax reviewed
✅ Changes ready for Railway staging deployment

Fixes #990