### PR TITLE
Fix: expose context-refinement-agent as MCP prompt resource

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -597,6 +597,20 @@ def response_agent_prompt() -> str:
 
 
 @mcp.prompt(
+    name="context-refinement-agent",
+    description=(
+        "The Reli context refinement agent's full system prompt. Adopt this persona "
+        "to decide whether enough context has been retrieved or if additional searches "
+        "are needed. Used as a continuation step after context-agent. "
+        "Designed for use with the fetch_context tool (read-only)."
+    ),
+)
+def context_refinement_agent_prompt() -> str:
+    """Reli context refinement agent — decides if more context searches are needed."""
+    return _load_prompt("context-refinement-agent")
+
+
+@mcp.prompt(
     name="thing-schema",
     description=(
         "Complete reference for the Reli Thing data model: all fields, valid values, "


### PR DESCRIPTION
## Summary

Expose the context-refinement-agent as an MCP prompt resource by registering it with the `@mcp.prompt` decorator in the MCP server. This allows MCP clients to discover and use the context-refinement-agent prompt through the standard MCP prompt registry.

## Changes

- **backend/mcp_server.py**: Added `@mcp.prompt` registration for `context-refinement-agent`
  - Follows the existing pattern used for `context-agent`, `reasoning-agent`, and `response-agent`
  - Inserted in logical order after `response-agent`
  - Prompt provides the read-only `fetch_context` tool

## Validation

- ✅ Syntax check: No errors
- ✅ Import check: Imports without error
- ✅ Prompt registry: `context-refinement-agent` confirmed in `mcp._prompt_manager.list_prompts()`
- ✅ Backend tests: 1039 passed, 14 skipped
- ✅ Frontend tests: 382 passed
- ✅ Frontend build: Successful

All 5 prompts now registered: context-agent, reasoning-agent, response-agent, context-refinement-agent, thing-schema

Fixes #323