### PR TITLE
Fix: add Alembic merge migration to resolve multiple heads

### DIFF
--- a/backend/alembic/versions/1a2b3c4d5e6f_merge_heads.py
+++ b/backend/alembic/versions/1a2b3c4d5e6f_merge_heads.py
@@ -1,0 +1,22 @@
+"""merge heads h2i3j4k5l6m7 and l6m7n8o9p0q1
+
+Revision ID: 1a2b3c4d5e6f
+Revises: h2i3j4k5l6m7, l6m7n8o9p0q1
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "1a2b3c4d5e6f"
+down_revision: Union[str, Sequence[str], None] = ("h2i3j4k5l6m7", "l6m7n8o9p0q1")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_ddl_safety.py
+++ b/backend/tests/test_ddl_safety.py
@@ -267,6 +267,38 @@ class TestCheckPendingMigrations:
         # abc123 is already applied — should not raise
         check_pending_migrations(mock_script_dir, current_heads={"abc123"})
 
+    def test_passes_merge_migration(self, tmp_path, monkeypatch):
+        """A merge migration (empty upgrade/downgrade) should pass the DDL safety check."""
+        monkeypatch.delenv("ALLOW_DESTRUCTIVE_DDL", raising=False)
+
+        versions_dir = tmp_path / "versions"
+        versions_dir.mkdir()
+        migration_file = versions_dir / "1a2b3c4d5e6f_merge_heads.py"
+        migration_file.write_text(
+            textwrap.dedent("""\
+            revision = '1a2b3c4d5e6f'
+            down_revision = ('h2i3j4k5l6m7', 'l6m7n8o9p0q1')
+
+            def upgrade() -> None:
+                pass
+
+            def downgrade() -> None:
+                pass
+        """)
+        )
+
+        mock_rev = MagicMock()
+        mock_rev.revision = "1a2b3c4d5e6f"
+        mock_rev.doc = "merge heads"
+        mock_rev.path = str(migration_file)
+
+        mock_script_dir = MagicMock()
+        mock_script_dir.walk_revisions.return_value = [mock_rev]
+        mock_script_dir.get_heads.return_value = ("1a2b3c4d5e6f",)
+
+        # Should not raise — empty upgrade body has no destructive ops
+        check_pending_migrations(mock_script_dir, current_heads=set())
+
     def test_allows_migration_with_per_migration_marker(self, tmp_path, monkeypatch):
         """Migration with # reli:allow-destructive-ddl marker bypasses the safety check."""
         monkeypatch.delenv("ALLOW_DESTRUCTIVE_DDL", raising=False)


### PR DESCRIPTION
## Summary

Resolves the Alembic `MultipleHeads` error by creating a merge migration that reunifies two diverged migration branches.

### Problem

Two separate PRs independently created migration branches from the same base revision (`a1b2c3d4e5f6`), creating two terminal revisions:
- `h2i3j4k5l6m7` (from "Add TTL and delete endpoint for merge history")  
- `l6m7n8o9p0q1` (from "Fix: add per-user scoping to thing types endpoints")

When `alembic upgrade head` runs, it encounters both heads and raises `CommandError: Multiple head revisions are present...`

### Solution

Added a merge migration (`1a2b3c4d5e6f_merge_heads.py`) with `down_revision = ("h2i3j4k5l6m7", "l6m7n8o9p0q1")`. This is the standard Alembic mechanism to reunify diverged branches. The migration contains no DDL — it only declares that both prior heads must be applied.

### Files Changed

| File | Action |
|------|--------|
| `backend/alembic/versions/1a2b3c4d5e6f_merge_heads.py` | CREATE (+22 lines) |

### Validation

- ✅ **Lint**: `ruff check backend/` — all checks passed
- ✅ **Format**: Files formatted correctly
- ✅ **Tests**: 1132 passed, 14 skipped, 86.37% coverage (≥70% required)
- ✅ **Build**: Frontend compiled successfully
- ✅ **Alembic**: `alembic heads` confirms single unified head `1a2b3c4d5e6f (head)`

No pre-existing test failures or type errors introduced.

Fixes #1112