### PR TITLE
Fix: align chat message input limit with peer endpoints

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -245,8 +245,8 @@ class ChatRequest(BaseModel):
     message: str = Field(
         ...,
         min_length=1,
-        max_length=10_000,
-        description="User message text (max 10 000 chars)",
+        max_length=5000,
+        description="User message text (max 5 000 chars)",
         examples=["What tasks are due this week?"],
     )
     mode: str = Field(

--- a/backend/tests/test_payload_limits.py
+++ b/backend/tests/test_payload_limits.py
@@ -59,7 +59,11 @@ class TestThingUpdateLimits:
 class TestChatRequestLimits:
     def test_message_too_long(self) -> None:
         with pytest.raises(ValidationError, match="string_too_long|max_length"):
-            ChatRequest(session_id="s", message="x" * 10_001)
+            ChatRequest(session_id="s", message="x" * 5001)
+
+    def test_message_at_limit_is_valid(self) -> None:
+        req = ChatRequest(session_id="s", message="x" * 5000)
+        assert len(req.message) == 5000
 
     def test_session_id_too_long(self) -> None:
         with pytest.raises(ValidationError, match="string_too_long|max_length"):


### PR DESCRIPTION
## Summary

Reduce `ChatRequest.message` max_length from 10,000 to 5,000 characters to align with `/think` and `/feedback` endpoints. This prevents oversized payloads that amplify LLM token costs and reduce DoS surface area.

**Security Impact**: Medium severity — addresses SEC-16 by closing input validation gap.

## Changes

- **backend/models.py** (lines 245–250): Updated `ChatRequest.message` field
  - Changed `max_length=10_000` → `max_length=5_000`
  - Updated description to reflect new limit

## Validation

| Check | Result |
|-------|--------|
| Type check (TS) | ✅ Pass |
| Tests (backend chat) | ✅ 50/50 passed |
| Payload limit tests | ✅ 21/21 passed (message_too_long validation confirmed) |
| Tests (frontend) | ✅ 403/403 passed |
| Build (frontend) | ✅ Success |

## Fixes

Fixes #1194