### PR TITLE
Fix staging-pipeline HTTP 000000 bug — same pattern as #1153

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -95,7 +95,8 @@ jobs:
           sleep 90
           echo "Polling ${RAILWAY_STAGING_URL}/healthz ..."
           for i in $(seq 1 20); do
-            HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null || echo "000")
+            HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null)
+            HTTP_CODE=${HTTP_CODE:-000}
             BODY=$(cat /tmp/hc_body.txt 2>/dev/null || true)
             echo "Attempt $i/20: HTTP $HTTP_CODE — ${BODY:0:100}"
             if [ "$HTTP_CODE" = "200" ] && echo "$BODY" | grep -q '"status":"ok"'; then


### PR DESCRIPTION
## Summary

Fixed a latent `|| echo "000"` bug in `.github/workflows/staging-pipeline.yml:98` that duplicates HTTP status codes to `000000` when curl fails. This is the same pattern fixed in #1153 for the external health check script.

## Problem

When curl fails (timeout, connection refused) during the staging health check:
1. curl writes `000` to stdout via `-w "%{http_code}"`
2. curl exits with non-zero status
3. The `|| echo "000"` fallback fires, appending another `000`
4. Result: `HTTP_CODE=000000` (confusing and inconsistent after #1153)

## Changes

**File**: `.github/workflows/staging-pipeline.yml`  
**Lines**: 98

Changed from:
```bash
HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null || echo "000")
```

To:
```bash
HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null)
HTTP_CODE=${HTTP_CODE:-000}
```

## Validation

✅ YAML syntax: valid  
✅ Backend tests: 1226 passed, 14 skipped (86.88% coverage)  
✅ Frontend tests: 403 passed  
✅ Frontend build: successful  

Fixes #1156