### PR TITLE
fix(e2e): handle multiple Sign-in buttons on landing page

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -35,7 +35,7 @@ test.describe('Smoke – frontend serving', () => {
   test('unauthenticated user sees login page', async ({ page }) => {
     await page.goto('/')
     // The app should show the login page for unauthenticated users
-    await expect(page.getByText('Sign in with Google')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Sign in with Google').first()).toBeVisible({ timeout: 15_000 })
   })
 })
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3213,6 +3213,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4091,6 +4092,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -8937,6 +8939,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {


### PR DESCRIPTION
## Summary

- PR #1058 added a public landing page with three "Sign in with Google" buttons (navbar, hero, CTA)
- This broke the smoke test with a Playwright strict-mode violation: locator resolved to 3 elements instead of 1
- Fix: append `.first()` to the locator so it picks the first match

## Test plan

- [ ] CI smoke tests pass (the failing test now resolves to the first button)
- [ ] No change to production behaviour — landing page is unchanged

Fixes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)