### PR TITLE
Fix: reduce OAuth auth code TTL from 10 min to 60 seconds

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -48,7 +48,7 @@ COOKIE_NAME = "reli_session"
 _pending_flows: dict[str, dict] = {}
 _PENDING_FLOW_TTL_SECONDS = 600  # 10 minutes
 
-MCP_AUTH_CODE_TTL_SECONDS = 60 * 10  # 10 minutes
+MCP_AUTH_CODE_TTL_SECONDS = 60  # 60 seconds (IETF RFC 6819 §4.1.1)
 
 
 def _client_config() -> dict:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -309,7 +309,7 @@ class TestOAuthAllowlistRejection:
         fake_state = "test-state-value"
         fake_flow_entry = {
             "code_verifier": "fake-code-verifier",
-            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=600),
+            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=60),
         }
 
         mock_flow = MagicMock()
@@ -350,7 +350,7 @@ class TestOAuthCallbackDoesNotLogCode:
         fake_code = "supersecretauthcode123456"
         fake_flow_entry = {
             "code_verifier": "fake-verifier",
-            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=600),
+            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=60),
         }
 
         mock_flow = MagicMock()


### PR DESCRIPTION
## Summary

Reduces the OAuth authorization code TTL from 10 minutes (600 seconds) to 60 seconds to comply with IETF RFC 6819 §4.1.1 security recommendations.

## Changes

- **backend/routers/auth.py**: Reduced `MCP_AUTH_CODE_TTL_SECONDS` from `60 * 10` to `60` with updated comment referencing IETF standard
- **backend/tests/test_auth.py**: Updated test fixtures that hard-code auth code expiry times from 600 seconds to 60 seconds (lines 312, 353)

## Security Impact

- Reduces the OAuth code exchange window from 10 minutes to 60 seconds, narrowing the attack surface for replay attacks
- PKCE protection remains in place, but the shorter TTL aligns with established security best practices
- Severity: LOW (PKCE already mitigates replay risk, but the shorter window is still a security improvement)

## Testing

- ✅ All 30 tests in test_auth.py passing
- ✅ All 34 tests in test_mcp_oauth.py passing (no side effects)
- ✅ Type check: no errors in changed files
- ✅ Lint: all checks passed
- ✅ Format: both files already properly formatted

Fixes #1196