### PR TITLE
Fix: validate redirect_uri schemes in OAuth client registration

### DIFF
--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -100,22 +100,35 @@ def authorization_server_metadata() -> JSONResponse:
 async def oauth_register(request: Request) -> JSONResponse:
     """Register a new OAuth client dynamically (RFC 7591).
 
-    Single-tenant: accepts any registration request and stores the client
-    in memory. No approval flow needed.
+    Single-tenant: validates redirect_uris and stores the client in memory.
+    No approval flow is required.
+
+    Raises:
+        HTTPException 400: if any redirect_uri uses a scheme other than
+            https (or http for localhost/127.0.0.1 in development).
+        HTTPException 503: if the client store is at capacity.
     """
     body = await request.json()
 
-    # Validate redirect_uris: only https:// is allowed (http:// only for localhost in dev)
-    for uri in body.get("redirect_uris", []):
+    # Validate redirect_uris: only https:// is allowed
+    # (http:// permitted only for localhost / 127.0.0.1 in development)
+    for uri in body.get("redirect_uris") or []:
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme == "https":
             pass  # always allowed
         elif parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
             pass  # allow http for local development
         else:
+            logger.warning(
+                "MCP OAuth: rejected redirect_uri with unsafe scheme during registration: %r",
+                uri,
+            )
             raise HTTPException(
                 status_code=400,
-                detail=f"redirect_uri must use https (or http://localhost for development): {uri}",
+                detail=(
+                    f"redirect_uri must use https "
+                    f"(or http://localhost / http://127.0.0.1 for development): {uri}"
+                ),
             )
 
     client_id = str(uuid.uuid4())
@@ -124,7 +137,7 @@ async def oauth_register(request: Request) -> JSONResponse:
     client = {
         "client_id": client_id,
         "client_secret": client_secret,
-        "redirect_uris": body.get("redirect_uris", []),
+        "redirect_uris": body.get("redirect_uris") or [],
         "client_name": body.get("client_name", ""),
         "grant_types": body.get("grant_types", ["authorization_code"]),
         "response_types": body.get("response_types", ["code"]),

--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -14,6 +14,7 @@ import base64
 import hashlib
 import logging
 import secrets
+import urllib.parse
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -103,6 +104,19 @@ async def oauth_register(request: Request) -> JSONResponse:
     in memory. No approval flow needed.
     """
     body = await request.json()
+
+    # Validate redirect_uris: only https:// is allowed (http:// only for localhost in dev)
+    for uri in body.get("redirect_uris", []):
+        parsed = urllib.parse.urlparse(uri)
+        if parsed.scheme == "https":
+            pass  # always allowed
+        elif parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
+            pass  # allow http for local development
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"redirect_uri must use https (or http://localhost for development): {uri}",
+            )
 
     client_id = str(uuid.uuid4())
     client_secret = secrets.token_urlsafe(32)

--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -114,21 +114,17 @@ async def oauth_register(request: Request) -> JSONResponse:
     # (http:// permitted only for localhost / 127.0.0.1 in development)
     for uri in body.get("redirect_uris") or []:
         parsed = urllib.parse.urlparse(uri)
-        if parsed.scheme == "https":
-            pass  # always allowed
-        elif parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
-            pass  # allow http for local development
-        else:
+        allowed = parsed.scheme == "https" or (
+            parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1")
+        )
+        if not allowed:
             logger.warning(
                 "MCP OAuth: rejected redirect_uri with unsafe scheme during registration: %r",
                 uri,
             )
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    f"redirect_uri must use https "
-                    f"(or http://localhost / http://127.0.0.1 for development): {uri}"
-                ),
+                detail=f"redirect_uri must use https (or http://localhost / http://127.0.0.1 for development): {uri}",
             )
 
     client_id = str(uuid.uuid4())

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -206,6 +206,60 @@ class TestMcpRedirectScheme:
         assert "http://" not in location, f"redirect incorrectly uses http://: {location}"
 
 
+class TestOAuthRegisterRedirectUriValidation:
+    """POST /oauth/register must reject redirect_uris with unsafe URL schemes."""
+
+    def test_register_accepts_https_redirect_uri(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["https://legitimate.example.com/callback"], "client_name": "test"},
+        )
+        assert resp.status_code == 201
+
+    def test_register_accepts_http_localhost(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:8080/callback"], "client_name": "test"},
+        )
+        assert resp.status_code == 201
+
+    def test_register_accepts_http_127_0_0_1(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://127.0.0.1:3000/callback"], "client_name": "test"},
+        )
+        assert resp.status_code == 201
+
+    def test_register_rejects_http_external_host(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://evil.com/steal"], "client_name": "test"},
+        )
+        assert resp.status_code == 400
+        assert "redirect_uri must use https" in resp.json()["detail"]
+
+    def test_register_rejects_javascript_scheme(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["javascript:alert(1)"], "client_name": "test"},
+        )
+        assert resp.status_code == 400
+
+    def test_register_rejects_malformed_uri(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["notavalidurl"], "client_name": "test"},
+        )
+        assert resp.status_code == 400
+
+    def test_register_accepts_empty_redirect_uris(self, mcp_client):
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": [], "client_name": "test"},
+        )
+        assert resp.status_code == 201
+
+
 class TestMcpTokenAudience:
     """Tokens issued via /oauth/token must carry aud='mcp'."""
 

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -207,7 +207,7 @@ class TestMcpRedirectScheme:
 
 
 class TestOAuthRegisterRedirectUriValidation:
-    """POST /oauth/register must reject redirect_uris with unsafe URL schemes."""
+    """POST /oauth/register must enforce redirect_uri scheme rules (accept https/localhost, reject others)."""
 
     def test_register_accepts_https_redirect_uri(self, mcp_client):
         resp = mcp_client.post(
@@ -244,13 +244,16 @@ class TestOAuthRegisterRedirectUriValidation:
             json={"redirect_uris": ["javascript:alert(1)"], "client_name": "test"},
         )
         assert resp.status_code == 400
+        assert "redirect_uri must use https" in resp.json()["detail"]
 
-    def test_register_rejects_malformed_uri(self, mcp_client):
+    def test_register_rejects_schemeless_uri(self, mcp_client):
+        # urllib.parse yields scheme="" for bare strings; the else branch rejects it
         resp = mcp_client.post(
             "/oauth/register",
             json={"redirect_uris": ["notavalidurl"], "client_name": "test"},
         )
         assert resp.status_code == 400
+        assert "redirect_uri must use https" in resp.json()["detail"]
 
     def test_register_accepts_empty_redirect_uris(self, mcp_client):
         resp = mcp_client.post(
@@ -258,6 +261,37 @@ class TestOAuthRegisterRedirectUriValidation:
             json={"redirect_uris": [], "client_name": "test"},
         )
         assert resp.status_code == 201
+
+    def test_register_accepts_null_redirect_uris_as_empty(self, mcp_client):
+        # null redirect_uris is treated the same as an absent key (empty list)
+        # and must not cause a 500 TypeError
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={"redirect_uris": None, "client_name": "test"},
+        )
+        assert resp.status_code == 201
+
+    def test_register_rejects_mixed_valid_and_invalid_uris(self, mcp_client):
+        """A single invalid URI in the list must reject the whole registration."""
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["https://good.example.com/callback", "http://evil.com/steal"],
+                "client_name": "test",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_register_rejects_invalid_uri_regardless_of_position(self, mcp_client):
+        """Validation applies even when the invalid URI is not first."""
+        resp = mcp_client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://evil.com/steal", "https://good.example.com/callback"],
+                "client_name": "test",
+            },
+        )
+        assert resp.status_code == 400
 
 
 class TestMcpTokenAudience:


### PR DESCRIPTION
## Summary

Fixes #1075 — [Security] SEC-006: MCP OAuth Dynamic Client Registration - Open Redirect

Adds URL scheme validation to `POST /oauth/register` to block open redirect attacks. The endpoint now only accepts `https://` URIs (and `http://localhost` for development), preventing attackers from registering clients with arbitrary redirect URIs like `http://evil.com` or `javascript:` schemes.

## Changes

- **`backend/routers/mcp_oauth.py`**: Added redirect_uri scheme validation in `oauth_register()` using `urllib.parse.urlparse()`. Validates that each URI uses `https://` (always allowed) or `http://` on localhost/127.0.0.1 (development only). Rejects all other schemes with a 400 error.
- **`backend/tests/test_mcp_oauth.py`**: Added test cases covering:
  - Valid https:// URIs → accepted (201)
  - Valid http://localhost URIs → accepted (201) 
  - Invalid http://evil.com URIs → rejected (400)
  - Invalid javascript: URIs → rejected (400)

## Root Cause

The OAuth registration endpoint accepted any `redirect_uri` without validation. Combined with the phishing scenario (attacker tricks authenticated owner into completing OAuth flow), this allowed the auth code to be redirected to the attacker's server. The fix validates schemes at registration time rather than relying on a hostname allowlist (which was previously removed in #951 because it broke claude.ai integration).

## Validation

✅ All tests pass: 1145 passed, 14 skipped (coverage: 86.27%)
✅ Lint checks pass: ruff check and format both passing
✅ Type checks pass: mypy on changed files with no errors
✅ Frontend tests pass: 390 tests in 29 files
✅ Frontend build succeeds: 88 modules transformed

No pre-existing errors introduced.

Fixes #1075