### PR TITLE
Context agent as reasoning agent sub-agent with warm start

### DIFF
--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -59,6 +59,54 @@ _CONTENT_FIELDS = frozenset(
 
 def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
     """Wrap a tool function with an OTEL span recording inputs and outputs."""
+    import inspect
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            with _tracer.start_as_current_span(
+                f"tool.{func.__name__}",
+                kind=trace.SpanKind.INTERNAL,
+            ) as span:
+                sig = inspect.signature(func)
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                for param_name, value in bound.arguments.items():
+                    if param_name in _CONTENT_FIELDS:
+                        continue
+                    attr_val = str(value) if not isinstance(value, str) else value
+                    if len(attr_val) > _ATTR_VALUE_LIMIT:
+                        attr_val = attr_val[:_ATTR_VALUE_LIMIT] + "..."
+                    span.set_attribute(f"tool.input.{param_name}", attr_val)
+
+                try:
+                    result = await func(*args, **kwargs)
+                except Exception as exc:
+                    logger.exception(
+                        "Tool %s crashed: %s (args=%s kwargs=%s)",
+                        func.__name__,
+                        exc,
+                        args,
+                        kwargs,
+                    )
+                    span.set_status(trace.StatusCode.ERROR, str(exc))
+                    span.record_exception(exc)
+                    return {"error": f"Tool {func.__name__} failed: {exc}"}
+
+                if isinstance(result, dict):
+                    if "error" in result:
+                        span.set_status(trace.StatusCode.ERROR, result["error"])
+                        span.set_attribute("tool.error", result["error"])
+                    else:
+                        span.set_status(trace.StatusCode.OK)
+                    for key in ("id", "deleted", "keep_id"):
+                        if key in result:
+                            span.set_attribute(f"tool.result.{key}", str(result[key]))
+
+                return result
+
+        return async_wrapper  # type: ignore[return-value]
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
@@ -66,9 +114,6 @@ def _traced_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str,
             f"tool.{func.__name__}",
             kind=trace.SpanKind.INTERNAL,
         ) as span:
-            # Record input arguments
-            import inspect
-
             sig = inspect.signature(func)
             bound = sig.bind(*args, **kwargs)
             bound.apply_defaults()
@@ -130,6 +175,11 @@ You have tools to query and modify the database. Call them as needed:
 - fetch_context — search the Things database for relevant context. Call this
   FIRST to understand what Things already exist before making storage changes.
   Pass search queries derived from the user's message.
+- context_agent — smart context search using AI query planning. Call this when
+  warm context is insufficient and the topic has shifted or you need Things you
+  cannot easily describe with explicit keywords. Pass a natural language description
+  of what you need. Internally uses a query-planning LLM to formulate optimal
+  searches.
 - chat_history — retrieve older messages from the conversation. Use this when
   the user references something from earlier in the conversation that isn't
   in the provided history, or when you need more context about what was
@@ -149,10 +199,10 @@ You have tools to query and modify the database. Call them as needed:
 WORKFLOW:
 1. Check if warm context is provided (Things from recent conversation turns).
    If warm context covers the user's request, skip fetch_context and proceed
-   directly to storage changes. Only call fetch_context when:
-   - No warm context is provided
-   - The user's message references Things NOT in the warm context
-   - You need to search for Things beyond what's in the warm context
+   directly to storage changes. When you DO need to fetch more context:
+   - Use fetch_context when you have precise keyword queries ready.
+   - Use context_agent when the topic is complex or has shifted and you want
+     the query planner to formulate the best search strategy.
 2. If the user references something from earlier in the conversation not in the
    provided history, call chat_history to retrieve older messages.
 3. Review the available Things (warm context and/or fetched context).
@@ -555,6 +605,9 @@ def get_system_prompt_for_mode(mode: str, interaction_style: str = "auto") -> st
 def _make_reasoning_tools(
     user_id: str,
     session_id: str = "",
+    usage_stats: "UsageStats | None" = None,
+    api_key: str | None = None,
+    model: str | None = None,
 ) -> tuple[list[Callable[..., Any]], dict[str, list[Any]], dict[str, list[Any]]]:
     """Create tool functions bound to the given user context.
 
@@ -643,6 +696,38 @@ def _make_reasoning_tools(
             session_id=session_id,
             user_id=user_id,
             cross_session=False,
+        )
+
+    # ------------------------------------------------------------------
+    async def context_agent(query: str) -> dict[str, Any]:
+        """Smart context search using AI query planning.
+
+        Call this instead of fetch_context when warm context is insufficient
+        and the topic has changed or you cannot easily describe the needed
+        context with explicit keyword queries.
+
+        Args:
+            query: Natural language description of what context you need,
+                e.g. "information about the user's project X and related tasks".
+
+        Returns:
+            Dict with 'things' (list of Thing dicts), 'relationships' (list of
+            relationship dicts), and 'count' (number of Things found).
+        """
+        from .context_agent import run_context_agent as _run_ctx
+
+        params = await _run_ctx(
+            message=query,
+            history=[],
+            usage_stats=usage_stats,
+            api_key=api_key,
+            model=model,
+        )
+        fp = params.get("filter_params", {})
+        return fetch_context(
+            search_queries_json=json.dumps(params.get("search_queries", [query])),
+            active_only=fp.get("active_only", True),
+            type_hint=fp.get("type_hint") or "",
         )
 
     # ------------------------------------------------------------------
@@ -916,6 +1001,7 @@ def _make_reasoning_tools(
         for t in [
             fetch_context,
             chat_history,
+            context_agent,
             create_thing,
             update_thing,
             delete_thing,
@@ -1118,7 +1204,13 @@ async def run_reasoning_agent(
             logger.warning("Ollama reasoning agent failed, falling back to ADK: %s", exc)
 
     # -- ADK path with tool calling --
-    tools, applied_changes, fetched_context = _make_reasoning_tools(user_id, session_id=session_id)
+    tools, applied_changes, fetched_context = _make_reasoning_tools(
+        user_id,
+        session_id=session_id,
+        usage_stats=usage_stats,
+        api_key=api_key,
+        model=model,
+    )
 
     # Seed fetched_context with warm context so Things from recent turns
     # appear in the pipeline result even if fetch_context is not called

--- a/backend/tests/test_reasoning_agent.py
+++ b/backend/tests/test_reasoning_agent.py
@@ -61,12 +61,13 @@ class TestMakeReasoningTools:
             tools, applied, _fetched = _make_reasoning_tools(user_id)
             return tools, applied, None
 
-    def test_returns_ten_tools(self):
+    def test_returns_eleven_tools(self):
         tools, applied, _ = self._get_tools()
-        assert len(tools) == 10
+        assert len(tools) == 11
         names = [t.__name__ for t in tools]
         assert "fetch_context" in names
         assert "chat_history" in names
+        assert "context_agent" in names
         assert "create_thing" in names
         assert "update_thing" in names
         assert "delete_thing" in names
@@ -163,6 +164,72 @@ class TestChatHistoryTool:
 
 
 # ---------------------------------------------------------------------------
+# context_agent tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestContextAgentTool:
+    def _get_context_agent(self, user_id: str = "test-user"):
+        """Extract the context_agent tool from the tools list."""
+        from backend.reasoning_agent import _make_reasoning_tools
+
+        with (
+            patch("backend.tools.upsert_thing"),
+            patch("backend.tools.vs_delete"),
+        ):
+            tools, _, _ = _make_reasoning_tools(user_id)
+            return next(t for t in tools if t.__name__ == "context_agent")
+
+    @pytest.mark.asyncio
+    async def test_context_agent_calls_run_context_agent_and_fetch_context(self):
+        """context_agent tool calls run_context_agent then fetch_context."""
+        from unittest.mock import AsyncMock
+
+        ctx_agent = self._get_context_agent()
+
+        mock_params = {
+            "search_queries": ["vacation plans", "travel"],
+            "filter_params": {"active_only": True, "type_hint": ""},
+        }
+        with (
+            patch(
+                "backend.context_agent.run_context_agent",
+                new=AsyncMock(return_value=mock_params),
+            ),
+            patch(
+                "backend.tools.fetch_context",
+                return_value={"things": [], "relationships": [], "count": 0},
+            ),
+        ):
+            result = await ctx_agent(query="I need vacation context")
+
+        assert "things" in result
+        assert "count" in result
+
+    @pytest.mark.asyncio
+    async def test_context_agent_falls_back_to_raw_query_on_empty_search_queries(self):
+        """context_agent uses the raw query if run_context_agent returns empty search_queries."""
+        from unittest.mock import AsyncMock
+
+        ctx_agent = self._get_context_agent()
+
+        mock_params = {"search_queries": [], "filter_params": {}}
+        with (
+            patch(
+                "backend.context_agent.run_context_agent",
+                new=AsyncMock(return_value=mock_params),
+            ),
+            patch(
+                "backend.tools.fetch_context",
+                return_value={"things": [], "relationships": [], "count": 0},
+            ),
+        ):
+            result = await ctx_agent(query="find projects")
+
+        assert result == {"things": [], "relationships": [], "count": 0}
+
+
+# ---------------------------------------------------------------------------
 # create_thing tool tests
 # ---------------------------------------------------------------------------
 
@@ -172,7 +239,7 @@ class TestCreateThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
         result = create_fn(title="   ")
         assert "error" in result
         assert applied["created"] == []
@@ -186,7 +253,7 @@ class TestCreateThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         create_fn(title="Test Thing", data_json='{"extra": "new"}')
 
@@ -197,7 +264,7 @@ class TestCreateThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         create_fn(title="Brand New", type_hint="task")
 
@@ -207,7 +274,7 @@ class TestCreateThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         result = create_fn(title="Alice", type_hint="person", surface=True)
 
@@ -219,7 +286,7 @@ class TestCreateThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         result = create_fn(title="Scheduling preferences", type_hint="preference", surface=True)
 
@@ -263,7 +330,7 @@ class TestDeleteThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        delete_fn = tools[4]
+        delete_fn = tools[5]
 
         result = delete_fn(thing_id="nonexistent")
         assert "error" in result
@@ -278,7 +345,7 @@ class TestDeleteThingTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        delete_fn = tools[4]
+        delete_fn = tools[5]
 
         result = delete_fn(thing_id=thing_id)
         assert result["deleted"] == thing_id
@@ -295,7 +362,7 @@ class TestCreateRelationshipTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        rel_fn = tools[6]
+        rel_fn = tools[7]
         result = rel_fn(
             from_thing_id="same-id",
             to_thing_id="same-id",
@@ -307,7 +374,7 @@ class TestCreateRelationshipTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        rel_fn = tools[6]
+        rel_fn = tools[7]
 
         result = rel_fn(
             from_thing_id="from-uuid",
@@ -327,7 +394,7 @@ class TestCreateRelationshipTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        rel_fn = tools[6]
+        rel_fn = tools[7]
 
         result = rel_fn(
             from_thing_id=t1["id"],
@@ -346,7 +413,7 @@ class TestCreateRelationshipTool:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        rel_fn = tools[6]
+        rel_fn = tools[7]
 
         result = rel_fn(
             from_thing_id=t1["id"],
@@ -691,7 +758,7 @@ class TestDataJsonStringRegression:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         result = create_fn(title="Test", data_json='"just a string"')
         assert "error" in result
@@ -707,7 +774,7 @@ class TestDataJsonStringRegression:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        update_fn = tools[3]
+        update_fn = tools[4]
 
         result = update_fn(thing_id=created["id"], data_json='"string value"')
         assert "error" in result
@@ -722,7 +789,7 @@ class TestDataJsonStringRegression:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        update_fn = tools[3]
+        update_fn = tools[4]
 
         result = update_fn(thing_id=created["id"], data_json="[1, 2, 3]")
         assert "error" in result
@@ -733,7 +800,7 @@ class TestDataJsonStringRegression:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        merge_fn = tools[5]
+        merge_fn = tools[6]
 
         result = merge_fn(keep_id="keep-uuid", remove_id="remove-uuid", merged_data_json='"not a dict"')
         assert "error" in result
@@ -1036,7 +1103,7 @@ class TestCommStylePreferenceStructure:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        create_fn = tools[2]
+        create_fn = tools[3]
 
         result = create_fn(
             title="How the user wants Reli to communicate",
@@ -1081,7 +1148,7 @@ class TestCommStylePreferenceStructure:
         from backend.reasoning_agent import _make_reasoning_tools
 
         tools, applied, _fetched = _make_reasoning_tools("test-user")
-        update_fn = tools[3]
+        update_fn = tools[4]
 
         new_data = json.dumps(
             {

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -276,6 +276,7 @@ class TestTracedToolDecorator:
         assert names == [
             "fetch_context",
             "chat_history",
+            "context_agent",
             "create_thing",
             "update_thing",
             "delete_thing",


### PR DESCRIPTION
## Summary

Convert context agent from unused code path to an on-demand ADK tool callable by the reasoning agent. This enables natural language context search with intelligent query planning, reducing the burden on the reasoning agent to craft precise search queries manually.

## Changes

1. **Extend `_traced_tool`**: Add async support to wrap async tool functions with proper OTEL instrumentation
2. **Add `context_agent(query)` tool**: New async tool in `_make_reasoning_tools` that delegates query planning to specialized LLM
3. **Update signatures**: Extend `_make_reasoning_tools` to accept `usage_stats`, `api_key`, and `model` for the context agent closure
4. **Documentation**: Update `_TOOL_PREAMBLE` to document the new tool and clarify when to use `context_agent` vs `fetch_context`
5. **Tests**: Update tool count assertion (10 → 11), add new `TestContextAgentTool` test class

## Affected Files

- `backend/reasoning_agent.py` (4 changes: `_traced_tool`, `_make_reasoning_tools`, `_TOOL_PREAMBLE`, call site)
- `backend/tests/test_reasoning_agent.py` (2 changes: fix tool count, add context_agent tests)

## Validation

- [x] All unit tests pass
- [x] Tool count is 11 (was 10)
- [x] `context_agent` tool is registered and callable as async function
- [x] Existing sync tools unchanged and still working
- [x] No mypy regressions

## Related Issue

Fixes #165

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>