### PR TITLE
Add per-message chat history deletion

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -174,6 +174,42 @@ def delete_history(session_id: str, user_id: str = Depends(require_user)) -> Non
         session.commit()
 
 
+@router.delete(
+    "/history/{session_id}/{message_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a single chat message",
+)
+def delete_message(
+    session_id: str,
+    message_id: int,
+    user_id: str = Depends(require_user),
+) -> None:
+    """Delete a single chat message and its associated usage records."""
+    with Session(_engine_mod.engine) as session:
+        record = session.exec(
+            select(ChatHistoryRecord).where(
+                ChatHistoryRecord.id == message_id,
+                ChatHistoryRecord.session_id == session_id,
+                user_filter_clause(ChatHistoryRecord.user_id, user_id),
+            )
+        ).first()
+        if not record:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Message '{message_id}' not found in session '{session_id}'",
+            )
+        # Delete associated usage records first (FK constraint)
+        usage_records = session.exec(
+            select(ChatMessageUsageRecord).where(
+                ChatMessageUsageRecord.chat_message_id == message_id
+            )
+        ).all()
+        for u in usage_records:
+            session.delete(u)
+        session.delete(record)
+        session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Chat Sessions CRUD
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_api_contracts.py
+++ b/backend/tests/test_api_contracts.py
@@ -244,6 +244,22 @@ class TestChatHistoryContract:
         assert isinstance(msg["timestamp"], str)
         assert ISO_DATE_RE.match(msg["timestamp"])
 
+    def test_delete_single_message_returns_204(self, client):
+        """DELETE /api/chat/history/{session_id}/{message_id} removes one message."""
+        msg = _create_chat_message(client, "del-single-sess", "user", "to delete")
+        msg_id = msg["id"]
+        resp = client.delete(f"/api/chat/history/del-single-sess/{msg_id}")
+        assert resp.status_code == 204
+        # Confirm it's gone
+        history = client.get("/api/chat/history/del-single-sess").json()
+        assert all(m["id"] != msg_id for m in history)
+
+    def test_delete_single_message_404_for_wrong_session(self, client):
+        """DELETE returns 404 when session_id does not match the message."""
+        msg = _create_chat_message(client, "del-wrong-sess", "user", "belongs here")
+        resp = client.delete(f"/api/chat/history/other-session/{msg['id']}")
+        assert resp.status_code == 404
+
 
 # ===========================================================================
 # Contract tests — Chat Pipeline endpoint

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -415,6 +415,8 @@ function MessageBubble({ msg, speakingId, speak }: { msg: ChatMessage; speakingI
   const isUser = msg.role === 'user'
   const ts = formatReliTimestamp(msg.timestamp, isUser)
   const openThingDetail = useStore(s => s.openThingDetail)
+  const deleteMessage = useStore(s => s.deleteMessage)
+  const sessionId = useStore(s => s.sessionId)
 
   const referencedThings = msg.applied_changes?.referenced_things ?? []
   const renderedContent = referencedThings.length > 0
@@ -528,9 +530,19 @@ function MessageBubble({ msg, speakingId, speak }: { msg: ChatMessage; speakingI
         )}
 
         {/* Usage + speak row */}
-        <div className={`flex items-center gap-2 mt-1 ${isUser ? 'justify-end' : 'justify-start'}`}>
+        <div className={`flex items-center gap-2 mt-1 ${isUser ? 'justify-end' : 'justify-start'} group/actions`}>
           {!isUser && <UsagePill msg={msg} />}
           {!isUser && <SpeakButton msg={msg} speakingId={speakingId} speak={speak} />}
+          {msg.id && (
+            <button
+              onClick={() => deleteMessage(sessionId, msg.id as number)}
+              className="opacity-0 group-hover/actions:opacity-100 transition-opacity text-on-surface-variant/40 hover:text-error text-xs ml-1"
+              title="Delete message"
+              aria-label="Delete message"
+            >
+              ✕
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -275,6 +275,7 @@ interface ReliState {
   switchChatSession: (sessionId: string) => Promise<void>
   renameChatSession: (sessionId: string, title: string) => Promise<void>
   deleteChatSession: (sessionId: string) => Promise<void>
+  deleteMessage: (sessionId: string, messageId: number) => Promise<void>
   clearError: () => void
   fetchCalendarStatus: () => Promise<void>
   fetchGmailStatus: () => Promise<void>
@@ -1185,6 +1186,16 @@ export const useStore = create<ReliState>((set, get) => ({
           await get().createChatSession()
         }
       }
+    } catch {
+      // ignore
+    }
+  },
+
+  deleteMessage: async (sessionId: string, messageId: number) => {
+    try {
+      const res = await apiFetch(`${BASE}/chat/history/${sessionId}/${messageId}`, { method: 'DELETE' })
+      if (!res.ok) return
+      set(state => ({ messages: state.messages.filter(m => m.id !== messageId) }))
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Summary

Implements selective per-message deletion for chat history, allowing users to remove individual sensitive messages (Gmail bodies, Calendar details, etc.) without deleting the entire session. Completes the privacy control gap identified in #1198.

## Changes

### Backend (`backend/routers/chat.py`)
- Added `DELETE /api/chat/history/{session_id}/{message_id}` endpoint
- Deletes the target message and its associated `ChatMessageUsageRecord` entries (FK constraint)
- Returns 204 No Content on success, 404 if message or session not found
- Enforces user ownership via `user_filter_clause`

### Frontend (`frontend/src/store.ts`)
- Added `deleteMessage(sessionId: string, messageId: number)` store action
- Calls the new backend endpoint and optimistically filters the message from local state
- Handles errors gracefully (silent failure pattern matching existing code)

### UI (`frontend/src/components/ChatPanel.tsx`)
- Added per-message delete button (✕) to `MessageBubble`
- Button is hidden by default, revealed on row hover (opacity-0 → opacity-100)
- Not shown on streaming messages (guards with `msg.id`)
- Positioned after Usage pill and Speak button

### Tests (`backend/tests/test_api_contracts.py`)
- Added `test_delete_single_message_returns_204`: verifies message deletion
- Added `test_delete_single_message_404_for_wrong_session`: verifies session ownership check

## Validation

| Check | Result |
|-------|--------|
| Type check | ✅ `tsc -b` clean |
| Lint (in-scope) | ✅ ChatPanel.tsx, store.ts — 0 errors |
| Tests (frontend) | ✅ 403 passed |
| Tests (backend) | ✅ 32 passed (all new tests included) |
| Build | ✅ Compiled successfully |

## Related

- Fixes #1198
- Complements #1213 (time-based retention) and #1214 (GDPR delete-all)