### PR TITLE
Fix: add per-migration opt-in for destructive DDL safety check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Reli stores user data in two places — both contain production data that must b
 ### SQLite (`data/reli.db`)
 
 1. **NEVER delete or recreate the database file.** The Docker volume mounts `./data:/app/data` — the DB persists across container rebuilds.
-2. **Schema changes must use additive SQL migrations** (`ALTER TABLE`, `CREATE TABLE IF NOT EXISTS`). See `backend/database.py` for the existing migration pattern. Never use destructive DDL (`DROP TABLE`, `DROP COLUMN`) without a data migration plan.
+2. **Schema changes must use additive SQL migrations** (`ALTER TABLE`, `CREATE TABLE IF NOT EXISTS`). See `backend/database.py` for the existing migration pattern. Never use destructive DDL (`DROP TABLE`, `DROP COLUMN`) without a data migration plan. When a destructive operation is intentional and data is preserved, add `# reli:allow-destructive-ddl` as a top-level comment in the migration file to opt in per-migration (preferred over the global `ALLOW_DESTRUCTIVE_DDL=true` env override).
 3. **Test migrations on a copy first** — copy `reli.db` and run your migration against the copy before committing.
 4. **Never hard-code a different DB path** — the path is set by `DATA_DIR` env var (defaults to `backend/`). Production uses `/app/data` inside the container.
 

--- a/backend/alembic/safety.py
+++ b/backend/alembic/safety.py
@@ -14,9 +14,9 @@ import os
 import re
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-
 from alembic.script import ScriptDirectory
+
+logger = logging.getLogger(__name__)
 
 # Alembic op.* calls considered destructive
 DESTRUCTIVE_OPS = frozenset(

--- a/backend/alembic/safety.py
+++ b/backend/alembic/safety.py
@@ -32,6 +32,11 @@ _DESTRUCTIVE_SQL_PATTERNS = [
     re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE),
 ]
 
+# Per-migration opt-in marker.  Add this comment to a migration file to
+# acknowledge that the destructive operations are intentional and data has
+# been preserved (e.g. migrated to another table before the column drop).
+_ALLOW_MARKER = "# reli:allow-destructive-ddl"
+
 
 class DestructiveDDLFound(RuntimeError):
     """Raised when a migration contains destructive DDL without explicit opt-in."""
@@ -111,6 +116,10 @@ def check_pending_migrations(
             continue
 
         source = source_path.read_text()
+        # Per-migration opt-in: skip safety check if the migration explicitly
+        # acknowledges the destructive operation.
+        if _ALLOW_MARKER in source:
+            continue
         findings = _find_destructive_ops_in_source(source)
 
         if findings:
@@ -136,7 +145,11 @@ def check_pending_migrations(
             "To apply these migrations, set the environment variable:",
             "  ALLOW_DESTRUCTIVE_DDL=true alembic upgrade head",
             "",
-            "Or from Python:",
+            "Or add the following comment to the migration file to opt-in per-migration",
+            "(only after verifying data is preserved):",
+            "  # reli:allow-destructive-ddl",
+            "",
+            "Or from Python (global override):",
             '  os.environ["ALLOW_DESTRUCTIVE_DDL"] = "true"',
         ]
     )

--- a/backend/alembic/safety.py
+++ b/backend/alembic/safety.py
@@ -1,14 +1,20 @@
 """Safety guard for destructive DDL operations in Alembic migrations.
 
 Scans pending migration scripts for destructive operations (DROP TABLE,
-DROP COLUMN, etc.) and blocks execution unless explicitly allowed via
-the ALLOW_DESTRUCTIVE_DDL environment variable.
+DROP COLUMN, etc.) and blocks execution unless explicitly allowed via:
+
+- The ``ALLOW_DESTRUCTIVE_DDL`` environment variable (global override), or
+- A ``# reli:allow-destructive-ddl`` comment in the migration file itself
+  (per-migration opt-in, preferred when data is preserved within the migration).
 """
 
 import ast
+import logging
 import os
 import re
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from alembic.script import ScriptDirectory
 
@@ -119,6 +125,10 @@ def check_pending_migrations(
         # Per-migration opt-in: skip safety check if the migration explicitly
         # acknowledges the destructive operation.
         if _ALLOW_MARKER in source:
+            logger.info(
+                "Skipping destructive DDL check for %s — per-migration opt-in marker present",
+                rev_id,
+            )
             continue
         findings = _find_destructive_ops_in_source(source)
 

--- a/backend/alembic/versions/d4e5f6a7b8c9_remove_parent_id_use_relationships.py
+++ b/backend/alembic/versions/d4e5f6a7b8c9_remove_parent_id_use_relationships.py
@@ -9,6 +9,10 @@ relationships, then drops the parent_id column and its index from the
 things table.  See GitHub issue #338.
 """
 
+# reli:allow-destructive-ddl — parent_id data is migrated to thing_relationships
+# in Step 1 of upgrade() before the column and index are dropped in Step 2.
+# Downgrade restores both. Approved per issue #1110.
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/backend/tests/test_ddl_safety.py
+++ b/backend/tests/test_ddl_safety.py
@@ -1,12 +1,14 @@
 """Tests for the destructive DDL safety guard in Alembic migrations."""
 
 import textwrap
+from unittest.mock import MagicMock
 
 import pytest
 
 from backend.alembic.safety import (
     DestructiveDDLFound,
     _find_destructive_ops_in_source,
+    check_pending_migrations,
 )
 
 
@@ -145,20 +147,12 @@ class TestCheckPendingMigrations:
 
     def test_allows_when_env_var_set(self, tmp_path, monkeypatch):
         """ALLOW_DESTRUCTIVE_DDL=true bypasses the check entirely."""
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
-
         monkeypatch.setenv("ALLOW_DESTRUCTIVE_DDL", "true")
         mock_script_dir = MagicMock()
         # Should not raise even with a mocked script dir
         check_pending_migrations(mock_script_dir, current_heads=set())
 
     def test_env_var_case_insensitive(self, monkeypatch):
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
-
         for value in ("TRUE", "True", "1", "yes", "YES"):
             monkeypatch.setenv("ALLOW_DESTRUCTIVE_DDL", value)
             mock_script_dir = MagicMock()
@@ -186,10 +180,6 @@ class TestCheckPendingMigrations:
                 op.create_table('users')
         """)
         )
-
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
 
         # Mock script directory
         mock_rev = MagicMock()
@@ -232,10 +222,6 @@ class TestCheckPendingMigrations:
         """)
         )
 
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
-
         mock_rev = MagicMock()
         mock_rev.revision = "def456"
         mock_rev.doc = "add column"
@@ -269,10 +255,6 @@ class TestCheckPendingMigrations:
                 pass
         """)
         )
-
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
 
         mock_rev = MagicMock()
         mock_rev.revision = "abc123"
@@ -308,10 +290,6 @@ class TestCheckPendingMigrations:
                 pass
         """)
         )
-
-        from unittest.mock import MagicMock
-
-        from backend.alembic.safety import check_pending_migrations
 
         mock_rev = MagicMock()
         mock_rev.revision = "ghi789"

--- a/backend/tests/test_ddl_safety.py
+++ b/backend/tests/test_ddl_safety.py
@@ -207,6 +207,7 @@ class TestCheckPendingMigrations:
         error_msg = str(exc_info.value)
         assert "drop_table" in error_msg
         assert "ALLOW_DESTRUCTIVE_DDL" in error_msg
+        assert "reli:allow-destructive-ddl" in error_msg
 
     def test_passes_safe_migration(self, tmp_path, monkeypatch):
         """A pending migration with only safe ops should pass."""
@@ -283,3 +284,42 @@ class TestCheckPendingMigrations:
 
         # abc123 is already applied — should not raise
         check_pending_migrations(mock_script_dir, current_heads={"abc123"})
+
+    def test_allows_migration_with_per_migration_marker(self, tmp_path, monkeypatch):
+        """Migration with # reli:allow-destructive-ddl marker bypasses the safety check."""
+        monkeypatch.delenv("ALLOW_DESTRUCTIVE_DDL", raising=False)
+
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        migration_file = versions_dir / "ghi789_drop_col.py"
+        migration_file.write_text(
+            textwrap.dedent("""\
+            # reli:allow-destructive-ddl — data migrated before this drop
+
+            revision = 'ghi789'
+            down_revision = None
+
+            from alembic import op
+
+            def upgrade():
+                op.drop_column('things', 'parent_id')
+
+            def downgrade():
+                pass
+        """)
+        )
+
+        from unittest.mock import MagicMock
+
+        from backend.alembic.safety import check_pending_migrations
+
+        mock_rev = MagicMock()
+        mock_rev.revision = "ghi789"
+        mock_rev.doc = "drop parent_id"
+        mock_rev.path = str(migration_file)
+
+        mock_script_dir = MagicMock()
+        mock_script_dir.walk_revisions.return_value = [mock_rev]
+
+        # Should NOT raise — marker opts this migration out of the safety check
+        check_pending_migrations(mock_script_dir, current_heads=set())

--- a/backend/tests/test_gmail_redirect_uri.py
+++ b/backend/tests/test_gmail_redirect_uri.py
@@ -33,7 +33,8 @@ class TestGmailRedirectUri:
             assert _gmail_redirect_uri() == "http://localhost:8000/api/gmail/callback"
 
     def test_fallback_does_not_double_path(self):
-        """Positional split must not produce a doubled path when GOOGLE_REDIRECT_URI already ends with /api/gmail/callback."""
+        """Positional split must not produce a doubled path when GOOGLE_REDIRECT_URI
+        already ends with /api/gmail/callback."""
         with patch("backend.routers.gmail.settings") as mock_settings:
             mock_settings.RELI_BASE_URL = ""
             mock_settings.GOOGLE_REDIRECT_URI = "https://prod.example.com/api/gmail/callback"

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -178,7 +178,7 @@ def init_db() -> None:
 
 3. **Test on a copy first:** `cp data/reli.db /tmp/reli-test.db` and run the migration against the copy.
 
-**Never use** `DROP TABLE` or `DROP COLUMN` without a data migration plan.
+**Never use** `DROP TABLE` or `DROP COLUMN` without a data migration plan. When a destructive operation is intentional and data is preserved (e.g. migrated to another column/table before the drop), add `# reli:allow-destructive-ddl` as a top-level comment in the Alembic migration file. This opts that single migration out of the safety check without disabling the check globally.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #1110 — adds a per-migration opt-in mechanism to the destructive DDL safety check, allowing migrations with legitimate destructive operations (like data-preserving column drops) to bypass the safety guard without globally disabling it.

## Problem

The Alembic migration `d4e5f6a7b8c9` (remove_parent_id_use_relationships) performs a safe, data-preserving operation:
1. Migrates `things.parent_id` values into `thing_relationships` rows
2. Drops the column and its index

However, the safety check in `backend/alembic/safety.py` has no per-migration opt-in mechanism. The only bypass is the global `ALLOW_DESTRUCTIVE_DDL` env var, which is not set in docker-compose. This blocks the migration on every deployment with `DestructiveDDLFound`, preventing the app from starting.

## Solution

Add a per-migration marker constant `# reli:allow-destructive-ddl` that migration authors can add as a comment to explicitly opt-in to the safety check bypass. The marker:
- Is self-documenting and visible in code review
- Only applies to the specific migration that contains it
- Requires explicit acknowledgment that data has been preserved
- Does not globally disable the safety check for future migrations

## Changes

### `backend/alembic/safety.py`
- Add `_ALLOW_MARKER` constant (per-migration opt-in string)
- Check for marker in migration source before raising `DestructiveDDLFound`
- Update error message to explain the per-migration marker option alongside the global env var

### `backend/alembic/versions/d4e5f6a7b8c9_remove_parent_id_use_relationships.py`
- Add `# reli:allow-destructive-ddl` marker comment with explanation

## Validation

| Check | Result |
|-------|--------|
| Backend tests | ✅ 1121 passed, 14 skipped (coverage 86.26%) |
| Backend lint | ✅ Passed (fixed pre-existing line-length error) |
| Backend format | ✅ 136 files formatted correctly |
| Backend type check | ✅ Implementation files pass clean |
| Frontend tests | ✅ 390 passed |
| Frontend build | ✅ Compiled successfully |

All tests pass. The fix allows the blocked migration to proceed without affecting safety checks for other migrations.

## Testing

Tested by:
- Running `python -m pytest backend/tests/ -k "safety or migration"` — safety tests pass
- Running the full test suite — 1121 tests pass with 86.26% coverage
- Verified that migrations with the marker skip the safety check, while unmarked destructive migrations still trigger it

Fixes #1110