### PR TITLE
Fix: Move OAUTHLIB_RELAX_TOKEN_SCOPE to docker-compose env

### DIFF
--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -81,9 +80,6 @@ def exchange_code(code: str, state: str = "", user_id: str = "") -> Credentials:
         code_verifier = None
     if code_verifier:
         flow.code_verifier = code_verifier
-
-    # Google returns scopes in expanded URI form; tell oauthlib to accept it
-    os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
 
     flow.fetch_token(code=code)
     creds: Credentials = flow.credentials

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -210,11 +210,6 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state.")
     flow.code_verifier = code_verifier
 
-    # Google returns scopes in expanded URI form; tell oauthlib to accept it
-    import os as _os
-
-    _os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
-
     try:
         flow.fetch_token(code=code)
     except Exception:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -32,4 +32,5 @@ services:
       - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-reli-staging}
       - DATABASE_URL=${DATABASE_URL:-}
+      - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-reli}
       - DATABASE_URL=${DATABASE_URL:-}
+      - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     restart: unless-stopped
 
   phoenix:


### PR DESCRIPTION
## Summary

Move `OAUTHLIB_RELAX_TOKEN_SCOPE=1` configuration from runtime `os.environ` mutations in request handlers to static environment configuration in docker-compose files. This eliminates global-state mutation in request handlers and centralizes infrastructure config where it belongs.

## Changes

**Files Modified:**
- `docker-compose.yml` — added `OAUTHLIB_RELAX_TOKEN_SCOPE=1` to reli service environment
- `docker-compose.staging.yml` — added same env var for parity
- `backend/routers/auth.py` — removed lines 213–216 (comment + `import os as _os` + environ mutation)
- `backend/google_calendar.py` — removed line 5 (`import os`) and lines 85–86 (comment + environ mutation)

## Problem Fixed

The env var was being set inside OAuth callback handlers (`google_callback()` in auth.py and `_exchange_code()` in google_calendar.py), causing:
- Global state mutation on every OAuth token exchange (non-idempotent side effect)
- Value never gets unset (leaks across all subsequent requests in process)
- Runtime config mixed into application code instead of infrastructure config

## Validation

✅ Static analysis: Zero `OAUTHLIB_RELAX_TOKEN_SCOPE` occurrences in Python files
✅ Import cleanup: No unused `os` imports remain in modified files
✅ Syntax check: Both modified Python files compile cleanly
✅ Environment vars: Exactly 2 occurrences in compose files (one per file)

**No functional breakage** — env var is set at container startup instead of first request, semantically equivalent but without request-handler side effects.

Fixes #945