### PR TITLE
Fix: move OAUTHLIB_RELAX_TOKEN_SCOPE to startup config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN UV_SYSTEM_PYTHON=1 uv sync --frozen --no-dev
 # Add the virtualenv created by uv sync to PATH so uvicorn and python
 # resolve to the venv's binaries rather than the (empty) system install.
 ENV PATH="/app/.venv/bin:$PATH"
+ENV OAUTHLIB_RELAX_TOKEN_SCOPE=1
 
 # Copy config
 COPY config.yaml ./config.yaml

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -210,11 +210,6 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
         raise HTTPException(status_code=400, detail="Invalid or expired OAuth state.")
     flow.code_verifier = code_verifier
 
-    # Google returns scopes in expanded URI form; tell oauthlib to accept it
-    import os as _os
-
-    _os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
-
     try:
         flow.fetch_token(code=code)
     except Exception:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -32,4 +32,5 @@ services:
       - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-reli-staging}
       - DATABASE_URL=${DATABASE_URL:-}
+      - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - PHOENIX_ENDPOINT=${PHOENIX_ENDPOINT:-http://phoenix:6006/v1/traces}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-reli}
       - DATABASE_URL=${DATABASE_URL:-}
+      - OAUTHLIB_RELAX_TOKEN_SCOPE=1
     restart: unless-stopped
 
   phoenix:


### PR DESCRIPTION
## Summary

Move `OAUTHLIB_RELAX_TOKEN_SCOPE` from runtime mutation in request handlers to static startup configuration. This fixes SEC-037 (environment variable configuration hygiene).

**Problem**: The environment variable was being mutated at runtime inside the OAuth callback handler (`backend/routers/auth.py:216`) on every request, rather than set once at container startup.

**Solution**: Declare `OAUTHLIB_RELAX_TOKEN_SCOPE=1` as a static ENV in the Dockerfile and in docker-compose configurations. Remove the runtime mutation from auth.py.

## Changes

- `backend/routers/auth.py`: Removed runtime `os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"` mutation (lines 213-216)
- `Dockerfile`: Added `ENV OAUTHLIB_RELAX_TOKEN_SCOPE=1`
- `docker-compose.yml`: Added `- OAUTHLIB_RELAX_TOKEN_SCOPE=1` to environment section
- `docker-compose.staging.yml`: Added `- OAUTHLIB_RELAX_TOKEN_SCOPE=1` to environment section

## Validation

✅ All Python lint checks pass (ruff)
✅ All backend tests pass (1039 passed, 14 skipped)
✅ All frontend tests pass (382 passed)
✅ Frontend builds successfully
✅ `OAUTHLIB_RELAX_TOKEN_SCOPE` properly removed from auth.py
✅ `OAUTHLIB_RELAX_TOKEN_SCOPE=1` correctly set in all configuration files
✅ `flow.fetch_token(code=code)` still present and unmodified

Pre-existing issues in unrelated files (Python format, mypy, frontend lint) are outside the scope of this bead and are not addressed.

Fixes #945
