### PR TITLE
Fix: replace config details in error messages with generic text

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -162,9 +162,11 @@ def _create_user_thing_sqlmodel(
 def google_login() -> dict:
     """Return the Google OAuth2 authorization URL."""
     if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
-        raise HTTPException(status_code=501, detail="Google OAuth not configured")
+        logger.error("Google OAuth not configured: GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET missing")
+        raise HTTPException(status_code=501, detail="Authentication service unavailable")
     if not SECRET_KEY:
-        raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+        logger.error("Google OAuth not configured: SECRET_KEY missing")
+        raise HTTPException(status_code=501, detail="Authentication service unavailable")
 
     flow = Flow.from_client_config(_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_REDIRECT_URI
@@ -193,7 +195,8 @@ def google_login() -> dict:
 def google_callback(code: str, state: str = "") -> RedirectResponse:
     """Exchange authorization code for tokens, create session."""
     if not SECRET_KEY:
-        raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+        logger.error("Google OAuth callback not configured: SECRET_KEY missing")
+        raise HTTPException(status_code=501, detail="Authentication service unavailable")
 
     logger.info("OAuth callback: redirect_uri=%s", GOOGLE_REDIRECT_URI)
 

--- a/backend/routers/mcp_oauth.py
+++ b/backend/routers/mcp_oauth.py
@@ -184,9 +184,11 @@ def oauth_authorize(
 ) -> RedirectResponse:
     """Receive MCP client OAuth params, start Google login, redirect back with auth code."""
     if not settings.GOOGLE_CLIENT_ID or not settings.GOOGLE_CLIENT_SECRET:
-        raise HTTPException(status_code=501, detail="Google OAuth not configured")
+        logger.error("MCP OAuth not configured: GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET missing")
+        raise HTTPException(status_code=501, detail="Authentication service unavailable")
     if not settings.SECRET_KEY:
-        raise HTTPException(status_code=501, detail="SECRET_KEY not configured")
+        logger.error("MCP OAuth not configured: SECRET_KEY missing")
+        raise HTTPException(status_code=501, detail="Authentication service unavailable")
     if response_type != "code":
         raise HTTPException(status_code=400, detail="Only response_type=code is supported")
     if code_challenge_method != "S256":

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -391,3 +391,68 @@ class TestOAuthCallbackDoesNotLogCode:
         assert fake_code[:20] not in caplog.text, (
             f"Authorization code prefix appeared in logs — CWE-532 regression: {caplog.text!r}"
         )
+
+
+class TestGoogleLoginGenericError:
+    """google_login() must return generic 501 text — no env var names in response (CWE-209)."""
+
+    def test_missing_client_id_returns_generic_error(self, patched_db):
+        with (
+            patch("backend.routers.auth.GOOGLE_CLIENT_ID", ""),
+            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
+            patch("backend.routers.auth.SECRET_KEY", "key"),
+        ):
+            from backend.main import app
+
+            with TestClient(app) as client:
+                resp = client.get("/api/auth/google")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "GOOGLE_CLIENT_ID" not in detail
+        assert "GOOGLE_CLIENT_SECRET" not in detail
+
+    def test_missing_client_secret_returns_generic_error(self, patched_db):
+        with (
+            patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
+            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", ""),
+            patch("backend.routers.auth.SECRET_KEY", "key"),
+        ):
+            from backend.main import app
+
+            with TestClient(app) as client:
+                resp = client.get("/api/auth/google")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "GOOGLE_CLIENT_SECRET" not in detail
+
+    def test_missing_secret_key_returns_generic_error(self, patched_db):
+        with (
+            patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
+            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
+            patch("backend.routers.auth.SECRET_KEY", ""),
+        ):
+            from backend.main import app
+
+            with TestClient(app) as client:
+                resp = client.get("/api/auth/google")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "SECRET_KEY" not in detail
+
+
+class TestGoogleCallbackGenericError:
+    """google_callback() must return generic 501 text when SECRET_KEY is missing (CWE-209)."""
+
+    def test_missing_secret_key_returns_generic_error(self, patched_db):
+        with patch("backend.routers.auth.SECRET_KEY", ""):
+            from backend.main import app
+
+            with TestClient(app) as client:
+                resp = client.get("/api/auth/google/callback?code=x&state=y")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "SECRET_KEY" not in detail

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -396,11 +396,19 @@ class TestOAuthCallbackDoesNotLogCode:
 class TestGoogleLoginGenericError:
     """google_login() must return generic 501 text — no env var names in response (CWE-209)."""
 
-    def test_missing_client_id_returns_generic_error(self, patched_db):
+    @pytest.mark.parametrize(
+        "client_id,client_secret,secret_key,expected_log_key",
+        [
+            ("", "secret", "key", "GOOGLE_CLIENT_ID"),
+            ("client-id", "", "key", "GOOGLE_CLIENT_SECRET"),
+            ("client-id", "secret", "", "SECRET_KEY"),
+        ],
+    )
+    def test_returns_generic_error(self, patched_db, client_id, client_secret, secret_key, expected_log_key):
         with (
-            patch("backend.routers.auth.GOOGLE_CLIENT_ID", ""),
-            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
-            patch("backend.routers.auth.SECRET_KEY", "key"),
+            patch("backend.routers.auth.GOOGLE_CLIENT_ID", client_id),
+            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", client_secret),
+            patch("backend.routers.auth.SECRET_KEY", secret_key),
             patch("backend.routers.auth.logger") as mock_logger,
         ):
             from backend.main import app
@@ -408,54 +416,9 @@ class TestGoogleLoginGenericError:
             with TestClient(app) as client:
                 resp = client.get("/api/auth/google")
         assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "GOOGLE_CLIENT_ID" not in detail
-        assert "GOOGLE_CLIENT_SECRET" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        assert resp.json()["detail"] == "Authentication service unavailable"
         mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "GOOGLE_CLIENT_ID" in logged_msg
-
-    def test_missing_client_secret_returns_generic_error(self, patched_db):
-        with (
-            patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
-            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", ""),
-            patch("backend.routers.auth.SECRET_KEY", "key"),
-            patch("backend.routers.auth.logger") as mock_logger,
-        ):
-            from backend.main import app
-
-            with TestClient(app) as client:
-                resp = client.get("/api/auth/google")
-        assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "GOOGLE_CLIENT_SECRET" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
-        mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "GOOGLE_CLIENT_SECRET" in logged_msg
-
-    def test_missing_secret_key_returns_generic_error(self, patched_db):
-        with (
-            patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
-            patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
-            patch("backend.routers.auth.SECRET_KEY", ""),
-            patch("backend.routers.auth.logger") as mock_logger,
-        ):
-            from backend.main import app
-
-            with TestClient(app) as client:
-                resp = client.get("/api/auth/google")
-        assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "SECRET_KEY" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
-        mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "SECRET_KEY" in logged_msg
+        assert expected_log_key in mock_logger.error.call_args[0][0]
 
 
 class TestGoogleCallbackGenericError:
@@ -471,10 +434,6 @@ class TestGoogleCallbackGenericError:
             with TestClient(app) as client:
                 resp = client.get("/api/auth/google/callback?code=x&state=y")
         assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "SECRET_KEY" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        assert resp.json()["detail"] == "Authentication service unavailable"
         mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "SECRET_KEY" in logged_msg
+        assert "SECRET_KEY" in mock_logger.error.call_args[0][0]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -401,6 +401,7 @@ class TestGoogleLoginGenericError:
             patch("backend.routers.auth.GOOGLE_CLIENT_ID", ""),
             patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
             patch("backend.routers.auth.SECRET_KEY", "key"),
+            patch("backend.routers.auth.logger") as mock_logger,
         ):
             from backend.main import app
 
@@ -411,12 +412,17 @@ class TestGoogleLoginGenericError:
         assert detail == "Authentication service unavailable"
         assert "GOOGLE_CLIENT_ID" not in detail
         assert "GOOGLE_CLIENT_SECRET" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "GOOGLE_CLIENT_ID" in logged_msg
 
     def test_missing_client_secret_returns_generic_error(self, patched_db):
         with (
             patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
             patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", ""),
             patch("backend.routers.auth.SECRET_KEY", "key"),
+            patch("backend.routers.auth.logger") as mock_logger,
         ):
             from backend.main import app
 
@@ -426,12 +432,17 @@ class TestGoogleLoginGenericError:
         detail = resp.json()["detail"]
         assert detail == "Authentication service unavailable"
         assert "GOOGLE_CLIENT_SECRET" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "GOOGLE_CLIENT_SECRET" in logged_msg
 
     def test_missing_secret_key_returns_generic_error(self, patched_db):
         with (
             patch("backend.routers.auth.GOOGLE_CLIENT_ID", "client-id"),
             patch("backend.routers.auth.GOOGLE_CLIENT_SECRET", "secret"),
             patch("backend.routers.auth.SECRET_KEY", ""),
+            patch("backend.routers.auth.logger") as mock_logger,
         ):
             from backend.main import app
 
@@ -441,13 +452,20 @@ class TestGoogleLoginGenericError:
         detail = resp.json()["detail"]
         assert detail == "Authentication service unavailable"
         assert "SECRET_KEY" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "SECRET_KEY" in logged_msg
 
 
 class TestGoogleCallbackGenericError:
     """google_callback() must return generic 501 text when SECRET_KEY is missing (CWE-209)."""
 
     def test_missing_secret_key_returns_generic_error(self, patched_db):
-        with patch("backend.routers.auth.SECRET_KEY", ""):
+        with (
+            patch("backend.routers.auth.SECRET_KEY", ""),
+            patch("backend.routers.auth.logger") as mock_logger,
+        ):
             from backend.main import app
 
             with TestClient(app) as client:
@@ -456,3 +474,7 @@ class TestGoogleCallbackGenericError:
         detail = resp.json()["detail"]
         assert detail == "Authentication service unavailable"
         assert "SECRET_KEY" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "SECRET_KEY" in logged_msg

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -426,3 +426,41 @@ class TestValidateClientSecret:
         self._register_client("conf-client3", "correct-secret", "client_secret_post")
         # Should not raise
         _validate_client_secret("conf-client3", "correct-secret")
+
+
+class TestOAuthAuthorizeGenericError:
+    """oauth_authorize() must return generic 501 text — no env var names in response (CWE-209)."""
+
+    def test_missing_client_id_returns_generic_error(self, mcp_client):
+        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+            mock_settings.GOOGLE_CLIENT_ID = ""
+            mock_settings.GOOGLE_CLIENT_SECRET = "secret"
+            mock_settings.SECRET_KEY = "key"
+            resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "GOOGLE_CLIENT_ID" not in detail
+        assert "GOOGLE_CLIENT_SECRET" not in detail
+
+    def test_missing_client_secret_returns_generic_error(self, mcp_client):
+        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+            mock_settings.GOOGLE_CLIENT_ID = "client-id"
+            mock_settings.GOOGLE_CLIENT_SECRET = ""
+            mock_settings.SECRET_KEY = "key"
+            resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "GOOGLE_CLIENT_SECRET" not in detail
+
+    def test_missing_secret_key_returns_generic_error(self, mcp_client):
+        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+            mock_settings.GOOGLE_CLIENT_ID = "client-id"
+            mock_settings.GOOGLE_CLIENT_SECRET = "secret"
+            mock_settings.SECRET_KEY = ""
+            resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
+        assert resp.status_code == 501
+        detail = resp.json()["detail"]
+        assert detail == "Authentication service unavailable"
+        assert "SECRET_KEY" not in detail

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -432,7 +432,10 @@ class TestOAuthAuthorizeGenericError:
     """oauth_authorize() must return generic 501 text — no env var names in response (CWE-209)."""
 
     def test_missing_client_id_returns_generic_error(self, mcp_client):
-        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+        with (
+            patch("backend.routers.mcp_oauth.settings") as mock_settings,
+            patch("backend.routers.mcp_oauth.logger") as mock_logger,
+        ):
             mock_settings.GOOGLE_CLIENT_ID = ""
             mock_settings.GOOGLE_CLIENT_SECRET = "secret"
             mock_settings.SECRET_KEY = "key"
@@ -442,9 +445,16 @@ class TestOAuthAuthorizeGenericError:
         assert detail == "Authentication service unavailable"
         assert "GOOGLE_CLIENT_ID" not in detail
         assert "GOOGLE_CLIENT_SECRET" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "GOOGLE_CLIENT_ID" in logged_msg
 
     def test_missing_client_secret_returns_generic_error(self, mcp_client):
-        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+        with (
+            patch("backend.routers.mcp_oauth.settings") as mock_settings,
+            patch("backend.routers.mcp_oauth.logger") as mock_logger,
+        ):
             mock_settings.GOOGLE_CLIENT_ID = "client-id"
             mock_settings.GOOGLE_CLIENT_SECRET = ""
             mock_settings.SECRET_KEY = "key"
@@ -453,9 +463,16 @@ class TestOAuthAuthorizeGenericError:
         detail = resp.json()["detail"]
         assert detail == "Authentication service unavailable"
         assert "GOOGLE_CLIENT_SECRET" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "GOOGLE_CLIENT_SECRET" in logged_msg
 
     def test_missing_secret_key_returns_generic_error(self, mcp_client):
-        with patch("backend.routers.mcp_oauth.settings") as mock_settings:
+        with (
+            patch("backend.routers.mcp_oauth.settings") as mock_settings,
+            patch("backend.routers.mcp_oauth.logger") as mock_logger,
+        ):
             mock_settings.GOOGLE_CLIENT_ID = "client-id"
             mock_settings.GOOGLE_CLIENT_SECRET = "secret"
             mock_settings.SECRET_KEY = ""
@@ -464,3 +481,7 @@ class TestOAuthAuthorizeGenericError:
         detail = resp.json()["detail"]
         assert detail == "Authentication service unavailable"
         assert "SECRET_KEY" not in detail
+        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        mock_logger.error.assert_called_once()
+        logged_msg = mock_logger.error.call_args[0][0]
+        assert "SECRET_KEY" in logged_msg

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -431,57 +431,24 @@ class TestValidateClientSecret:
 class TestOAuthAuthorizeGenericError:
     """oauth_authorize() must return generic 501 text — no env var names in response (CWE-209)."""
 
-    def test_missing_client_id_returns_generic_error(self, mcp_client):
+    @pytest.mark.parametrize(
+        "client_id,client_secret,secret_key,expected_log_key",
+        [
+            ("", "secret", "key", "GOOGLE_CLIENT_ID"),
+            ("client-id", "", "key", "GOOGLE_CLIENT_SECRET"),
+            ("client-id", "secret", "", "SECRET_KEY"),
+        ],
+    )
+    def test_returns_generic_error(self, mcp_client, client_id, client_secret, secret_key, expected_log_key):
         with (
             patch("backend.routers.mcp_oauth.settings") as mock_settings,
             patch("backend.routers.mcp_oauth.logger") as mock_logger,
         ):
-            mock_settings.GOOGLE_CLIENT_ID = ""
-            mock_settings.GOOGLE_CLIENT_SECRET = "secret"
-            mock_settings.SECRET_KEY = "key"
+            mock_settings.GOOGLE_CLIENT_ID = client_id
+            mock_settings.GOOGLE_CLIENT_SECRET = client_secret
+            mock_settings.SECRET_KEY = secret_key
             resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
         assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "GOOGLE_CLIENT_ID" not in detail
-        assert "GOOGLE_CLIENT_SECRET" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
+        assert resp.json()["detail"] == "Authentication service unavailable"
         mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "GOOGLE_CLIENT_ID" in logged_msg
-
-    def test_missing_client_secret_returns_generic_error(self, mcp_client):
-        with (
-            patch("backend.routers.mcp_oauth.settings") as mock_settings,
-            patch("backend.routers.mcp_oauth.logger") as mock_logger,
-        ):
-            mock_settings.GOOGLE_CLIENT_ID = "client-id"
-            mock_settings.GOOGLE_CLIENT_SECRET = ""
-            mock_settings.SECRET_KEY = "key"
-            resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
-        assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "GOOGLE_CLIENT_SECRET" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
-        mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "GOOGLE_CLIENT_SECRET" in logged_msg
-
-    def test_missing_secret_key_returns_generic_error(self, mcp_client):
-        with (
-            patch("backend.routers.mcp_oauth.settings") as mock_settings,
-            patch("backend.routers.mcp_oauth.logger") as mock_logger,
-        ):
-            mock_settings.GOOGLE_CLIENT_ID = "client-id"
-            mock_settings.GOOGLE_CLIENT_SECRET = "secret"
-            mock_settings.SECRET_KEY = ""
-            resp = mcp_client.get("/oauth/authorize?client_id=x&redirect_uri=http://localhost")
-        assert resp.status_code == 501
-        detail = resp.json()["detail"]
-        assert detail == "Authentication service unavailable"
-        assert "SECRET_KEY" not in detail
-        # Verify logger.error was called with the specific missing var (diagnostic preserved server-side)
-        mock_logger.error.assert_called_once()
-        logged_msg = mock_logger.error.call_args[0][0]
-        assert "SECRET_KEY" in logged_msg
+        assert expected_log_key in mock_logger.error.call_args[0][0]


### PR DESCRIPTION
## Summary

- Five `HTTPException` detail strings in `auth.py` and `mcp_oauth.py` named internal env vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `SECRET_KEY`) in HTTP 501 responses, enabling attacker configuration reconnaissance (CWE-209 / OWASP A05)
- Replaced all five with `"Authentication service unavailable"` and added `logger.error()` before each raise to preserve server-side diagnostics
- Added 7 tests covering all three misconfiguration branches across both endpoints

## Test plan

- [ ] `python3 -m pytest tests/test_auth.py::TestGoogleLoginGenericError -v` — 3 tests (missing client_id, missing client_secret, missing SECRET_KEY)
- [ ] `python3 -m pytest tests/test_auth.py::TestGoogleCallbackGenericError -v` — 1 test (missing SECRET_KEY in callback)
- [ ] `python3 -m pytest tests/test_mcp_oauth.py::TestOAuthAuthorizeGenericError -v` — 3 tests (same 3 branches for `/oauth/authorize`)
- [ ] All 7 tests pass (confirmed locally)

Fixes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)