### PR TITLE
feat: add response agent accuracy eval golden dataset

### DIFF
--- a/backend/tests/test_evals.py
+++ b/backend/tests/test_evals.py
@@ -463,3 +463,12 @@ async def test_response_agent_question_quality() -> None:
         test_file=str(EVAL_ROOT / "response_agent" / "question_quality.test.json"),
         threshold=0.7,
     )
+
+
+@pytest.mark.asyncio
+async def test_response_agent_accuracy() -> None:
+    """Eval: response agent — accuracy and faithfulness to reasoning agent output."""
+    await _run_response_agent_eval(
+        test_file=str(EVAL_ROOT / "response_agent" / "accuracy.test.json"),
+        threshold=0.7,
+    )

--- a/eval/response_agent/accuracy.test.json
+++ b/eval/response_agent/accuracy.test.json
@@ -1,0 +1,134 @@
+{
+  "eval_set_id": "response-agent-accuracy",
+  "name": "Response Agent — Accuracy and Faithfulness",
+  "description": "Golden dataset: response agent must accurately reflect what the reasoning agent decided without hallucinating changes or omitting key information.",
+  "eval_cases": [
+    {
+      "eval_id": "accuracy-deletion-confirmed",
+      "description": "Reasoning deleted a thing. Response must confirm deletion, not say 'created' or 'updated'.",
+      "input": {
+        "user_message": "remove the dentist appointment, I already went",
+        "reasoning_summary": "Deleted 'Dentist appointment' — user confirmed it's no longer needed.",
+        "applied_changes": {
+          "created": [],
+          "updated": [],
+          "deleted": [{"id": "thing-den01", "title": "Dentist appointment", "type_hint": "task"}],
+          "merged": [],
+          "relationships_created": []
+        },
+        "questions_for_user": [],
+        "priority_question": "",
+        "briefing_mode": false,
+        "personality_patterns": []
+      },
+      "rubric": [
+        "Response confirms the item was removed or deleted",
+        "Response does NOT say the item was 'created' or 'updated'",
+        "Response does NOT claim any items were added or modified"
+      ]
+    },
+    {
+      "eval_id": "accuracy-no-changes-no-hallucination",
+      "description": "Reasoning made no changes. Response must NOT claim any changes were made.",
+      "input": {
+        "user_message": "how's my week looking?",
+        "reasoning_summary": "No changes made. Surfacing active items: Team standup, Client proposal draft, Gym session.",
+        "applied_changes": {
+          "created": [],
+          "updated": [],
+          "deleted": [],
+          "merged": [],
+          "relationships_created": []
+        },
+        "questions_for_user": [],
+        "priority_question": "",
+        "briefing_mode": false,
+        "personality_patterns": []
+      },
+      "rubric": [
+        "Response does NOT claim anything was created, updated, deleted, or changed",
+        "Response surfaces or mentions at least one of the active items (Team standup, Client proposal draft, or Gym session)",
+        "Response does NOT fabricate items that are not in the reasoning summary"
+      ]
+    },
+    {
+      "eval_id": "accuracy-multi-create-all-mentioned",
+      "description": "Reasoning created multiple things. Response must acknowledge all of them, not just one.",
+      "input": {
+        "user_message": "add grocery shopping and pick up dry cleaning to my errands",
+        "reasoning_summary": "Created two tasks: 'Grocery shopping' and 'Pick up dry cleaning'.",
+        "applied_changes": {
+          "created": [
+            {"id": "thing-gro01", "title": "Grocery shopping", "type_hint": "task", "active": 1},
+            {"id": "thing-dry01", "title": "Pick up dry cleaning", "type_hint": "task", "active": 1}
+          ],
+          "updated": [],
+          "deleted": [],
+          "merged": [],
+          "relationships_created": []
+        },
+        "questions_for_user": [],
+        "priority_question": "",
+        "briefing_mode": false,
+        "personality_patterns": []
+      },
+      "rubric": [
+        "Response mentions grocery shopping (or groceries)",
+        "Response mentions dry cleaning",
+        "Response does NOT omit either of the two created items",
+        "Response does NOT claim items were deleted or completed"
+      ]
+    },
+    {
+      "eval_id": "accuracy-importance-update",
+      "description": "Reasoning changed importance to critical. Response must reflect urgency, not neutral tone.",
+      "input": {
+        "user_message": "the server migration is now critical, it has to be done by end of day",
+        "reasoning_summary": "Updated 'Server migration' importance to critical. Deadline is today.",
+        "applied_changes": {
+          "created": [],
+          "updated": [{"id": "thing-srv01", "title": "Server migration", "type_hint": "task", "importance": 2, "active": 1}],
+          "deleted": [],
+          "merged": [],
+          "relationships_created": []
+        },
+        "questions_for_user": [],
+        "priority_question": "",
+        "briefing_mode": false,
+        "personality_patterns": []
+      },
+      "rubric": [
+        "Response acknowledges the increased urgency or critical priority of the server migration",
+        "Response does NOT treat this as a routine update with neutral language",
+        "Response does NOT claim the item was created or deleted"
+      ]
+    },
+    {
+      "eval_id": "accuracy-merge-confirmed",
+      "description": "Reasoning consolidated two duplicate things. Response must mention the merge/consolidation.",
+      "input": {
+        "user_message": "those two budget items are the same thing, combine them",
+        "reasoning_summary": "Merged 'Budget review Q2' and 'Q2 budget analysis' into one item. Kept 'Budget review Q2', marked 'Q2 budget analysis' as inactive.",
+        "applied_changes": {
+          "created": [],
+          "updated": [
+            {"id": "thing-bud01", "title": "Budget review Q2", "type_hint": "task", "active": 1},
+            {"id": "thing-bud02", "title": "Q2 budget analysis", "type_hint": "task", "active": 0}
+          ],
+          "deleted": [],
+          "merged": [],
+          "relationships_created": []
+        },
+        "questions_for_user": [],
+        "priority_question": "",
+        "briefing_mode": false,
+        "personality_patterns": []
+      },
+      "rubric": [
+        "Response mentions that items were merged, combined, or consolidated",
+        "Response does NOT say two new items were created",
+        "Response does NOT omit the fact that a merge/consolidation happened"
+      ]
+    }
+  ]
+}

--- a/eval/response_agent/accuracy.test.json
+++ b/eval/response_agent/accuracy.test.json
@@ -87,7 +87,7 @@
         "reasoning_summary": "Updated 'Server migration' importance to critical. Deadline is today.",
         "applied_changes": {
           "created": [],
-          "updated": [{"id": "thing-srv01", "title": "Server migration", "type_hint": "task", "importance": 2, "active": 1}],
+          "updated": [{"id": "thing-srv01", "title": "Server migration", "type_hint": "task", "importance": 0, "active": 1}],
           "deleted": [],
           "merged": [],
           "relationships_created": []
@@ -112,11 +112,12 @@
         "applied_changes": {
           "created": [],
           "updated": [
-            {"id": "thing-bud01", "title": "Budget review Q2", "type_hint": "task", "active": 1},
-            {"id": "thing-bud02", "title": "Q2 budget analysis", "type_hint": "task", "active": 0}
+            {"id": "thing-bud01", "title": "Budget review Q2", "type_hint": "task", "active": 1}
           ],
           "deleted": [],
-          "merged": [],
+          "merged": [
+            {"keep_id": "thing-bud01", "remove_id": "thing-bud02", "keep_title": "Budget review Q2", "remove_title": "Q2 budget analysis"}
+          ],
           "relationships_created": []
         },
         "questions_for_user": [],


### PR DESCRIPTION
## Summary

Completes issue #251 by adding eval coverage for response agent accuracy — the final missing dimension in the response agent eval suite.

The response agent must faithfully reflect what the reasoning agent decided, without hallucinating changes or omitting key information. This PR adds:
- **Golden dataset** (`eval/response_agent/accuracy.test.json`) with 5 test cases covering accuracy scenarios
- **Test function** (`test_response_agent_accuracy()`) in `backend/tests/test_evals.py` to validate accuracy via LLM-as-judge

## Changes

| File | Action | Details |
|------|--------|---------|
| `eval/response_agent/accuracy.test.json` | Created | 5 golden eval cases; follows exact schema of existing response agent test files |
| `backend/tests/test_evals.py` | Updated | Added `test_response_agent_accuracy()` function with threshold=0.7 |

## Test Cases

1. **accuracy-deletion-confirmed** — Deletion reflected; response does not claim creation/update
2. **accuracy-no-changes-no-hallucination** — No changes → no hallucinated changes
3. **accuracy-multi-create-all-mentioned** — Multiple creates all acknowledged
4. **accuracy-importance-update** — Urgency reflected in response tone
5. **accuracy-merge-confirmed** — Merge/consolidation mentioned

## Validation

✅ JSON validation: `eval/response_agent/accuracy.test.json` parses cleanly with 5 eval cases
✅ Type check: `mypy` — no issues in `backend/tests/test_evals.py`
✅ Lint: `ruff check backend/` — 0 errors
✅ Tests: All 1016 tests pass, 84.59% coverage (required: 70%)
✅ Test collection: 4 response agent tests now collected (new accuracy test verified)

## Testing

Standard test suite (1016 tests) passes with no regressions. Eval tests (`test_evals.py`) require `RUN_EVALS=1` and are opt-in by design (require live LLM endpoint).

To run eval tests with API key:
```bash
RUN_EVALS=1 pytest backend/tests/test_evals.py::test_response_agent_accuracy -v
```

Fixes #251