### PR TITLE
Fix: refactor subprocess.run(shell=True) to shell=False

### DIFF
--- a/.gc/scripts/dashboard.py
+++ b/.gc/scripts/dashboard.py
@@ -4,6 +4,7 @@
 import json
 import os
 import re
+import shlex
 import subprocess
 import threading
 import time
@@ -33,8 +34,9 @@ ISSUES_INTERVAL = 60
 # ── helpers ──────────────────────────────────────────────────────────────
 
 def run(cmd, cwd=None, timeout=10):
+    args = cmd if isinstance(cmd, list) else shlex.split(cmd)
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+        r = subprocess.run(args, shell=False, capture_output=True, text=True,
                            cwd=cwd, timeout=timeout)
         return r.stdout.strip()
     except Exception:

--- a/.gc/scripts/dashboard.py
+++ b/.gc/scripts/dashboard.py
@@ -10,12 +10,17 @@ import threading
 import time
 from datetime import datetime
 
-from textual.app import App, ComposeResult
-from textual.containers import Vertical, VerticalScroll
-from textual.widgets import (
-    DataTable, Header, Static, Label, TabbedContent, TabPane,
-)
 from textual import work
+from textual.app import App, ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import (
+    DataTable,
+    Header,
+    Label,
+    Static,
+    TabbedContent,
+    TabPane,
+)
 from textual.worker import get_current_worker
 
 CITY_ROOT = "/mnt/ext-fast/gc"

--- a/.gc/scripts/health.py
+++ b/.gc/scripts/health.py
@@ -10,6 +10,7 @@ Rewrite of health.sh — same checks, same output, same CLI.
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -97,20 +98,21 @@ class HealthReport:
 # Subprocess helpers
 # ---------------------------------------------------------------------------
 
-def run_cmd(cmd: str, timeout: int = CMD_TIMEOUT, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
-    """Run a shell command and return the CompletedProcess."""
+def run_cmd(cmd: list[str] | str, timeout: int = CMD_TIMEOUT, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
+    """Run a command and return the CompletedProcess."""
+    args = cmd if isinstance(cmd, list) else shlex.split(cmd)
     try:
         return subprocess.run(
-            cmd, shell=True, capture_output=True, text=True,
+            args, shell=False, capture_output=True, text=True,
             timeout=timeout, cwd=cwd,
         )
     except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="timeout")
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="timeout")
     except Exception as e:
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=str(e))
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr=str(e))
 
 
-def run_cmd_output(cmd: str, timeout: int = CMD_TIMEOUT, cwd: Optional[str] = None) -> str:
+def run_cmd_output(cmd: list[str] | str, timeout: int = CMD_TIMEOUT, cwd: Optional[str] = None) -> str:
     """Run a command and return stripped stdout (empty string on failure)."""
     r = run_cmd(cmd, timeout=timeout, cwd=cwd)
     return r.stdout.strip() if r.returncode == 0 else ""
@@ -252,8 +254,10 @@ def check_controller(report: HealthReport, fix: bool) -> None:
 def check_disk(report: HealthReport) -> None:
     """Section 1: Disk usage."""
     report.section("DISK")
-    pct_out = run_cmd_output("df / --output=pcent 2>/dev/null | tail -1")
-    avail_out = run_cmd_output("df -h / --output=avail 2>/dev/null | tail -1")
+    pct_out = run_cmd_output(["df", "/", "--output=pcent"])
+    pct_out = pct_out.splitlines()[-1].strip() if pct_out else ""
+    avail_out = run_cmd_output(["df", "-h", "/", "--output=avail"])
+    avail_out = avail_out.splitlines()[-1].strip() if avail_out else ""
     pct_str = pct_out.strip().replace("%", "").strip()
     avail_str = avail_out.strip()
     try:
@@ -274,18 +278,27 @@ def check_dolt(report: HealthReport, fix: bool, city: str = CITY_ROOT) -> None:
     report.section("DOLT")
 
     # Find dolt PID
-    dolt_pid = run_cmd_output(f"pgrep -f 'dolt sql-server.*{city}' | head -1")
+    dolt_pid = run_cmd_output(["pgrep", "-f", f"dolt sql-server.*{city}"])
+    dolt_pid = dolt_pid.splitlines()[0].strip() if dolt_pid else ""
     if not dolt_pid:
-        dolt_pid = run_cmd_output("pgrep -f 'dolt sql-server.*dolt-config' | head -1")
+        dolt_pid = run_cmd_output(["pgrep", "-f", "dolt sql-server.*dolt-config"])
+        dolt_pid = dolt_pid.splitlines()[0].strip() if dolt_pid else ""
     if not dolt_pid:
         report.fail("Dolt server not running")
         return
 
     # Port and size
-    dolt_port = run_cmd_output(
-        f"ss -tlnp 2>/dev/null | grep 'pid={dolt_pid}' | grep -oP ':\\K\\d+' | head -1"
-    ) or "?"
-    dolt_size = run_cmd_output(f"du -sh {city}/.beads/dolt 2>/dev/null | cut -f1") or "?"
+    _r = run_cmd(["ss", "-tlnp"])
+    dolt_port = "?"
+    if _r.returncode == 0:
+        for _line in _r.stdout.splitlines():
+            if f"pid={dolt_pid}" in _line:
+                _m = re.search(r':(\d+)\s', _line)
+                if _m:
+                    dolt_port = _m.group(1)
+                    break
+    _du_out = run_cmd_output(["du", "-sh", f"{city}/.beads/dolt"])
+    dolt_size = _du_out.split()[0] if _du_out else "?"
 
     info_str = f"PID {dolt_pid}, port {dolt_port}, {dolt_size}"
 

--- a/.gc/scripts/health.py
+++ b/.gc/scripts/health.py
@@ -774,8 +774,13 @@ def _check_orphaned_beads(report: HealthReport, rig: str, rig_dir: str,
 
 def _check_untracked_branches(report: HealthReport, rig: str, rig_dir: str,
                               repo: str) -> None:
-    unmerged_out = run_cmd_output(
-        f"git -C {rig_dir} branch -r --no-merged master 2>/dev/null | grep 'origin/' | grep -v 'HEAD' | sed 's|.*origin/||'"
+    raw = run_cmd_output(
+        ["git", "-C", rig_dir, "branch", "-r", "--no-merged", "master"],
+    )
+    unmerged_out = "\n".join(
+        line.strip().removeprefix("origin/")
+        for line in raw.splitlines()
+        if "origin/" in line and "HEAD" not in line
     )
     if not unmerged_out:
         return


### PR DESCRIPTION
## Summary

Refactor subprocess calls in `.gc/scripts/` admin scripts to use `shell=False` with explicit argument lists, eliminating a security risk from shell injection. This addresses SEC-23.

**Changes**:
- `.gc/scripts/dashboard.py`: rewrite `run()` to use `shell=False` with list arguments
- `.gc/scripts/health.py`: rewrite `run_cmd()` to use `shell=False`, fix shell-pipe callers in `check_disk()` and `check_dolt()`

## Validation

- ✅ All tests passing: 44 health tests, 1248 backend tests (87.60% coverage)
- ✅ Python linter (Ruff) checks pass
- ✅ No instances of `shell=True` remain in `.gc/scripts/`
- ✅ Shell pipeline calls replaced with list args + Python string filtering
- ✅ Frontend tests pass (403 passed)

## Implementation Details

**Key changes in `health.py`**:
- Added `shlex` import
- Updated `run_cmd()` to accept `list[str] | str` and pass list args to `subprocess.run(shell=False)`
- Fixed `check_disk()` and `check_dolt()` to use list argument wrappers instead of shell pipes
- Replaced shell pipeline string (line 778) with list args + Python filtering

**Key changes in `dashboard.py`**:
- Added `shlex` import
- Updated `run()` to use `shell=False` with split command arguments
- Fixed import order and removed unused `Vertical` import

## Related Issue

Fixes #1201

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>