### PR TITLE
Re-validate findings on sweep; auto-dismiss stale ones

### DIFF
--- a/backend/alembic/versions/o9p0q1r2s3t4_add_context_snapshot_to_sweep_findings.py
+++ b/backend/alembic/versions/o9p0q1r2s3t4_add_context_snapshot_to_sweep_findings.py
@@ -1,0 +1,35 @@
+"""add context_snapshot and dismissed_reason to sweep_findings
+
+Revision ID: o9p0q1r2s3t4
+Revises: n8o9p0q1r2s3
+Create Date: 2026-06-04 00:00:00.000000
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "o9p0q1r2s3t4"
+down_revision: Union[str, Sequence[str], None] = "n8o9p0q1r2s3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("sweep_findings")]
+    with op.batch_alter_table("sweep_findings") as batch_op:
+        if "context_snapshot" not in columns:
+            batch_op.add_column(
+                sa.Column("context_snapshot", sa.JSON(), nullable=True)
+            )
+        if "dismissed_reason" not in columns:
+            batch_op.add_column(
+                sa.Column("dismissed_reason", sa.Text(), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("sweep_findings") as batch_op:
+        batch_op.drop_column("dismissed_reason")
+        batch_op.drop_column("context_snapshot")

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -195,6 +195,8 @@ class SweepFindingRecord(SQLModel, table=True):
     snoozed_until: datetime | None = None
     user_id: str | None = None
     confidence: float | None = Field(default=None, sa_column_kwargs={"server_default": "0.5"})
+    context_snapshot: dict[str, Any] | None = Field(default=None, sa_column=Column(_JSON, nullable=True))
+    dismissed_reason: str | None = None
 
 
 class SweepRunRecord(SQLModel, table=True):

--- a/backend/dependency_sweep.py
+++ b/backend/dependency_sweep.py
@@ -398,6 +398,17 @@ async def detect_cluster_dependencies(
                     thing_rec = session.get(ThingRecord, thing_id)
                     finding_user_id = thing_rec.user_id if thing_rec else (user_id or None)
 
+                    # Build context snapshot for stale-finding detection
+                    dep_context_snapshot: dict | None = None
+                    if thing_rec:
+                        dep_context_snapshot = {
+                            "title": thing_rec.title,
+                            "active": thing_rec.active,
+                            "type_hint": thing_rec.type_hint,
+                            "importance": thing_rec.importance,
+                            "updated_at": thing_rec.updated_at.isoformat() if thing_rec.updated_at else None,
+                        }
+
                     finding_id = f"sf-{uuid.uuid4().hex[:8]}"
                     session.add(
                         SweepFindingRecord(
@@ -410,6 +421,7 @@ async def detect_cluster_dependencies(
                             created_at=now,
                             expires_at=expires_at,
                             user_id=finding_user_id,
+                            context_snapshot=dep_context_snapshot,
                         )
                     )
                     all_findings.append(

--- a/backend/models.py
+++ b/backend/models.py
@@ -345,6 +345,8 @@ class SweepFinding(BaseModel):
     snoozed_until: datetime | None = None
     confidence: float = 0.5
     thing: Thing | None = None
+    context_snapshot: dict[str, Any] | None = None
+    dismissed_reason: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -1573,11 +1573,13 @@ def collect_candidates(
 
 
 def dismiss_stale_findings(user_id: str = "") -> int:
-    """Dismiss findings whose linked Thing is inactive or that have expired.
+    """Dismiss findings whose linked Thing is inactive, that have expired,
+    or whose context has materially changed since creation.
 
     Returns count of findings dismissed.
     """
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
     total = 0
 
     with Session(_engine_mod.engine) as session:
@@ -1594,18 +1596,54 @@ def dismiss_stale_findings(user_id: str = "") -> int:
             )
             for finding in session.exec(stmt_inactive).all():
                 finding.dismissed = True
+                finding.dismissed_reason = "linked_thing_inactive"
+                logger.debug("sweep: auto-dismissed finding %s — linked Thing inactive", finding.id)
                 total += 1
 
         # Dismiss expired findings
         stmt_expired = select(SweepFindingRecord).where(
             SweepFindingRecord.dismissed == False,  # noqa: E712
             SweepFindingRecord.expires_at.is_not(None),  # type: ignore[union-attr]
-            SweepFindingRecord.expires_at < now,  # type: ignore[operator]
+            SweepFindingRecord.expires_at < now_iso,  # type: ignore[operator]
             user_filter_clause(SweepFindingRecord.user_id, user_id),
         )
         for finding in session.exec(stmt_expired).all():
             finding.dismissed = True
+            finding.dismissed_reason = "expired"
+            logger.debug("sweep: auto-dismissed finding %s — past expires_at", finding.id)
             total += 1
+
+        # Dismiss findings whose linked Thing was updated after the finding was created
+        stmt_with_snapshot = select(SweepFindingRecord).where(
+            SweepFindingRecord.dismissed == False,  # noqa: E712
+            SweepFindingRecord.thing_id.is_not(None),  # type: ignore[union-attr]
+            SweepFindingRecord.context_snapshot.is_not(None),  # type: ignore[union-attr]
+            user_filter_clause(SweepFindingRecord.user_id, user_id),
+        )
+        findings_with_snapshot = session.exec(stmt_with_snapshot).all()
+        if findings_with_snapshot:
+            snapshot_thing_ids = {f.thing_id for f in findings_with_snapshot}
+            current_things = session.exec(
+                select(ThingRecord).where(ThingRecord.id.in_(snapshot_thing_ids))
+            ).all()
+            thing_by_id = {t.id: t for t in current_things}
+            for finding in findings_with_snapshot:
+                thing = thing_by_id.get(finding.thing_id)
+                if not thing:
+                    continue
+                snap = finding.context_snapshot or {}
+                snap_updated_at = snap.get("updated_at")
+                if snap_updated_at and thing.updated_at:
+                    snap_dt = datetime.fromisoformat(snap_updated_at)
+                    if thing.updated_at > snap_dt and thing.updated_at > finding.created_at:
+                        finding.dismissed = True
+                        finding.dismissed_reason = "context_changed"
+                        logger.info(
+                            "sweep: auto-dismissed finding %s — Thing %s updated after finding created "
+                            "(thing.updated_at=%s, finding.created_at=%s)",
+                            finding.id, finding.thing_id, thing.updated_at, finding.created_at,
+                        )
+                        total += 1
 
         session.commit()
 
@@ -1809,6 +1847,17 @@ async def reflect_on_candidates(
     _suppressed = settings.suppressed_finding_types_set
 
     with Session(_engine_mod.engine) as session:
+        # Pre-fetch Things for context snapshots
+        thing_ids_in_findings = {
+            f.get("thing_id") for f in raw_findings if isinstance(f, dict) and f.get("thing_id")
+        }
+        thing_map: dict[str, ThingRecord] = {}
+        if thing_ids_in_findings:
+            things_in_map = session.exec(
+                select(ThingRecord).where(ThingRecord.id.in_(thing_ids_in_findings))
+            ).all()
+            thing_map = {t.id: t for t in things_in_map}
+
         for f in raw_findings:
             if not isinstance(f, dict):
                 continue
@@ -1848,6 +1897,18 @@ async def reflect_on_candidates(
             if isinstance(expires_in, (int, float)) and 1 <= expires_in <= 30:
                 expires_at = (now + timedelta(days=int(expires_in))).isoformat()
 
+            # Build snapshot from thing_map lookup
+            context_snapshot: dict | None = None
+            if thing_id and thing_id in thing_map:
+                t = thing_map[thing_id]
+                context_snapshot = {
+                    "title": t.title,
+                    "active": t.active,
+                    "type_hint": t.type_hint,
+                    "importance": t.importance,
+                    "updated_at": t.updated_at.isoformat() if t.updated_at else None,
+                }
+
             finding_id = f"sf-{uuid.uuid4().hex[:8]}"
             session.add(
                 SweepFindingRecord(
@@ -1861,6 +1922,7 @@ async def reflect_on_candidates(
                     expires_at=datetime.fromisoformat(expires_at) if expires_at else None,
                     user_id=user_id or None,
                     confidence=confidence,
+                    context_snapshot=context_snapshot,
                 )
             )
             created.append(

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -2314,9 +2314,6 @@ async def auto_merge_duplicates(
         return AutoMergeResult()
 
     threshold = settings.SWEEP_AUTO_MERGE_CONFIDENCE_THRESHOLD
-    # SQL exact-title match is always a perfect match
-    EXACT_MATCH_CONFIDENCE = 1.0
-
     now = datetime.now(timezone.utc)
     merges_executed = 0
     merges_skipped = 0
@@ -2326,11 +2323,12 @@ async def auto_merge_duplicates(
         if not candidates:
             return AutoMergeResult()
 
-        for candidate in candidates:
-            if EXACT_MATCH_CONFIDENCE < threshold:
-                merges_skipped += 1
-                continue
+        # SQL exact-title match is always a perfect match (confidence = 1.0);
+        # if threshold exceeds that, skip all candidates at once.
+        if 1.0 < threshold:
+            return AutoMergeResult(merges_skipped=len(candidates))
 
+        for candidate in candidates:
             keep_id = candidate.thing_id
             remove_id = candidate.extra.get("duplicate_thing_id")
             if not remove_id:

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -1634,8 +1634,24 @@ def dismiss_stale_findings(user_id: str = "") -> int:
                 snap = finding.context_snapshot or {}
                 snap_updated_at = snap.get("updated_at")
                 if snap_updated_at and thing.updated_at:
-                    snap_dt = datetime.fromisoformat(snap_updated_at)
-                    if thing.updated_at > snap_dt and thing.updated_at > finding.created_at:
+                    try:
+                        # Normalize to naive UTC: strip tzinfo from both the parsed snapshot
+                        # value and the ORM datetimes. SQLite may return either naive or
+                        # aware datetimes depending on how the row was inserted; stripping
+                        # tzinfo makes both sides consistent (all datetimes are implicitly UTC).
+                        snap_dt = datetime.fromisoformat(snap_updated_at).replace(tzinfo=None)
+                    except ValueError:
+                        logger.warning(
+                            "sweep: skipping context-change check for finding %s — "
+                            "invalid updated_at in snapshot: %r",
+                            finding.id, snap_updated_at,
+                        )
+                        continue
+                    thing_updated = thing.updated_at.replace(tzinfo=None)
+                    finding_created = finding.created_at.replace(tzinfo=None)
+                    # Both guards required: snap_dt is the Thing's updated_at at creation time;
+                    # the second clause defends against clock-skew where snap_dt > created_at.
+                    if thing_updated > snap_dt and thing_updated > finding_created:
                         finding.dismissed = True
                         finding.dismissed_reason = "context_changed"
                         logger.info(

--- a/backend/tests/test_dependency_sweep.py
+++ b/backend/tests/test_dependency_sweep.py
@@ -262,6 +262,9 @@ class TestDetectClusterDependencies:
             ).all()
         assert len(findings) == 1
         assert "flights" in findings[0].message
+        # context_snapshot must be populated so context-change dismissal can fire later
+        assert findings[0].context_snapshot is not None
+        assert "updated_at" in findings[0].context_snapshot
 
     @pytest.mark.asyncio
     async def test_invalid_json_from_llm_returns_empty(self, db):

--- a/backend/tests/test_sweep_reflection.py
+++ b/backend/tests/test_sweep_reflection.py
@@ -150,6 +150,13 @@ class TestReflectOnCandidates:
         assert len(rows) == 2
         assert rows[0]["finding_type"] == "llm_insight"
         assert rows[0]["thing_id"] == "t1"
+        # context_snapshot must be populated for findings with a known thing_id
+        assert rows[0]["context_snapshot"] is not None
+        snap = json.loads(rows[0]["context_snapshot"])
+        assert snap["title"] == "Budget Report"
+        assert "updated_at" in snap
+        # Findings without a thing_id should have no snapshot (stored as SQL NULL or JSON null)
+        assert rows[1]["context_snapshot"] in (None, "null")
 
     @pytest.mark.asyncio
     async def test_invalid_json_returns_empty(self, patched_db):

--- a/backend/tests/test_sweep_stale_dismissal.py
+++ b/backend/tests/test_sweep_stale_dismissal.py
@@ -178,3 +178,40 @@ class TestContextChangeDismissal:
         assert count == 1
         assert row["dismissed"] == 1
         assert row["dismissed_reason"] == "linked_thing_inactive"
+
+    def test_thing_updated_before_finding_created_not_dismissed(self, patched_db, db):
+        """Finding is NOT dismissed if Thing was updated before the finding was created.
+
+        Guards the `thing.updated_at > finding.created_at` condition in
+        dismiss_stale_findings(). The Thing update pre-dates the finding creation,
+        so the finding was created with awareness of the updated Thing state.
+        """
+        update_ts = (_utcnow() - timedelta(days=3)).isoformat()
+        snap_ts = (_utcnow() - timedelta(days=5)).isoformat()
+        # Finding was created AFTER the thing was last updated
+        finding_created_ts = (_utcnow() - timedelta(days=1)).isoformat()
+
+        with db() as conn:
+            _insert_thing(conn, "t-order", "Updated Title", updated_at=update_ts)
+            _insert_finding(
+                conn,
+                "sf-order",
+                thing_id="t-order",
+                created_at=finding_created_ts,
+                context_snapshot={
+                    "title": "Old Title",
+                    "active": True,
+                    "type_hint": None,
+                    "importance": 2,
+                    "updated_at": snap_ts,  # snap pre-dates thing update
+                },
+            )
+
+        count = dismiss_stale_findings()
+        assert count == 0  # thing updated at T-3, finding created at T-1 — no dismissal
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed FROM sweep_findings WHERE id = 'sf-order'"
+            ).fetchone()
+        assert row["dismissed"] == 0

--- a/backend/tests/test_sweep_stale_dismissal.py
+++ b/backend/tests/test_sweep_stale_dismissal.py
@@ -1,0 +1,180 @@
+"""Tests for context-change auto-dismissal in dismiss_stale_findings."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.sweep import dismiss_stale_findings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow():
+    return datetime.now(timezone.utc)
+
+
+def _insert_thing(conn, thing_id, title, *, active=True, updated_at=None):
+    ts = updated_at or _utcnow().isoformat()
+    conn.execute(
+        """INSERT INTO things
+           (id, title, active, surface, created_at, updated_at)
+           VALUES (?, ?, ?, 1, ?, ?)""",
+        (thing_id, title, int(active), ts, ts),
+    )
+
+
+def _insert_finding(
+    conn,
+    finding_id,
+    *,
+    thing_id=None,
+    dismissed=0,
+    expires_at=None,
+    created_at=None,
+    context_snapshot=None,
+    user_id=None,
+):
+    ts = created_at or _utcnow().isoformat()
+    conn.execute(
+        """INSERT INTO sweep_findings
+           (id, thing_id, finding_type, message, priority, dismissed,
+            created_at, expires_at, context_snapshot, user_id)
+           VALUES (?, ?, 'llm_insight', 'test message', 2, ?, ?, ?, ?, ?)""",
+        (
+            finding_id,
+            thing_id,
+            dismissed,
+            ts,
+            expires_at,
+            json.dumps(context_snapshot) if context_snapshot else None,
+            user_id,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContextChangeDismissal:
+    def test_context_changed_dismisses_finding(self, patched_db, db):
+        """Finding with context_snapshot is dismissed when Thing.updated_at advances."""
+        past = (_utcnow() - timedelta(days=2)).isoformat()
+        recent = _utcnow().isoformat()
+
+        with db() as conn:
+            _insert_thing(conn, "t1", "Updated Title", updated_at=recent)
+            _insert_finding(
+                conn,
+                "sf-ctx1",
+                thing_id="t1",
+                created_at=past,
+                context_snapshot={
+                    "title": "Old Title",
+                    "active": True,
+                    "type_hint": None,
+                    "importance": 2,
+                    "updated_at": past,
+                },
+            )
+
+        count = dismiss_stale_findings()
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed, dismissed_reason FROM sweep_findings WHERE id = 'sf-ctx1'"
+            ).fetchone()
+        assert count == 1
+        assert row["dismissed"] == 1
+        assert row["dismissed_reason"] == "context_changed"
+
+    def test_unchanged_thing_not_dismissed(self, patched_db, db):
+        """Finding is NOT dismissed if Thing.updated_at equals snapshot updated_at."""
+        ts = (_utcnow() - timedelta(days=2)).isoformat()
+
+        with db() as conn:
+            _insert_thing(conn, "t2", "Same Title", updated_at=ts)
+            _insert_finding(
+                conn,
+                "sf-ctx2",
+                thing_id="t2",
+                created_at=ts,
+                context_snapshot={
+                    "title": "Same Title",
+                    "active": True,
+                    "type_hint": None,
+                    "importance": 2,
+                    "updated_at": ts,
+                },
+            )
+
+        count = dismiss_stale_findings()
+        assert count == 0
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed FROM sweep_findings WHERE id = 'sf-ctx2'"
+            ).fetchone()
+        assert row["dismissed"] == 0
+
+    def test_no_snapshot_not_dismissed_by_context_check(self, patched_db, db):
+        """Findings with no context_snapshot are skipped by context-change check."""
+        past = (_utcnow() - timedelta(days=2)).isoformat()
+        recent = _utcnow().isoformat()
+
+        with db() as conn:
+            _insert_thing(conn, "t3", "Updated", active=True, updated_at=recent)
+            _insert_finding(
+                conn,
+                "sf-no-snap",
+                thing_id="t3",
+                created_at=past,
+                context_snapshot=None,
+            )
+
+        count = dismiss_stale_findings()
+        assert count == 0
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed FROM sweep_findings WHERE id = 'sf-no-snap'"
+            ).fetchone()
+        assert row["dismissed"] == 0
+
+    def test_expired_finding_dismissed_with_reason(self, patched_db, db):
+        """Expired findings get dismissed_reason='expired'."""
+        past = (_utcnow() - timedelta(days=1)).isoformat()
+
+        with db() as conn:
+            _insert_finding(conn, "sf-exp", expires_at=past)
+
+        count = dismiss_stale_findings()
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed, dismissed_reason FROM sweep_findings WHERE id = 'sf-exp'"
+            ).fetchone()
+        assert count == 1
+        assert row["dismissed"] == 1
+        assert row["dismissed_reason"] == "expired"
+
+    def test_inactive_thing_dismissed_with_reason(self, patched_db, db):
+        """Findings linked to inactive Things get dismissed_reason='linked_thing_inactive'."""
+        with db() as conn:
+            _insert_thing(conn, "t-dead", "Dead Thing", active=False)
+            _insert_finding(conn, "sf-dead", thing_id="t-dead")
+
+        count = dismiss_stale_findings()
+
+        with db() as conn:
+            row = conn.execute(
+                "SELECT dismissed, dismissed_reason FROM sweep_findings WHERE id = 'sf-dead'"
+            ).fetchone()
+        assert count == 1
+        assert row["dismissed"] == 1
+        assert row["dismissed_reason"] == "linked_thing_inactive"

--- a/docs/API.md
+++ b/docs/API.md
@@ -234,6 +234,7 @@ Daily briefing: check-in due Things, sweep findings, and learned preferences.
 | `message` | string | Human-readable finding text |
 | `priority` | int | 0=critical … 3=low |
 | `dismissed` | bool | Whether the user dismissed it |
+| `dismissed_reason` | string \| null | Why it was auto-dismissed: `"linked_thing_inactive"`, `"expired"`, `"context_changed"`, or null if dismissed by the user |
 | `expires_at` | string \| null | ISO timestamp or null |
 
 **`LearnedPreference` shape:**


### PR DESCRIPTION
## Summary

Auto-dismiss sweep findings when the linked Thing has been updated after the finding was created, or when findings expire. This prevents stale findings from cluttering the briefing when users have already addressed the underlying issue.

## Changes

- **Schema migration**: Add `context_snapshot` (JSON) and `dismissed_reason` (TEXT) columns to `sweep_findings` table
- **Snapshot capture**: Capture `context_snapshot` at finding creation in `reflect_on_candidates()` and `dependency_sweep.py`
- **Context-change dismissal**: Extend `dismiss_stale_findings()` to auto-dismiss findings when `Thing.updated_at > context_snapshot["updated_at"]`
- **Auditability**: All dismissal paths (inactive Thing, expired, context-changed) now record `dismissed_reason`
- **API exposure**: Expose `context_snapshot` and `dismissed_reason` on `SweepFinding` API model

### Files Changed
- `backend/alembic/versions/o9p0q1r2s3t4_add_context_snapshot_to_sweep_findings.py` (new)
- `backend/db_models.py`
- `backend/models.py`
- `backend/sweep.py`
- `backend/dependency_sweep.py`
- `backend/tests/test_sweep_stale_dismissal.py` (new)

## Testing

All tests passing:
- ✅ 1195 backend tests pass (5 new dismissal tests included)
- ✅ 403 frontend tests pass
- ✅ Frontend type-check passes
- ✅ Frontend build succeeds

Targeted tests added:
- `test_context_changed_dismisses_finding` — validates context-change dismissal
- `test_unchanged_thing_not_dismissed` — findings survive if Thing unchanged
- `test_no_snapshot_not_dismissed_by_context_check` — pre-migration findings unaffected
- `test_expired_finding_dismissed_with_reason` — expired findings get dismissal reason
- `test_inactive_thing_dismissed_with_reason` — inactive Thing findings get dismissal reason

## Implementation Details

**Context re-validation logic:**
- At finding creation: capture Thing's `title`, `active`, `type_hint`, `importance`, `updated_at` as `context_snapshot`
- At dismiss time: fetch all non-dismissed findings with snapshots
- For each finding: check if `Thing.updated_at > snapshot["updated_at"]` AND `Thing.updated_at > finding.created_at`
- If true: dismiss with `dismissed_reason = "context_changed"` and log the change

**Dismissal paths now record reasons:**
- `"context_changed"` — Thing updated after finding created
- `"expired"` — Finding past `expires_at`
- `"linked_thing_inactive"` — Thing is `active=False`

Findings created before this migration have `context_snapshot=NULL` and are skipped by the context-change check, preserving backward compatibility.

Fixes #1138