### PR TITLE
Fix: add server-side JWT revocation on logout

### DIFF
--- a/backend/alembic/versions/q1r2s3t4u5v6_add_revoked_tokens_table.py
+++ b/backend/alembic/versions/q1r2s3t4u5v6_add_revoked_tokens_table.py
@@ -1,0 +1,39 @@
+"""add revoked_tokens table
+
+Revision ID: q1r2s3t4u5v6
+Revises: p0q1r2s3t4u5
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+
+revision: str = "q1r2s3t4u5v6"
+down_revision: Union[str, Sequence[str], None] = "p0q1r2s3t4u5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create revoked_tokens table."""
+    op.create_table(
+        "revoked_tokens",
+        sa.Column("jti", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("user_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("jti"),
+    )
+    op.create_index("ix_revoked_tokens_user_id", "revoked_tokens", ["user_id"])
+    op.create_index("ix_revoked_tokens_expires_at", "revoked_tokens", ["expires_at"])
+
+
+def downgrade() -> None:
+    """Drop revoked_tokens table."""
+    op.drop_index("ix_revoked_tokens_expires_at", table_name="revoked_tokens")
+    op.drop_index("ix_revoked_tokens_user_id", table_name="revoked_tokens")
+    op.drop_table("revoked_tokens")

--- a/backend/alembic/versions/q1r2s3t4u5v6_add_revoked_tokens_table.py
+++ b/backend/alembic/versions/q1r2s3t4u5v6_add_revoked_tokens_table.py
@@ -1,3 +1,6 @@
+# reli:allow-destructive-ddl — downgrade drops the revoked_tokens table.
+# Running this in production re-opens a token-replay window for all previously
+# revoked sessions. Only run with explicit operator approval.
 """add revoked_tokens table
 
 Revision ID: q1r2s3t4u5v6

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -133,9 +133,7 @@ async def require_user(request: Request) -> str:
 
                 if random.random() < 0.01:
                     now = datetime.now(timezone.utc)
-                    expired = db.exec(
-                        select(RevokedTokenRecord).where(RevokedTokenRecord.expires_at <= now)
-                    ).all()
+                    expired = db.exec(select(RevokedTokenRecord).where(RevokedTokenRecord.expires_at <= now)).all()
                     for row in expired:
                         db.delete(row)
                     if expired:

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -14,12 +14,18 @@ Two auth methods are supported:
 """
 
 import logging
+import random
 import secrets
+from datetime import datetime, timezone
 
 import jwt
 from fastapi import HTTPException, Request, status
+from sqlmodel import Session, select
+
+import backend.db_engine as _engine_mod
 
 from .config import settings
+from .db_models import RevokedTokenRecord
 
 _log = logging.getLogger(__name__)
 
@@ -118,28 +124,24 @@ async def require_user(request: Request) -> str:
     # Check revocation blacklist (only for tokens that carry a jti claim)
     jti: str = payload.get("jti", "")
     if jti:
-        from datetime import datetime, timezone
-
-        from sqlmodel import Session, select
-
-        import backend.db_engine as _engine_mod
-
-        from .db_models import RevokedTokenRecord
-
         try:
             with Session(_engine_mod.engine) as db:
                 # Prune expired rows opportunistically (low-cost, ~1% of requests)
-                import random
-
                 if random.random() < 0.01:
-                    now = datetime.now(timezone.utc)
-                    expired = db.exec(select(RevokedTokenRecord).where(RevokedTokenRecord.expires_at <= now)).all()
-                    for row in expired:
-                        db.delete(row)
-                    if expired:
-                        db.commit()
+                    try:
+                        now = datetime.now(timezone.utc)
+                        expired = db.exec(select(RevokedTokenRecord).where(RevokedTokenRecord.expires_at <= now)).all()
+                        for row in expired:
+                            db.delete(row)
+                        if expired:
+                            db.commit()
+                    except Exception:
+                        _log.warning("Revocation prune failed (non-fatal)", exc_info=True)
                 revoked = db.get(RevokedTokenRecord, jti)
         except Exception:
+            # SECURITY TRADEOFF: fail open to preserve availability during DB outages.
+            # Consequence: a revoked token may pass this check if the DB is unreachable.
+            # The token will still expire naturally (JWT exp claim).
             revoked = None
             _log.warning("Revocation check failed; allowing request", exc_info=True)
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -115,4 +115,40 @@ async def require_user(request: Request) -> str:
             detail="Invalid session payload",
         )
 
+    # Check revocation blacklist (only for tokens that carry a jti claim)
+    jti: str = payload.get("jti", "")
+    if jti:
+        from datetime import datetime, timezone
+
+        from sqlmodel import Session, select
+
+        import backend.db_engine as _engine_mod
+
+        from .db_models import RevokedTokenRecord
+
+        try:
+            with Session(_engine_mod.engine) as db:
+                # Prune expired rows opportunistically (low-cost, ~1% of requests)
+                import random
+
+                if random.random() < 0.01:
+                    now = datetime.now(timezone.utc)
+                    expired = db.exec(
+                        select(RevokedTokenRecord).where(RevokedTokenRecord.expires_at <= now)
+                    ).all()
+                    for row in expired:
+                        db.delete(row)
+                    if expired:
+                        db.commit()
+                revoked = db.get(RevokedTokenRecord, jti)
+        except Exception:
+            revoked = None
+            _log.warning("Revocation check failed; allowing request", exc_info=True)
+
+        if revoked:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session revoked",
+            )
+
     return user_id

--- a/backend/db_models.py
+++ b/backend/db_models.py
@@ -547,3 +547,19 @@ class GmailOAuthStateRecord(SQLModel, table=True):
     user_id: str = Field(primary_key=True)
     state: str
     expires_at: float  # Unix epoch
+
+
+# ---------------------------------------------------------------------------
+# Revoked Tokens (SEC-017)
+# ---------------------------------------------------------------------------
+
+
+class RevokedTokenRecord(SQLModel, table=True):
+    """Revoked JWT IDs. Checked on every authenticated request."""
+
+    __tablename__ = "revoked_tokens"
+
+    jti: str = Field(primary_key=True)
+    user_id: str = Field(index=True)
+    revoked_at: datetime = Field(default_factory=_utcnow)
+    expires_at: datetime  # mirrors JWT exp — used for cleanup

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -325,8 +325,8 @@ def logout(request: Request, response: Response) -> dict:
             payload = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM], audience="web")
             jti = payload.get("jti")
             if jti:
-                exp_ts = payload.get("exp", 0)
-                expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc)
+                exp_ts = payload.get("exp")
+                expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc) if exp_ts else datetime.now(timezone.utc)
                 with Session(_engine_mod.engine) as session:
                     session.add(
                         RevokedTokenRecord(
@@ -337,6 +337,7 @@ def logout(request: Request, response: Response) -> dict:
                     )
                     session.commit()
         except Exception:
-            pass  # Best-effort; always delete the cookie
+            logger.warning("Failed to record token revocation on logout; cookie will still be cleared", exc_info=True)
+            # Best-effort; always delete the cookie
     response.delete_cookie(key=COOKIE_NAME, path="/")
     return {"status": "logged_out"}

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -338,6 +338,5 @@ def logout(request: Request, response: Response) -> dict:
                     session.commit()
         except Exception:
             logger.warning("Failed to record token revocation on logout; cookie will still be cleared", exc_info=True)
-            # Best-effort; always delete the cookie
     response.delete_cookie(key=COOKIE_NAME, path="/")
     return {"status": "logged_out"}

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -18,7 +18,7 @@ from sqlmodel import Session, select
 import backend.db_engine as _engine_mod
 
 from ..config import settings
-from ..db_models import ThingRecord, UserRecord
+from ..db_models import RevokedTokenRecord, ThingRecord, UserRecord
 from ..oauth_state import (
     StoreFullError,
     cleanup_and_get,
@@ -72,6 +72,7 @@ def _create_jwt(user_id: str, email: str, aud: str = "web") -> str:
         "aud": aud,
         "iat": now_ts,
         "exp": now_ts + JWT_EXPIRY_SECONDS,
+        "jti": str(uuid.uuid4()),
     }
     return jwt.encode(payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
 
@@ -316,7 +317,24 @@ def get_current_user(request: Request) -> dict:
 
 
 @router.post("/logout", summary="Log out")
-def logout(response: Response) -> dict:
-    """Clear the session cookie."""
+def logout(request: Request, response: Response) -> dict:
+    """Clear the session cookie and revoke the JWT server-side."""
+    token = request.cookies.get(COOKIE_NAME)
+    if token and SECRET_KEY:
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM], audience="web")
+            jti = payload.get("jti")
+            if jti:
+                exp_ts = payload.get("exp", 0)
+                expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc)
+                with Session(_engine_mod.engine) as session:
+                    session.add(RevokedTokenRecord(
+                        jti=jti,
+                        user_id=payload.get("sub", ""),
+                        expires_at=expires_at,
+                    ))
+                    session.commit()
+        except Exception:
+            pass  # Best-effort; always delete the cookie
     response.delete_cookie(key=COOKIE_NAME, path="/")
     return {"status": "logged_out"}

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -328,11 +328,13 @@ def logout(request: Request, response: Response) -> dict:
                 exp_ts = payload.get("exp", 0)
                 expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc)
                 with Session(_engine_mod.engine) as session:
-                    session.add(RevokedTokenRecord(
-                        jti=jti,
-                        user_id=payload.get("sub", ""),
-                        expires_at=expires_at,
-                    ))
+                    session.add(
+                        RevokedTokenRecord(
+                            jti=jti,
+                            user_id=payload.get("sub", ""),
+                            expires_at=expires_at,
+                        )
+                    )
                     session.commit()
         except Exception:
             pass  # Best-effort; always delete the cookie

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -200,9 +200,7 @@ def delete_message(
             )
         # Delete associated usage records first (FK constraint)
         usage_records = session.exec(
-            select(ChatMessageUsageRecord).where(
-                ChatMessageUsageRecord.chat_message_id == message_id
-            )
+            select(ChatMessageUsageRecord).where(ChatMessageUsageRecord.chat_message_id == message_id)
         ).all()
         for u in usage_records:
             session.delete(u)

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -235,10 +235,14 @@ def delete_all_user_data(
 
     # 3. ThingRelationshipRecord (FK → things, no user_id)
     if thing_ids:
-        _delete_where(session, ThingRelationshipRecord, or_(
-            ThingRelationshipRecord.from_thing_id.in_(thing_ids),  # type: ignore[attr-defined]
-            ThingRelationshipRecord.to_thing_id.in_(thing_ids),  # type: ignore[attr-defined]
-        ))
+        _delete_where(
+            session,
+            ThingRelationshipRecord,
+            or_(
+                ThingRelationshipRecord.from_thing_id.in_(thing_ids),  # type: ignore[attr-defined]
+                ThingRelationshipRecord.to_thing_id.in_(thing_ids),  # type: ignore[attr-defined]
+            ),
+        )
 
     # 4. SweepFindingRecord (FK → things)
     _delete_where(session, SweepFindingRecord, user_filter_clause(SweepFindingRecord.user_id, user_id))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -437,3 +437,68 @@ class TestGoogleCallbackGenericError:
         assert resp.json()["detail"] == "Authentication service unavailable"
         mock_logger.error.assert_called_once()
         assert "SECRET_KEY" in mock_logger.error.call_args[0][0]
+
+
+class TestSessionRevocation:
+    """Token revocation via logout."""
+
+    @pytest.fixture()
+    def revocation_client(self, patched_db):
+        """TestClient with SECRET_KEY set on both auth and router modules."""
+        with (
+            patch("backend.auth.SECRET_KEY", "test-secret-key"),
+            patch("backend.routers.auth.SECRET_KEY", "test-secret-key"),
+        ):
+            from backend.main import app
+
+            with TestClient(app) as c:
+                yield c
+
+    def test_logout_revokes_token(self, revocation_client):
+        """After logout, the same JWT should be rejected."""
+        import jwt as _jwt
+
+        from backend.routers.auth import JWT_ALGORITHM, JWT_EXPIRY_SECONDS
+
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        payload = {
+            "sub": "test-user-id",
+            "email": "test@example.com",
+            "aud": "web",
+            "iat": now_ts,
+            "exp": now_ts + JWT_EXPIRY_SECONDS,
+            "jti": "revoke-me-123",
+        }
+        token = _jwt.encode(payload, "test-secret-key", algorithm=JWT_ALGORITHM)
+
+        # Set cookie and verify it works
+        revocation_client.cookies.set("reli_session", token)
+        resp = revocation_client.get("/api/things")
+        assert resp.status_code == 200
+
+        # Logout
+        resp = revocation_client.post("/api/auth/logout")
+        assert resp.status_code == 200
+
+        # Restore the cookie manually and try an authenticated endpoint
+        revocation_client.cookies.set("reli_session", token)
+        resp = revocation_client.get("/api/things")
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Session revoked"
+
+    def test_logout_without_jti_still_clears_cookie(self, revocation_client):
+        """Tokens without jti (legacy) should still log out without error."""
+        import jwt as _jwt
+
+        payload = {
+            "sub": "test-user-id",
+            "email": "test@example.com",
+            "aud": "web",
+            "exp": 9999999999,
+        }
+        token = _jwt.encode(payload, "test-secret-key", algorithm="HS256")
+        revocation_client.cookies.set("reli_session", token)
+
+        resp = revocation_client.post("/api/auth/logout")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "logged_out"}

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -502,3 +502,86 @@ class TestSessionRevocation:
         resp = revocation_client.post("/api/auth/logout")
         assert resp.status_code == 200
         assert resp.json() == {"status": "logged_out"}
+
+    def test_logout_with_malformed_cookie_still_succeeds(self, revocation_client):
+        """Malformed cookie must not prevent logout."""
+        revocation_client.cookies.set("reli_session", "not-a-valid-jwt")
+        resp = revocation_client.post("/api/auth/logout")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "logged_out"}
+
+    def test_revocation_check_db_failure_allows_request(self, revocation_client):
+        """DB failure during revocation check must fail-open (allow the request)."""
+        import jwt as _jwt
+
+        from backend.routers.auth import JWT_ALGORITHM, JWT_EXPIRY_SECONDS
+
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        payload = {
+            "sub": "test-user-id",
+            "email": "test@example.com",
+            "aud": "web",
+            "iat": now_ts,
+            "exp": now_ts + JWT_EXPIRY_SECONDS,
+            "jti": "fail-open-jti",
+        }
+        token = _jwt.encode(payload, "test-secret-key", algorithm=JWT_ALGORITHM)
+        revocation_client.cookies.set("reli_session", token)
+
+        # Patch only the Session used in backend.auth (revocation check), not other routes
+        with patch("backend.auth.Session", side_effect=Exception("DB down")):
+            resp = revocation_client.get("/api/things")
+
+        # Fail-open: request must be allowed, not 401/500
+        assert resp.status_code == 200
+
+    def test_opportunistic_pruning_removes_expired_rows(self, revocation_client):
+        """Expired revocation rows are deleted during the 1% prune pass."""
+        import jwt as _jwt
+
+        import backend.db_engine as _engine_mod
+        from backend.db_models import RevokedTokenRecord
+        from backend.routers.auth import JWT_ALGORITHM, JWT_EXPIRY_SECONDS
+
+        # Seed an expired revocation row
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        with Session(_engine_mod.engine) as db:
+            db.add(RevokedTokenRecord(jti="expired-jti", user_id="u1", expires_at=past))
+            db.commit()
+
+        # Build a fresh valid token (different jti — not revoked)
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        payload = {
+            "sub": "test-user-id",
+            "email": "test@example.com",
+            "aud": "web",
+            "iat": now_ts,
+            "exp": now_ts + JWT_EXPIRY_SECONDS,
+            "jti": "live-jti",
+        }
+        token = _jwt.encode(payload, "test-secret-key", algorithm=JWT_ALGORITHM)
+        revocation_client.cookies.set("reli_session", token)
+
+        with patch("backend.auth.random.random", return_value=0.0):  # always prune
+            resp = revocation_client.get("/api/things")
+
+        assert resp.status_code == 200
+
+        with Session(_engine_mod.engine) as db:
+            assert db.get(RevokedTokenRecord, "expired-jti") is None, "Expired row should be pruned"
+
+
+def test_create_jwt_includes_jti():
+    """Tokens issued by _create_jwt must carry a non-empty jti UUID claim."""
+    import uuid
+
+    import jwt as _jwt
+
+    from backend.routers.auth import JWT_ALGORITHM, _create_jwt
+
+    with patch("backend.routers.auth.SECRET_KEY", "test-secret-key"):
+        token = _create_jwt("user-123", "user@example.com")
+
+    payload = _jwt.decode(token, "test-secret-key", algorithms=[JWT_ALGORITHM], audience="web")
+    assert "jti" in payload
+    uuid.UUID(payload["jti"])  # raises ValueError if not a valid UUID

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ Interactive docs available at `http://localhost:8000/docs` (Swagger UI) when run
 | GET | `/api/auth/google` | Redirect to Google OAuth consent screen |
 | GET | `/api/auth/google/callback` | Handle OAuth callback, set `reli_session` cookie |
 | GET | `/api/auth/me` | Return current user profile |
-| POST | `/api/auth/logout` | Clear session cookie |
+| POST | `/api/auth/logout` | Revoke JWT server-side and clear session cookie |
 
 **`GET /api/auth/me` response:**
 ```json


### PR DESCRIPTION
## Summary

Implements server-side session revocation to address [SEC-17](https://github.com/alexsiri7/reli/security/advisories/SEC-17). When users log out, their JWT tokens are now added to a revocation list, preventing further use even if the token hasn't expired.

**Fixes #1195**

## Changes

- **Added RevokedTokenRecord model**: New database model to track revoked JWT tokens with timestamp
- **Created Alembic migration**: Adds `revoked_tokens` table to persist revocation records
- **Enhanced JWT creation**: Added `jti` (JWT ID) claim to all tokens for unique identification
- **Revocation on logout**: `/api/auth/logout` endpoint now adds the token's `jti` to the revocation list
- **Revocation check**: `require_user()` decorator validates that the JWT hasn't been revoked before granting access
- **New tests**: Added `TestSessionRevocation` class with 2 tests covering logout revocation and edge cases

## Validation

✅ **All checks passed:**
- Lint (ruff): 0 errors
- Format (ruff): 4 files auto-formatted
- Tests (pytest): 1264 passed, 14 skipped (including 2 new revocation tests)
- Type check (mypy): No issues in changed files
- Build (frontend): Compiled successfully

## Implementation Details

### Files Changed
- `backend/db_models.py` (+15 lines)
- `backend/alembic/versions/q1r2s3t4u5v6_add_revoked_tokens_table.py` (new, +41 lines)
- `backend/routers/auth.py` (+19/-2 lines)
- `backend/auth.py` (+31/-1 lines)
- `backend/tests/test_auth.py` (+71 lines)

### Security Impact
- Completes logout by invalidating tokens server-side
- Prevents token replay attacks after logout
- Maintains backward compatibility (tokens without `jti` are treated as non-revocable)