### PR TITLE
Fix ValueError crash in _urgency_sort_key for Check-in detail strings

### DIFF
--- a/backend/tests/test_weekly_briefing.py
+++ b/backend/tests/test_weekly_briefing.py
@@ -1,0 +1,45 @@
+"""Tests for weekly_briefing helpers."""
+
+import pytest
+
+from backend.models import WeeklyBriefingItem
+from backend.weekly_briefing import _urgency_sort_key
+
+
+def _make_item(detail: str | None = None) -> WeeklyBriefingItem:
+    return WeeklyBriefingItem(thing_id="t1", title="X", detail=detail)
+
+
+class TestUrgencySortKey:
+    """Verify _urgency_sort_key handles all detail string formats without crashing."""
+
+    @pytest.mark.parametrize(
+        "detail,expected",
+        [
+            ("Check-in due today", 0),
+            ("Deadline today", 0),
+            ("Deadline in 1d", 1),
+            ("Deadline in 3d", 3),
+            ("Birthday in 7d", 7),
+            ("Check-in in 3d", 3),
+            ("Check-in tomorrow", 1),  # regression: contains "in " but is not urgency pattern
+            ("Check-in due tomorrow", 1),
+            (None, 1),
+        ],
+    )
+    def test_sort_key_values(self, detail: str | None, expected: int):
+        assert _urgency_sort_key(_make_item(detail)) == expected
+
+    def test_sort_order(self):
+        """Items sort: today first, then by ascending days, then default last."""
+        items = [
+            _make_item("Birthday in 5d"),
+            _make_item("Deadline in 2d"),
+            _make_item("Check-in due today"),
+        ]
+        items.sort(key=_urgency_sort_key)
+        assert [i.detail for i in items] == [
+            "Check-in due today",
+            "Deadline in 2d",
+            "Birthday in 5d",
+        ]

--- a/backend/weekly_briefing.py
+++ b/backend/weekly_briefing.py
@@ -276,8 +276,10 @@ def generate_weekly_briefing(
     def _urgency_sort_key(item: WeeklyBriefingItem) -> int:
         if item.detail and "today" in item.detail:
             return 0
-        if item.detail and "in " in item.detail:
-            return int(item.detail.split("in ")[1].rstrip("d"))
+        if item.detail:
+            m = re.search(r" in (\d+)d$", item.detail)
+            if m:
+                return int(m.group(1))
         return 1
 
     upcoming.sort(key=_urgency_sort_key)

--- a/backend/weekly_briefing.py
+++ b/backend/weekly_briefing.py
@@ -62,6 +62,17 @@ def _parse_date(value: object) -> date | None:
     return None
 
 
+def _urgency_sort_key(item: WeeklyBriefingItem) -> int:
+    """Sort key for upcoming items: today=0, 'in Xd'=X, everything else=1."""
+    if item.detail and "today" in item.detail:
+        return 0
+    if item.detail:
+        m = re.search(r" in (\d+)d$", item.detail)
+        if m:
+            return int(m.group(1))
+    return 1
+
+
 def _days_until_recurring(target: date, today: date) -> int:
     this_year = today.replace(month=target.month, day=target.day)
     if this_year >= today:
@@ -272,15 +283,6 @@ def generate_weekly_briefing(
     # Build preferences learned
     for rec in pref_rows:
         preferences_learned.append(rec.title)
-
-    def _urgency_sort_key(item: WeeklyBriefingItem) -> int:
-        if item.detail and "today" in item.detail:
-            return 0
-        if item.detail:
-            m = re.search(r" in (\d+)d$", item.detail)
-            if m:
-                return int(m.group(1))
-        return 1
 
     upcoming.sort(key=_urgency_sort_key)
 


### PR DESCRIPTION
## Summary

- Fixes a `ValueError: invalid literal for int() with base 10: ''` in `backend/weekly_briefing.py` that crashes the `/weekly-briefing` endpoint (Sentry issue RELI-ZO-1X)
- Root cause: `_urgency_sort_key` used `str.split("in ")[1]` which fails when the detail contains the substring `"in "` — specifically "Check-in in Nd" yields `""` at index 1, and "Check-in tomorrow" would yield `"tomorrow"`
- Fix: replace the split-based parse with `re.search(r" in (\d+)d$", detail)` that anchors to the trailing day-count pattern

## Test plan

- [ ] Run `uv run pytest backend/tests/ -k weekly_briefing -v` to confirm no regressions
- [ ] Manually trigger `/weekly-briefing` endpoint; verify no 500 errors for users who have Check-in Things with upcoming dates

Fixes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)