### PR TITLE
Fix: Enable ADK auto-instrumentation for Phoenix tracing

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
 opentelemetry-exporter-otlp-proto-http>=1.41.1
+openinference-instrumentation-google-adk>=0.1.0
 supabase>=2.0.0
 sqlmodel>=0.0.22
 alembic>=1.13.0

--- a/backend/tests/test_tracing.py
+++ b/backend/tests/test_tracing.py
@@ -58,6 +58,55 @@ def test_init_tracing_configures_provider_when_enabled():
             assert backend.tracing._initialized is True
 
 
+def test_init_tracing_calls_adk_instrumentor_when_enabled():
+    """init_tracing should activate GoogleADKInstrumentor when PHOENIX_ENABLED=true."""
+    with patch("backend.tracing.settings") as mock_settings:
+        mock_settings.phoenix_enabled_bool = True
+        mock_settings.PHOENIX_ENDPOINT = "http://localhost:6006/v1/traces"
+        mock_settings.OTEL_SERVICE_NAME = "reli-test"
+
+        mock_instrumentor = MagicMock()
+
+        with (
+            patch("opentelemetry.sdk.trace.TracerProvider", return_value=MagicMock()),
+            patch(
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "opentelemetry.sdk.trace.export.BatchSpanProcessor",
+                return_value=MagicMock(),
+            ),
+            patch("opentelemetry.trace.set_tracer_provider"),
+            patch(
+                "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
+                return_value=mock_instrumentor,
+            ),
+        ):
+            import backend.tracing
+
+            backend.tracing._initialized = False
+            backend.tracing.init_tracing()
+
+        mock_instrumentor.instrument.assert_called_once()
+
+
+def test_init_tracing_does_not_call_adk_instrumentor_when_disabled():
+    """GoogleADKInstrumentor must not be called when PHOENIX_ENABLED=false."""
+    with patch("backend.tracing.settings") as mock_settings:
+        mock_settings.phoenix_enabled_bool = False
+
+        with patch(
+            "openinference.instrumentation.google_adk.GoogleADKInstrumentor"
+        ) as mock_cls:
+            import backend.tracing
+
+            backend.tracing._initialized = False
+            backend.tracing.init_tracing()
+
+        mock_cls.assert_not_called()
+
+
 def test_shutdown_tracing_flushes_provider():
     """shutdown_tracing should call shutdown on the tracer provider."""
     import backend.tracing

--- a/backend/tracing.py
+++ b/backend/tracing.py
@@ -46,6 +46,11 @@ def init_tracing() -> None:
         exporter = OTLPSpanExporter(endpoint=settings.PHOENIX_ENDPOINT)
         provider.add_span_processor(BatchSpanProcessor(exporter))
         trace.set_tracer_provider(provider)
+
+        from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+
+        GoogleADKInstrumentor().instrument()
+
         _initialized = True
         logger.info(
             "OTEL tracing initialized — exporting to %s (service: %s)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "opentelemetry-exporter-otlp-proto-http>=1.41.1",
+    "openinference-instrumentation-google-adk>=0.1.0",
     "supabase>=2.0.0",
     "sqlmodel>=0.0.22",
     "alembic>=1.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2996,6 +2996,24 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation-google-adk"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ae/a1abf77d606515c3610d030bf5a4a6831b23ffd215b38f85f9201192855d/openinference_instrumentation_google_adk-0.1.13.tar.gz", hash = "sha256:026255bc683204bec00e7439c21f61ac21141f492e00948439c3bb85942c1f0d", size = 14499, upload-time = "2026-05-14T19:29:19.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/be/76bf335747fc00a00edf43986c39504d23b24bf95d6761d0b30636cb344c/openinference_instrumentation_google_adk-0.1.13-py3-none-any.whl", hash = "sha256:68e5995c3b5152d9622a517bdbc147899d6cf348aabc59a725aba85a08c6c7e8", size = 16443, upload-time = "2026-05-14T19:29:16.267Z" },
+]
+
+[[package]]
 name = "openinference-instrumentation-openai"
 version = "0.1.48"
 source = { registry = "https://pypi.org/simple" }
@@ -4392,6 +4410,7 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "openinference-instrumentation-google-adk" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -4435,6 +4454,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.80.0" },
     { name = "mcp", specifier = ">=1.27.1" },
     { name = "openai", specifier = ">=1.30.0" },
+    { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.41.1" },


### PR DESCRIPTION
## Summary

Enable ADK auto-instrumentation for Phoenix tracing to make LLM calls visible as distinct spans in the Phoenix UI. This completes issue #250 by calling `GoogleADKInstrumentor().instrument()` during tracing startup so every ADK LLM invocation becomes a visible span with prompt, completion, model name, and token count information.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `pyproject.toml` | Add `openinference-instrumentation-google-adk>=0.1.0` dependency | +1 |
| `backend/requirements.txt` | Mirror dependency for Docker image | +1 |
| `backend/tracing.py` | Call `GoogleADKInstrumentor().instrument()` in `init_tracing()` | +4 |
| `backend/tests/test_tracing.py` | Add tests for ADK instrumentor activation | +50 |

## Details

### What's new in the Phoenix UI

**Before**: Custom spans only (`reli.pipeline`, `reli.stage.reasoning`, `reli.stage.response`, tool spans) — no LLM-level visibility  
**After**: ADK LLM spans now appear as children of stage spans, showing:
- Model name (e.g., `gemini-2.5-*`)
- Input/output token counts
- Prompt and completion text
- Latency per LLM call

### Implementation

- Added `openinference-instrumentation-google-adk>=0.1.0` to `pyproject.toml` and `requirements.txt` so the package is available in the Docker image
- Inside `backend/tracing.py::init_tracing()`, after `trace.set_tracer_provider(provider)`, added:
  ```python
  from openinference.instrumentation.google_adk import GoogleADKInstrumentor
  GoogleADKInstrumentor().instrument()
  ```
- Added two new tests in `backend/tests/test_tracing.py`:
  - `test_init_tracing_calls_adk_instrumentor_when_enabled`: Verifies the instrumentor is called when Phoenix is enabled
  - `test_init_tracing_does_not_call_adk_instrumentor_when_disabled`: Verifies it's skipped when disabled

## Validation

✅ **Ruff lint**: All checks passed  
✅ **Mypy type check**: No issues found  
✅ **Unit tests**: 16 passed in `test_tracing.py` (includes 2 new ADK tests)  
✅ **Extended tests**: 45 passed across `test_tracing.py`, `test_config.py`, and `test_sentry.py`  

All new tests pass, and existing tests remain unaffected.

## Related Issue

Fixes #250

## Testing

To verify the changes locally:
```bash
# Run lint and type checks
uv run ruff check backend/tracing.py backend/tests/test_tracing.py
uv run mypy backend/tracing.py

# Run unit tests
uv run python -m pytest backend/tests/test_tracing.py -v
```