### PR TITLE
Move OAUTHLIB_RELAX_TOKEN_SCOPE to startup

### DIFF
--- a/backend/google_calendar.py
+++ b/backend/google_calendar.py
@@ -82,9 +82,6 @@ def exchange_code(code: str, state: str = "", user_id: str = "") -> Credentials:
     if code_verifier:
         flow.code_verifier = code_verifier
 
-    # Google returns scopes in expanded URI form; tell oauthlib to accept it
-    os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
-
     flow.fetch_token(code=code)
     creds: Credentials = flow.credentials
     _save_credentials(creds, user_id=user_id)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,13 @@
 """Reli FastAPI application entry point."""
 
 import logging
+import os
 import pathlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+
+# Google OAuth returns scopes in expanded URI form; set once at startup.
+os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
 
 import httpx
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -210,11 +210,6 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state.")
     flow.code_verifier = code_verifier
 
-    # Google returns scopes in expanded URI form; tell oauthlib to accept it
-    import os as _os
-
-    _os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
-
     try:
         flow.fetch_token(code=code)
     except Exception:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-reli}
       - DATABASE_URL=${DATABASE_URL:-}
+      - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     restart: unless-stopped
 
   phoenix:


### PR DESCRIPTION
## Summary

Move the `OAUTHLIB_RELAX_TOKEN_SCOPE` environment variable configuration from runtime handlers to process startup, following best practices for environment configuration.

## Changes

- **backend/main.py**: Added `os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")` at startup
- **backend/routers/auth.py**: Removed inline `import os as _os` and `os.environ[...] = "1"` mutation
- **backend/google_calendar.py**: Removed inline `os.environ[...] = "1"` mutation  
- **docker-compose.yml**: Added explicit `OAUTHLIB_RELAX_TOKEN_SCOPE=1` env var

## Validation

All acceptance criteria met:
- ✅ OAUTHLIB removed from handler files (auth.py, google_calendar.py)
- ✅ OAUTHLIB set in main.py via `os.environ.setdefault()`
- ✅ OAUTHLIB configured in docker-compose.yml
- ✅ No inline imports (`import os as _os`) in auth.py
- ✅ `os` import preserved in google_calendar.py where needed

Test results:
- ✅ Python syntax: all modified files parse cleanly
- ✅ Tests: 382 passed, 0 failed
- ✅ Build: compiled successfully

Fixes #945