### PR TITLE
Pass context Things to response agent for inline links

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -849,6 +849,7 @@ def _build_response_messages(
     priority_question: str = "",
     briefing_mode: bool = False,
     interaction_style: str = "auto",
+    context_things: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the message list for the response agent (shared by streaming and non-streaming)."""
     context = (
@@ -859,6 +860,11 @@ def _build_response_messages(
         f"Priority question (ask THIS one): {json.dumps(priority_question)}\n\n"
         f"Briefing mode: {json.dumps(briefing_mode)}"
     )
+    if context_things:
+        context += (
+            f"\n\nContext Things (use their IDs for referenced_things): "
+            f"{json.dumps(context_things, default=str)}"
+        )
     if open_questions_by_thing:
         context += (
             f"\n\nOpen questions on Things (knowledge gaps to ask about conversationally):\n"

--- a/backend/pipeline.py
+++ b/backend/pipeline.py
@@ -717,6 +717,7 @@ class ChatPipeline:
                             briefing_mode=briefing_mode,
                             interaction_style=self.interaction_style,
                             user_id=self.user_id,
+                            context_things=relevant_things or None,
                         )
                         reply = response_result.text
                         referenced_things = response_result.referenced_things
@@ -878,6 +879,7 @@ class ChatPipeline:
                             briefing_mode=briefing_mode,
                             interaction_style=self.interaction_style,
                             user_id=self.user_id,
+                            context_things=relevant_things or None,
                         ):
                             reply_parts.append(token)
                             yield PipelineEvent(type="token", data=token)

--- a/backend/response_agent.py
+++ b/backend/response_agent.py
@@ -90,6 +90,7 @@ def _build_user_prompt(
     priority_question: str = "",
     briefing_mode: bool = False,
     interaction_style: str = "auto",
+    context_things: list[dict[str, Any]] | None = None,
 ) -> str:
     """Build the user prompt content for the ADK agent.
 
@@ -106,6 +107,7 @@ def _build_user_prompt(
         priority_question=priority_question,
         briefing_mode=briefing_mode,
         interaction_style=interaction_style,
+        context_things=context_things,
     )
     # The second message (index 1) is the user message with all context
     content: str = messages[1]["content"]
@@ -278,6 +280,7 @@ async def run_response_agent(
     briefing_mode: bool = False,
     interaction_style: str = "auto",
     user_id: str = "",
+    context_things: list[dict[str, Any]] | None = None,
 ) -> ResponseResult:
     """Stage 4: generate friendly user-facing response via ADK LlmAgent.
 
@@ -296,6 +299,7 @@ async def run_response_agent(
         priority_question=priority_question,
         briefing_mode=briefing_mode,
         interaction_style=interaction_style,
+        context_things=context_things,
     )
 
     litellm_model = _make_litellm_model(
@@ -328,6 +332,7 @@ async def run_response_agent_stream(
     briefing_mode: bool = False,
     interaction_style: str = "auto",
     user_id: str = "",
+    context_things: list[dict[str, Any]] | None = None,
 ) -> AsyncIterator[str]:
     """Stage 4 (streaming): yield response tokens as they arrive via ADK LlmAgent."""
     personality_patterns = load_personality_preferences(user_id)
@@ -342,6 +347,7 @@ async def run_response_agent_stream(
         priority_question=priority_question,
         briefing_mode=briefing_mode,
         interaction_style=interaction_style,
+        context_things=context_things,
     )
 
     litellm_model = _make_litellm_model(

--- a/backend/tests/test_chat_pipeline.py
+++ b/backend/tests/test_chat_pipeline.py
@@ -241,6 +241,31 @@ class TestChatPipeline:
         resp = await async_client.post("/api/chat", json={"session_id": "", "message": ""})
         assert resp.status_code == 422
 
+    async def test_context_things_forwarded_to_response_agent(self, async_client):
+        """context_things derived from relevant_things should be forwarded to run_response_agent."""
+        reasoning_with_things = {
+            **MOCK_REASONING_RESULT,
+            "fetched_context": {
+                "things": [{"id": "t-1", "title": "Paris Trip", "type_hint": "travel"}],
+                "relationships": [],
+            },
+        }
+        with patch(
+            "backend.pipeline.run_reasoning_agent",
+            new=AsyncMock(return_value=reasoning_with_things),
+        ), patch(
+            "backend.pipeline.run_response_agent",
+            new=AsyncMock(return_value=ResponseResult(text="ok")),
+        ) as mock_resp:
+            await async_client.post(
+                "/api/chat",
+                json={"session_id": "ctx-sess", "message": "Tell me about my trip"},
+            )
+        call_kwargs = mock_resp.call_args.kwargs
+        assert call_kwargs.get("context_things") == [
+            {"id": "t-1", "title": "Paris Trip", "type_hint": "travel"}
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for _fetch_user_relationships

--- a/backend/tests/test_response_agent.py
+++ b/backend/tests/test_response_agent.py
@@ -113,3 +113,23 @@ class TestBuildUserPrompt:
         assert "Context Things" in result
         assert "thing-abc" in result
         assert "Trip to Paris" in result
+
+    def test_context_things_none_does_not_pollute_prompt(self):
+        result = _build_user_prompt(
+            message="Hello",
+            reasoning_summary="Summary",
+            questions_for_user=[],
+            applied_changes={},
+            context_things=None,
+        )
+        assert "Context Things" not in result
+
+    def test_context_things_empty_list_does_not_pollute_prompt(self):
+        result = _build_user_prompt(
+            message="Hello",
+            reasoning_summary="Summary",
+            questions_for_user=[],
+            applied_changes={},
+            context_things=[],
+        )
+        assert "Context Things" not in result

--- a/backend/tests/test_response_agent.py
+++ b/backend/tests/test_response_agent.py
@@ -101,3 +101,15 @@ class TestBuildUserPrompt:
         )
         assert "Open questions" in result
         assert "What is the deadline?" in result
+
+    def test_with_context_things(self):
+        result = _build_user_prompt(
+            message="How is it?",
+            reasoning_summary="Found Trip",
+            questions_for_user=[],
+            applied_changes={},
+            context_things=[{"id": "thing-abc", "title": "Trip to Paris", "type_hint": "travel"}],
+        )
+        assert "Context Things" in result
+        assert "thing-abc" in result
+        assert "Trip to Paris" in result

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1338,7 +1338,7 @@ def update_preference(
         if not isinstance(item, dict):
             return {"error": f"patterns[{i}] must be a dict"}
         pattern_str = item.get("pattern")
-        if not pattern_str or not isinstance(pattern_str, str) or not pattern_str.strip():
+        if not isinstance(pattern_str, str) or not pattern_str.strip():
             return {"error": f"patterns[{i}].pattern must be a non-empty string"}
         confidence = item.get("confidence")
         if confidence not in _VALID_CONFIDENCE_LEVELS:


### PR DESCRIPTION
## Summary

**Issue**: Fixes #187

Response agent can now produce inline links for Things mentioned in context (read from reasoning), not just Things that were modified. Previously, the agent only had IDs for Things in `applied_changes` (created/updated/deleted), so mentions of context Things appeared as plain text.

This PR threads `context_things` (the list of `{id, title, type_hint}` dicts) through the response agent call chain, making all Thing mentions eligible for clickable links in the frontend.

## Changes

### Backend Changes

| File | Change | Lines |
|------|--------|-------|
| `backend/agents.py` | Add `context_things` parameter to `_build_response_messages()`, include in prompt JSON | +5 |
| `backend/response_agent.py` | Add `context_things` to `_build_user_prompt()`, `run_response_agent()`, `run_response_agent_stream()` | +9 |
| `backend/pipeline.py` | Pass `relevant_things` as `context_things` at both response-agent call sites (stream & non-stream) | +2 |
| `backend/tests/test_response_agent.py` | Add `test_with_context_things` test to verify context Things appear in prompt | +10 |

**Implementation Details**:

- `_build_response_messages()` now includes context Things in the prompt as JSON, allowing the agent to map Thing mentions → `thing_id`
- All three response-agent entry points accept `context_things: list[dict[str, Any]] | None = None` (backwards compatible)
- Pipeline threads `relevant_things or None` at both call sites (~line 706 and ~line 867)
- Test validates that context Things with IDs appear in the user prompt

### No Frontend Changes

The frontend infrastructure is already complete:
- `injectThingLinks()` in ChatPanel already converts `thing://...` URLs to clickable links
- `MessageBubble` already renders `referenced_things` from response agent output

## Validation

### Type Checking
```
✅ No new type errors in task files
   Pre-existing SQLAlchemy errors in pipeline.py unrelated to this task
```

### Unit Tests
```
✅ 1034 tests passed, 0 failed, 14 skipped
   - test_response_agent.py: all tests pass including new test_with_context_things
   - test_chat_pipeline.py: all pipeline integration tests pass
   - test_chat_stream.py: all stream tests pass
```

## Acceptance Criteria

- ✅ `_build_response_messages()` accepts `context_things` and appends to prompt
- ✅ All three response-agent functions accept and forward `context_things`
- ✅ Both pipeline call sites pass `relevant_things` as `context_things`
- ✅ New test `test_with_context_things` passes
- ✅ All existing tests continue to pass (no regressions)

## Testing

Manual testing:
1. Open a chat where context Things are mentioned but not modified
2. Verify Thing names in agent response are clickable (tapping opens Thing detail)
3. Compare behavior with Things that were modified (should already have links) — now both work the same

The new parameter is backwards compatible — all existing callers work unchanged.

Fixes #187