### PR TITLE
Fix: make mcp_oauth_state_tables migration idempotent

### DIFF
--- a/backend/alembic/versions/j4k5l6m7n8o9_add_oauth_state_tables.py
+++ b/backend/alembic/versions/j4k5l6m7n8o9_add_oauth_state_tables.py
@@ -19,6 +19,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if inspector.has_table("mcp_oauth_sessions"):
+        return  # Tables already exist (e.g. created via create_all fallback); nothing to do.
+
     op.create_table(
         "mcp_oauth_sessions",
         sa.Column("server_state", sqlmodel.sql.sqltypes.AutoString(), nullable=False),

--- a/backend/alembic/versions/j4k5l6m7n8o9_add_oauth_state_tables.py
+++ b/backend/alembic/versions/j4k5l6m7n8o9_add_oauth_state_tables.py
@@ -19,6 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    """Create OAuth state tables (mcp_oauth_sessions and related) for MCP auth."""
     conn = op.get_bind()
     inspector = sa.inspect(conn)
     if inspector.has_table("mcp_oauth_sessions"):

--- a/backend/tests/test_migration_j4k5l6m7n8o9_add_oauth_state_tables.py
+++ b/backend/tests/test_migration_j4k5l6m7n8o9_add_oauth_state_tables.py
@@ -1,0 +1,38 @@
+"""Tests for the idempotency guard in j4k5l6m7n8o9_add_oauth_state_tables."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestOAuthStateTablesMigrationUpgrade:
+    def _run_upgrade(self):
+        from backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables import upgrade
+
+        upgrade()
+
+    @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.op")
+    @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.sa")
+    def test_skips_create_when_tables_exist(self, mock_sa, mock_op):
+        """upgrade() must not call op.create_table when mcp_oauth_sessions already exists."""
+        mock_inspector = MagicMock()
+        mock_inspector.has_table.return_value = True
+        mock_sa.inspect.return_value = mock_inspector
+        mock_op.get_bind.return_value = MagicMock()
+
+        self._run_upgrade()
+
+        mock_op.create_table.assert_not_called()
+        mock_op.create_index.assert_not_called()
+
+    @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.op")
+    @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.sa")
+    def test_creates_tables_when_absent(self, mock_sa, mock_op):
+        """upgrade() must create all 5 tables when mcp_oauth_sessions does not exist."""
+        mock_inspector = MagicMock()
+        mock_inspector.has_table.return_value = False
+        mock_sa.inspect.return_value = mock_inspector
+        mock_op.get_bind.return_value = MagicMock()
+
+        self._run_upgrade()
+
+        assert mock_op.create_table.call_count == 5
+        assert mock_op.create_index.call_count == 5

--- a/backend/tests/test_migration_j4k5l6m7n8o9_add_oauth_state_tables.py
+++ b/backend/tests/test_migration_j4k5l6m7n8o9_add_oauth_state_tables.py
@@ -12,7 +12,7 @@ class TestOAuthStateTablesMigrationUpgrade:
     @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.op")
     @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.sa")
     def test_skips_create_when_tables_exist(self, mock_sa, mock_op):
-        """upgrade() must not call op.create_table when mcp_oauth_sessions already exists."""
+        """upgrade() must not call op.create_table or op.create_index when mcp_oauth_sessions already exists."""
         mock_inspector = MagicMock()
         mock_inspector.has_table.return_value = True
         mock_sa.inspect.return_value = mock_inspector
@@ -26,7 +26,7 @@ class TestOAuthStateTablesMigrationUpgrade:
     @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.op")
     @patch("backend.alembic.versions.j4k5l6m7n8o9_add_oauth_state_tables.sa")
     def test_creates_tables_when_absent(self, mock_sa, mock_op):
-        """upgrade() must create all 5 tables when mcp_oauth_sessions does not exist."""
+        """upgrade() must create all 5 tables and 5 indexes when mcp_oauth_sessions does not exist."""
         mock_inspector = MagicMock()
         mock_inspector.has_table.return_value = False
         mock_sa.inspect.return_value = mock_inspector


### PR DESCRIPTION
## Summary

Fixes #1128 — The Alembic migration that creates the MCP OAuth state tables (`j4k5l6m7n8o9_add_oauth_state_tables.py`) was failing with a `DuplicateTable` error when `SQLModel.metadata.create_all()` had already created those tables. This prevented app startup in scenarios where the fallback path runs before Alembic (e.g., clean deploys or container restarts).

The fix adds an idempotency guard that checks if the tables already exist and returns early, mirroring the pattern already established in commit 4ff2c0e for the `mcp_mutations` migration.

## Changes

- **backend/alembic/versions/j4k5l6m7n8o9_add_oauth_state_tables.py** (+5 lines)
  - Added early return guard that checks if `mcp_oauth_sessions` table exists using `sa.inspect().has_table()`
  - All 5 tables in this migration are created together, so checking the first table is sufficient

- **backend/tests/test_migration_j4k5l6m7n8o9_add_oauth_state_tables.py** (new file, +38 lines)
  - Added test `test_skips_create_when_tables_exist` — verifies that `op.create_table` and `op.create_index` are not called when tables already exist
  - Added test `test_creates_tables_when_absent` — verifies that all 5 tables and 5 indices are created when tables don't exist
  - Test structure mirrors the pattern used in `test_migration_mcp_mutations.py`

## Validation

✅ Type check — no errors
✅ Lint — all checks passed
✅ Format — no changes needed
✅ Tests — 4 passed (2 new tests for this migration + 2 existing tests for `mcp_mutations` to ensure no regression)
✅ Integration — idempotency pattern matches the established `mcp_mutations` precedent

All validation completed successfully with no modifications required.