### PR TITLE
Fix: add Dependabot configuration for dependency vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    assignees:
+      - "alexsiri7"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    assignees:
+      - "alexsiri7"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    assignees:
+      - "alexsiri7"


### PR DESCRIPTION
## Summary

Adds GitHub Dependabot configuration to enable automated dependency vulnerability scanning for Python (pip), npm, and GitHub Actions. This completes issue #501 by activating GitHub's native vulnerability graph and automated update PR generation.

The existing CI pipeline already has `pip-audit` and `npm audit` gates in `dependency-scan.yml`. This commit adds the missing `.github/dependabot.yml` to enable proactive dependency updates via Dependabot, working in tandem with the reactive CI gates.

## Changes

| File | Action | Details |
|------|--------|---------|
| `.github/dependabot.yml` | CREATE | Dependabot configuration for pip, npm, github-actions ecosystems with weekly Monday schedule |

## Dependabot Configuration

The new configuration:
- **pip**: Targets `pyproject.toml` at repo root, weekly Monday updates
- **npm**: Targets `frontend/package.json`, weekly Monday updates  
- **github-actions**: Targets `.github/workflows/`, weekly Monday updates
- **Assignee**: `alexsiri7` for all ecosystems
- **Schedule**: Monday 06:00 UTC (aligned with existing `dependency-scan.yml` schedule)

## Validation

✅ YAML syntax validation passed
✅ Schema validation passed (version: 2, all 3 ecosystems present: pip, npm, github-actions)

## How to Test

After merge, verify GitHub Dependabot is active:
1. Visit repo Settings → Security → Dependabot → Alerts
2. Verify "Dependabot alerts are enabled" is shown
3. Check that Dependabot generates automated update PRs on the next Monday run

Fixes #501

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>