### PR TITLE
Fix: Add positive engagement signal detection for personality backprop

### DIFF
--- a/backend/preference_sweep.py
+++ b/backend/preference_sweep.py
@@ -451,7 +451,14 @@ Look for:
 - User says "simpler", "shorter", "brief", "quick", "tldr" in a follow-up
 - User appears to be correcting Reli's response length or style
 
-For each detected pattern, describe it briefly (e.g., "avoids emoji",
+**Positive engagement signals** (reinforce existing patterns):
+- User expresses satisfaction after Reli's response: "thanks", "perfect", "exactly",
+  "that's helpful", "great", "love it", "exactly what I needed", "that was clear"
+- These signal the current communication style is appreciated
+- Add matching existing patterns to "reinforced" (the style is working)
+- Do NOT add new patterns from positive signals alone
+
+For each detected correction pattern, describe it briefly (e.g., "avoids emoji",
 "prefers concise responses", "no bullet points").
 
 Also look for contradictions — if the user explicitly reverses a prior preference

--- a/backend/reasoning_agent.py
+++ b/backend/reasoning_agent.py
@@ -418,7 +418,16 @@ feedback about Reli's own behavior.
 - User says "simpler", "shorter", "brief", "quick", "tldr" in a follow-up
 - User appears to be correcting Reli's verbosity or style in their next message
 
-When you detect either type:
+**Positive engagement signals** (reinforce existing patterns only, do NOT create new ones):
+- User expresses satisfaction: "thanks", "perfect", "exactly right", "that's helpful",
+  "great", "love it", "exactly what I needed"
+- These signal the current approach is working — strengthen what already exists
+- ONLY act on positive signals if a reli_communication preference Thing already exists
+- Increment observations on each established/strong pattern (the ones that are working)
+- Do NOT create a new preference Thing from positive signals alone
+- Do NOT add new patterns from positive signals alone
+
+When you detect a correction (explicit or implicit):
 1. Search for an existing `reli_communication` preference Thing via fetch_context
    with search_queries like ["Reli communication style", "how Reli communicates"].
 2. If an existing preference Thing is found (category='reli_communication'), call
@@ -456,6 +465,12 @@ silence — only downgrade if the user explicitly contradicts a prior preference
 Do NOT create a reli_communication preference if:
 - The user is asking about communication in general (not correcting Reli)
 - The message is ambiguous and could be about something else
+
+When you detect a positive engagement signal:
+1. Search for an existing `reli_communication` preference Thing via fetch_context.
+2. If found, call update_thing to increment observations on each established/strong
+   pattern. Do not add new patterns or change confidence levels.
+3. If no preference Thing exists, skip — positive signals don't create new preferences.
 """
 
 REASONING_AGENT_TOOL_SYSTEM = _TOOL_PREAMBLE + _TOOL_RULES + _COMM_STYLE_SIGNAL_RULES

--- a/backend/tests/test_preference_sweep.py
+++ b/backend/tests/test_preference_sweep.py
@@ -689,3 +689,59 @@ class TestAggregateCommunicationStylePatterns:
         assert result.patterns_added == 0
         assert result.patterns_reinforced == 0
         assert result.patterns_removed == 0
+
+    @pytest.mark.asyncio
+    async def test_positive_engagement_reinforces_existing_patterns(self, patched_db, db):
+        """Positive signals ('thanks', 'perfect') reinforce existing established patterns."""
+        comm_data = {
+            "category": "reli_communication",
+            "patterns": [
+                {"pattern": "prefers concise responses", "confidence": "established", "observations": 3},
+                {"pattern": "no emoji", "confidence": "strong", "observations": 5},
+            ],
+        }
+        with db() as conn:
+            _insert_thing(conn, "pref-comm", "How user wants Reli to communicate", type_hint="preference", data=comm_data)
+            for i in range(MIN_INTERACTIONS + 2):
+                _insert_chat_message(conn, "user", f"Message {i}")
+                _insert_chat_message(conn, "assistant", f"Response {i}")
+            _insert_chat_message(conn, "user", "Perfect, thanks! Exactly what I needed.")
+
+        llm_response = json.dumps({
+            "detected": [],
+            "reinforced": ["prefers concise responses", "no emoji"],
+            "contradicted": [],
+        })
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            result = await aggregate_communication_style_patterns()
+
+        assert result.patterns_reinforced == 2
+        assert result.patterns_added == 0
+        assert result.patterns_removed == 0
+
+        with db() as conn:
+            row = conn.execute("SELECT data FROM things WHERE id = 'pref-comm'").fetchone()
+        data = json.loads(row["data"])
+        pattern_map = {p["pattern"]: p for p in data["patterns"]}
+        assert pattern_map["prefers concise responses"]["observations"] == 4
+        assert pattern_map["no emoji"]["observations"] == 6
+        assert pattern_map["no emoji"]["confidence"] == "strong"
+
+    @pytest.mark.asyncio
+    async def test_positive_engagement_no_existing_preference_does_nothing(self, patched_db, db):
+        """Positive signals with no existing preferences should not create new ones."""
+        with db() as conn:
+            for i in range(MIN_INTERACTIONS + 2):
+                _insert_chat_message(conn, "user", f"Message {i}")
+                _insert_chat_message(conn, "assistant", f"Response {i}")
+            _insert_chat_message(conn, "user", "Thanks, that was helpful!")
+
+        llm_response = json.dumps({"detected": [], "reinforced": [], "contradicted": []})
+
+        with patch("backend.agents._chat", new_callable=AsyncMock, return_value=llm_response):
+            result = await aggregate_communication_style_patterns()
+
+        assert result.patterns_added == 0
+        assert result.patterns_reinforced == 0
+        assert result.thing_id is None

--- a/eval/reasoning_agent/personality_adaptation.test.json
+++ b/eval/reasoning_agent/personality_adaptation.test.json
@@ -411,6 +411,144 @@
       "creation_timestamp": 0.0,
       "rubrics": null,
       "final_session_state": {}
+    },
+    {
+      "eval_id": "comm-style-positive-engagement",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-26 (Thursday)\n\n<user_message>\nPerfect, thanks! Exactly what I needed.\n</user_message>\n\nRelevant Things from database:\n[{\"id\": \"comm-pref-200\", \"title\": \"How the user wants Reli to communicate\", \"type_hint\": \"preference\", \"data\": \"{\\\"category\\\": \\\"reli_communication\\\", \\\"patterns\\\": [{\\\"pattern\\\": \\\"prefers concise responses\\\", \\\"confidence\\\": \\\"established\\\", \\\"observations\\\": 3}]}\", \"active\": 1}]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"User expressed satisfaction — reinforced existing communication style preferences.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "id": null,
+                "args": {
+                  "thing_id": "comm-pref-200",
+                  "data_json": "{\"category\": \"reli_communication\", \"patterns\": [{\"pattern\": \"prefers concise responses\", \"confidence\": \"established\", \"observations\": 4}]}"
+                },
+                "name": "update_thing",
+                "partial_args": null,
+                "will_continue": null
+              }
+            ],
+            "tool_responses": [
+              {
+                "will_continue": null,
+                "scheduling": null,
+                "parts": null,
+                "id": null,
+                "name": "update_thing",
+                "response": {
+                  "id": "comm-pref-200",
+                  "title": "How the user wants Reli to communicate",
+                  "type_hint": "preference"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
+    },
+    {
+      "eval_id": "comm-style-positive-no-existing-preference",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "Today's date: 2026-03-26 (Thursday)\n\n<user_message>\nThanks, that was helpful!\n</user_message>\n\nRelevant Things from database:\n[]",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "media_resolution": null,
+                "code_execution_result": null,
+                "executable_code": null,
+                "file_data": null,
+                "function_call": null,
+                "function_response": null,
+                "inline_data": null,
+                "text": "{\"questions_for_user\": [], \"priority_question\": \"\", \"reasoning_summary\": \"User expressed satisfaction.\", \"briefing_mode\": false}",
+                "thought": null,
+                "thought_signature": null,
+                "video_metadata": null
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [],
+            "tool_responses": [],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0,
+          "rubrics": null,
+          "app_details": null
+        }
+      ],
+      "conversation_scenario": null,
+      "session_input": null,
+      "creation_timestamp": 0.0,
+      "rubrics": null,
+      "final_session_state": {}
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add positive engagement signal detection to complete the backpropagation loop for Reli's personality adaptation. When a user expresses satisfaction ("thanks", "perfect", "exactly right"), the reasoning agent and preference sweep now reinforce existing `reli_communication` patterns by incrementing their observation counts — strengthening what's already working.

**Key principle**: Positive signals never create new preferences; they only strengthen existing ones.

## Changes

| File | Changes |
|------|---------|
| `backend/reasoning_agent.py` | Added "Positive engagement signals" section to `_COMM_STYLE_SIGNAL_RULES` with rules to only reinforce existing patterns, never create new ones (+14 lines) |
| `backend/preference_sweep.py` | Added "Positive engagement signals" section to `COMM_STYLE_AGGREGATION_SYSTEM` instructing LLM to add matching patterns to "reinforced" list (+7 lines) |
| `backend/tests/test_preference_sweep.py` | Added two unit tests: positive signal reinforcement and boundary case (no existing preference) (+55 lines) |
| `eval/reasoning_agent/personality_adaptation.test.json` | Added two eval cases validating positive engagement behavior (+142 lines) |

## Validation

All tests pass without regressions:
- ✅ Static analysis: imports OK
- ✅ Unit tests: 31 passed (29 existing + 2 new)
- ✅ Full suite: 49 passed (no regressions)
- ✅ Eval JSON: 7 cases valid (5 existing + 2 new)

## Behavior Changes

**Before**: Correction signals weaken patterns, but satisfaction signals are ignored.

**After**: 
- User satisfaction ("thanks", "perfect") reinforces existing communication style patterns
- Observation counts increment, strengthening patterns toward higher confidence tiers
- Positive signals never create new preferences
- Completes the bidirectional backpropagation loop (strengthen what works, weaken what doesn't)

Fixes #193