### PR TITLE
Fix: remove OAuth authorization code from logs (SEC-013)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 
 import jwt
-
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from google.auth.transport import requests as google_requests
@@ -79,8 +78,7 @@ def _create_jwt(user_id: str, email: str) -> str:
 
 def _decode_jwt(token: str) -> dict[str, str]:
     """Decode and validate a JWT. Raises on invalid/expired tokens."""
-    result: dict[str, str] = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
-    return result
+    return jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
 
 
 def _apply_profile_fields(user: UserRecord, email: str, name: str, picture: str | None, now: datetime) -> None:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -197,7 +197,7 @@ def google_callback(code: str, state: str = "") -> RedirectResponse:
     if not SECRET_KEY:
         raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
 
-    logger.info("OAuth callback: redirect_uri=%s, code=%s...", GOOGLE_REDIRECT_URI, code[:20])
+    logger.info("OAuth callback: redirect_uri=%s", GOOGLE_REDIRECT_URI)
 
     flow = Flow.from_client_config(_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_REDIRECT_URI

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -267,3 +267,55 @@ class TestOAuthAllowlistRejection:
 
         assert resp.status_code in (302, 307)
         assert "blocked@example.com" not in caplog.text
+
+
+class TestOAuthCallbackDoesNotLogCode:
+    """Regression test for CWE-532: authorization code must not appear in logs."""
+
+    def test_google_callback_does_not_log_authorization_code(self, patched_db, caplog):
+        """The INFO log at callback entry must not include any fragment of the auth code."""
+        fake_state = "test-state-value"
+        fake_code = "supersecretauthcode123456"
+        fake_flow_entry = {
+            "code_verifier": "fake-verifier",
+            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=600),
+        }
+
+        mock_flow = MagicMock()
+        mock_flow.fetch_token.return_value = None
+        mock_flow.credentials.id_token = "fake-token"
+        mock_flow.code_verifier = None
+
+        fake_id_info = {
+            "sub": "google-001",
+            "email": "allowed@example.com",
+            "name": "Test User",
+            "picture": None,
+        }
+
+        with (
+            patch("backend.routers.auth.SECRET_KEY", "test-secret-key"),
+            patch("backend.routers.auth.GOOGLE_CLIENT_ID", "fake-client-id"),
+            patch("backend.routers.auth._pending_flows", {fake_state: fake_flow_entry}),
+            patch("backend.routers.auth.Flow.from_client_config", return_value=mock_flow),
+            patch(
+                "backend.routers.auth.google_id_token.verify_oauth2_token",
+                return_value=fake_id_info,
+            ),
+            patch(
+                "backend.config.Settings.allowed_emails_set",
+                new_callable=lambda: property(lambda self: {"allowed@example.com"}),
+            ),
+            caplog.at_level(logging.INFO, logger="backend.routers.auth"),
+        ):
+            from backend.main import app
+
+            with TestClient(app, follow_redirects=False) as client:
+                client.get(f"/api/auth/google/callback?code={fake_code}&state={fake_state}")
+
+        assert fake_code not in caplog.text, (
+            f"Authorization code appeared in logs — CWE-532 regression: {caplog.text!r}"
+        )
+        assert fake_code[:20] not in caplog.text, (
+            f"Authorization code prefix appeared in logs — CWE-532 regression: {caplog.text!r}"
+        )


### PR DESCRIPTION
## Summary

- Remove `code[:20]` from the `logger.info` call in `google_callback` (`backend/routers/auth.py:200`)
- Authorization codes are bearer credentials — logging any portion violates CWE-532 and audit best practices
- `redirect_uri` alone is sufficient for debugging flow routing

## Test plan

- [ ] Trigger an OAuth login flow and confirm no `code=` token appears in application logs
- [ ] `grep -n "code\[:" backend/routers/auth.py` returns no results

Fixes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)