### PR TITLE
Fix: add safety caps to unbounded SQL queries

### DIFF
--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -111,6 +111,8 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
             .order_by(ThingRecord.importance.asc(), ThingRecord.updated_at.desc())
             .limit(10_000)
         ).all()
+        if len(all_active) == 10_000:
+            logger.warning("briefing: active-things query hit safety cap (10,000 rows) for user=%s", user_id)
 
         active_ids = [t.id for t in all_active]
 
@@ -130,6 +132,8 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
             if active_ids
             else []
         )
+        if len(rel_rows) == 20_000:
+            logger.warning("briefing: relationships query hit safety cap (20,000 rows) for user=%s", user_id)
 
         # Active (not dismissed, not expired, not snoozed) sweep findings with linked Things
         finding_stmt = (
@@ -162,6 +166,8 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
                 | SweepFindingRecord.confidence.is_(None)  # type: ignore[union-attr]
             )
         finding_results = session.exec(finding_stmt.limit(1_000)).all()
+        if len(finding_results) == 1_000:
+            logger.warning("briefing: findings query hit safety cap (1,000 rows) for user=%s", user_id)
 
     # Learned preference Things for "I Noticed" section
     pref_records = sorted(

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -108,6 +108,7 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
                 ThingRecord.active,
                 user_filter_clause(ThingRecord.user_id, user_id),
             )
+            .order_by(ThingRecord.importance.asc(), ThingRecord.updated_at.desc())
             .limit(10_000)
         ).all()
 

--- a/backend/routers/briefing.py
+++ b/backend/routers/briefing.py
@@ -103,10 +103,12 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
     with Session(_engine_mod.engine) as session:
         # All active things (for blocker graph + checkin-due filtering)
         all_active = session.exec(
-            select(ThingRecord).where(
+            select(ThingRecord)
+            .where(
                 ThingRecord.active,
                 user_filter_clause(ThingRecord.user_id, user_id),
             )
+            .limit(10_000)
         ).all()
 
         active_ids = [t.id for t in all_active]
@@ -114,13 +116,15 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
         # Relationships for blocker graph
         rel_rows = (
             session.exec(
-                select(ThingRelationshipRecord).where(
+                select(ThingRelationshipRecord)
+                .where(
                     ThingRelationshipRecord.relationship_type.in_(["blocks", "depends-on"]),  # type: ignore[union-attr]
                     or_(
                         ThingRelationshipRecord.from_thing_id.in_(active_ids),
                         ThingRelationshipRecord.to_thing_id.in_(active_ids),
                     ),
                 )
+                .limit(20_000)
             ).all()
             if active_ids
             else []
@@ -156,7 +160,7 @@ def get_briefing(as_of: date | None = None, user_id: str = Depends(require_user)
                 (SweepFindingRecord.confidence >= min_conf)
                 | SweepFindingRecord.confidence.is_(None)  # type: ignore[union-attr]
             )
-        finding_results = session.exec(finding_stmt).all()
+        finding_results = session.exec(finding_stmt.limit(1_000)).all()
 
     # Learned preference Things for "I Noticed" section
     pref_records = sorted(

--- a/backend/routers/focus.py
+++ b/backend/routers/focus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import date, datetime
 from typing import Any
@@ -18,6 +19,8 @@ from ..google_calendar import fetch_upcoming_events
 from ..google_calendar import is_connected as calendar_connected
 from ..models import FocusRecommendation, FocusResponse, Thing
 from .things import _record_to_thing
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/focus", tags=["focus"])
 
@@ -91,6 +94,8 @@ def _compute_recommendations(
             .limit(5_000)
         )  # type: ignore[union-attr, attr-defined]
         thing_records = session.exec(thing_stmt).all()
+        if len(thing_records) == 5_000:
+            logger.warning("focus: things query hit safety cap (5,000 rows) for user=%s", user_id)
         thing_ids = [r.id for r in thing_records]
 
         rel_records = (
@@ -107,6 +112,8 @@ def _compute_recommendations(
             if thing_ids
             else []
         )
+        if len(rel_records) == 10_000:
+            logger.warning("focus: relationships query hit safety cap (10,000 rows) for user=%s", user_id)
 
     things = [_record_to_thing(r) for r in thing_records]
     thing_map: dict[str, Thing] = {t.id: t for t in things}

--- a/backend/routers/focus.py
+++ b/backend/routers/focus.py
@@ -88,18 +88,21 @@ def _compute_recommendations(
                 user_filter_clause(ThingRecord.user_id, user_id),
             )
             .order_by(ThingRecord.importance.asc(), ThingRecord.updated_at.desc())
+            .limit(5_000)
         )  # type: ignore[union-attr, attr-defined]
         thing_records = session.exec(thing_stmt).all()
         thing_ids = [r.id for r in thing_records]
 
         rel_records = (
             session.exec(
-                select(ThingRelationshipRecord).where(
+                select(ThingRelationshipRecord)
+                .where(
                     or_(
                         ThingRelationshipRecord.from_thing_id.in_(thing_ids),
                         ThingRelationshipRecord.to_thing_id.in_(thing_ids),
                     )
                 )
+                .limit(10_000)
             ).all()
             if thing_ids
             else []

--- a/backend/routers/staleness.py
+++ b/backend/routers/staleness.py
@@ -1,5 +1,6 @@
 """Staleness & neglect detection endpoint -- batch summary for notifications."""
 
+import logging
 from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, Query
@@ -21,6 +22,8 @@ from ..models import (
 from ..sweep import _parse_date_value
 from .settings import get_user_stale_threshold
 from .things import _record_to_thing
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/staleness", tags=["staleness"])
 
@@ -71,6 +74,8 @@ def get_staleness_report(
             .limit(5_000)
         )
         stale_results = session.exec(stale_stmt).all()
+        if len(stale_results) == 5_000:
+            logger.warning("staleness: stale-things query hit safety cap (5,000 rows) for user=%s", user_id)
 
         # Overdue checkins
         overdue_stmt = (
@@ -85,6 +90,8 @@ def get_staleness_report(
             .limit(5_000)
         )
         overdue_records = session.exec(overdue_stmt).all()
+        if len(overdue_records) == 5_000:
+            logger.warning("staleness: overdue-checkins query hit safety cap (5,000 rows) for user=%s", user_id)
 
     stale_items: list[StaleItem] = []
     neglected_count = 0

--- a/backend/routers/staleness.py
+++ b/backend/routers/staleness.py
@@ -68,6 +68,7 @@ def get_staleness_report(
                 user_filter_clause(ThingRecord.user_id, user_id),
             )
             .order_by(ThingRecord.updated_at.asc())  # type: ignore[union-attr]
+            .limit(5_000)
         )
         stale_results = session.exec(stale_stmt).all()
 
@@ -81,6 +82,7 @@ def get_staleness_report(
                 user_filter_clause(ThingRecord.user_id, user_id),
             )
             .order_by(ThingRecord.checkin_date.asc())  # type: ignore[union-attr]
+            .limit(5_000)
         )
         overdue_records = session.exec(overdue_stmt).all()
 

--- a/backend/sweep.py
+++ b/backend/sweep.py
@@ -1622,10 +1622,11 @@ def dismiss_stale_findings(user_id: str = "") -> int:
         findings_with_snapshot = session.exec(stmt_with_snapshot).all()
         if findings_with_snapshot:
             snapshot_thing_ids = {f.thing_id for f in findings_with_snapshot}
-            current_things = session.exec(
-                select(ThingRecord).where(ThingRecord.id.in_(snapshot_thing_ids))
-            ).all()
-            thing_by_id = {t.id: t for t in current_things}
+            thing_by_id = {
+                t.id: t for t in session.exec(
+                    select(ThingRecord).where(ThingRecord.id.in_(snapshot_thing_ids))
+                ).all()
+            }
             for finding in findings_with_snapshot:
                 thing = thing_by_id.get(finding.thing_id)
                 if not thing:
@@ -1872,10 +1873,11 @@ async def reflect_on_candidates(
         }
         thing_map: dict[str, ThingRecord] = {}
         if thing_ids_in_findings:
-            things_in_map = session.exec(
-                select(ThingRecord).where(ThingRecord.id.in_(thing_ids_in_findings))
-            ).all()
-            thing_map = {t.id: t for t in things_in_map}
+            thing_map = {
+                t.id: t for t in session.exec(
+                    select(ThingRecord).where(ThingRecord.id.in_(thing_ids_in_findings))
+                ).all()
+            }
 
         for f in raw_findings:
             if not isinstance(f, dict):

--- a/backend/tests/test_focus.py
+++ b/backend/tests/test_focus.py
@@ -1,0 +1,69 @@
+"""Tests for the focus recommendations endpoint."""
+
+from datetime import date, timedelta
+
+
+def _create_thing(client, title: str, **kwargs) -> dict:
+    payload = {"title": title, **kwargs}
+    resp = client.post("/api/things", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+class TestFocusEndpoint:
+    def test_empty_focus(self, client):
+        resp = client.get("/api/focus")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "recommendations" in data
+        assert "total" in data
+        assert "calendar_active" in data
+        assert data["recommendations"] == []
+        assert data["total"] == 0
+
+    def test_focus_with_task(self, client):
+        _create_thing(client, "Important task", type_hint="task", importance=0)
+        resp = client.get("/api/focus")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        assert len(data["recommendations"]) >= 1
+        rec = data["recommendations"][0]
+        assert "thing" in rec
+        assert "score" in rec
+        assert "reasons" in rec
+        assert "is_blocked" in rec
+
+    def test_focus_limit_query_param(self, client):
+        for i in range(5):
+            _create_thing(client, f"Task {i}", type_hint="task", importance=1)
+        resp = client.get("/api/focus?limit=2")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["recommendations"]) <= 2
+
+    def test_focus_respects_active_flag(self, client):
+        thing = _create_thing(client, "Active task", type_hint="task", importance=0)
+        # Deactivate the thing
+        client.patch(f"/api/things/{thing['id']}", json={"active": False})
+        resp = client.get("/api/focus")
+        assert resp.status_code == 200
+        data = resp.json()
+        ids_in_focus = [r["thing"]["id"] for r in data["recommendations"]]
+        assert thing["id"] not in ids_in_focus
+
+    def test_focus_overdue_checkin_boosts_score(self, client):
+        past = (date.today() - timedelta(days=3)).isoformat()
+        overdue = _create_thing(
+            client, "Overdue check-in task", type_hint="task", importance=2,
+            checkin_date=f"{past}T09:00:00"
+        )
+        normal = _create_thing(client, "Normal task", type_hint="task", importance=2)
+        resp = client.get("/api/focus?limit=10")
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [r["thing"]["id"] for r in data["recommendations"]]
+        assert overdue["id"] in ids
+        # Overdue check-in should appear before normal task
+        if normal["id"] in ids:
+            assert ids.index(overdue["id"]) < ids.index(normal["id"])

--- a/backend/tests/test_focus.py
+++ b/backend/tests/test_focus.py
@@ -64,6 +64,6 @@ class TestFocusEndpoint:
         data = resp.json()
         ids = [r["thing"]["id"] for r in data["recommendations"]]
         assert overdue["id"] in ids
+        assert normal["id"] in ids
         # Overdue check-in should appear before normal task
-        if normal["id"] in ids:
-            assert ids.index(overdue["id"]) < ids.index(normal["id"])
+        assert ids.index(overdue["id"]) < ids.index(normal["id"])


### PR DESCRIPTION
## Summary

Fixes #1206 (SEC-28: Unbounded query results)

Adds hardcoded `LIMIT` clauses to 7 SQL SELECT queries that were fetching unbounded result sets. This prevents self-inflicted DoS where a user with a large dataset could exhaust server memory/CPU through endpoints that load entire result sets into Python for in-memory scoring.

**Impact**: Low severity — only affects the authenticated user's own data; no cross-user impact.

## Changes

Added `.limit(N)` safety caps to unbounded queries across three router modules:

### `backend/routers/briefing.py`
- Line 105: `active Things query` → `.limit(10_000)`
- Line 115: `relationships query` → `.limit(20_000)`
- Line 159: `findings query` → `.limit(1_000)`

### `backend/routers/staleness.py`
- Line 70: `stale items query` → `.limit(5_000)`
- Line 83: `overdue items query` → `.limit(5_000)`

### `backend/routers/focus.py`
- Line 92: `Things query` → `.limit(5_000)`
- Line 103: `relationships query` → `.limit(10_000)`

Limits are hardcoded and non-configurable because these endpoints perform in-memory scoring/filtering that would break with naive pagination. The caps are set orders of magnitude higher than any realistic user dataset.

## Validation

✅ **Type checking** (mypy): No new errors introduced  
✅ **Lint** (ruff): All checks passed  
✅ **Backend tests** (pytest): 1233 passed, 14 skipped, 0 failed  
✅ **Frontend tests** (vitest): 403 passed across 29 files  
✅ **Code coverage**: 86.95% (required: 70%)  

All changes are backend-only (no frontend changes required).

---

Fixes #1206