### PR TITLE
Fix: Add ADK auto-instrumentation for Phoenix tracing

### DIFF
--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -47,6 +47,10 @@ def init_tracing() -> None:
         provider.add_span_processor(BatchSpanProcessor(exporter))
         trace.set_tracer_provider(provider)
         _initialized = True
+
+        from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+        GoogleADKInstrumentor().instrument()
+
         logger.info(
             "OTEL tracing initialized — exporting to %s (service: %s)",
             settings.PHOENIX_ENDPOINT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "opentelemetry-exporter-otlp-proto-http>=1.41.1",
+    "openinference-instrumentation-google-adk>=0.1.0",
     "supabase>=2.0.0",
     "sqlmodel>=0.0.22",
     "alembic>=1.13.0",


### PR DESCRIPTION
## Summary

Implements the missing Task 3 from issue #250: add  dependency and enable it in the tracing initialization.

This auto-instruments Google ADK `LlmAgent` calls to emit OpenInference-format spans, capturing:
- Full prompt and completion text
- Model names and token counts
- Per-request latency and metadata

Without this, Phoenix traces showed only outer pipeline/stage/tool spans but had no visibility into ADK's internal LLM calls.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `openinference-instrumentation-google-adk>=0.1.0` dependency |
| `backend/tracing.py` | Call `GoogleADKInstrumentor().instrument()` inside `init_tracing()` after provider setup |

## Testing

- ✅ Syntax check: `backend/tracing.py` compiles cleanly
- ✅ Package import: `GoogleADKInstrumentor` imports successfully
- ✅ Test suite: all 14 tests in `test_tracing.py` pass

Fixes #250