### PR TITLE
Fix: replace MCP CORS wildcard fallback with allowlist-only policy

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -159,7 +159,7 @@ class Settings(BaseSettings):
 
     # --- CORS ---
     CORS_ORIGINS: str = ""  # Comma-separated extra origins (e.g. https://reli.interstellarai.net)
-    MCP_CORS_ORIGINS: str = ""  # Comma-separated origins allowed on MCP/OAuth endpoints; empty = use wildcard (*)
+    MCP_CORS_ORIGINS: str = ""  # Comma-separated origins allowed on MCP/OAuth endpoints; empty = localhost defaults only
 
     # --- Sentry ---
     SENTRY_DSN: str = ""

--- a/backend/config.py
+++ b/backend/config.py
@@ -159,7 +159,8 @@ class Settings(BaseSettings):
 
     # --- CORS ---
     CORS_ORIGINS: str = ""  # Comma-separated extra origins (e.g. https://reli.interstellarai.net)
-    MCP_CORS_ORIGINS: str = ""  # Comma-separated origins allowed on MCP/OAuth endpoints; empty = localhost defaults only
+    # Comma-separated origins allowed on MCP/OAuth endpoints; empty = localhost defaults only
+    MCP_CORS_ORIGINS: str = ""
 
     # --- Sentry ---
     SENTRY_DSN: str = ""

--- a/backend/main.py
+++ b/backend/main.py
@@ -289,7 +289,7 @@ _all_origins = _default_origins + _extra_origins
 _mcp_allowed_origins: set[str] = (
     {o.strip() for o in _app_settings.MCP_CORS_ORIGINS.split(",") if o.strip()}
     if _app_settings.MCP_CORS_ORIGINS
-    else set()
+    else set(_default_origins)
 )
 
 # MCP endpoints must accept cross-origin requests from any MCP client.
@@ -301,8 +301,10 @@ _MCP_CORS_PREFIXES = ("/oauth/", "/.well-known/", "/mcp")
 class _MCPCorsMiddleware(BaseHTTPMiddleware):
     """CORS for MCP OAuth / well-known endpoints.
 
-    If MCP_CORS_ORIGINS is configured, only those origins are reflected.
-    Otherwise, the wildcard '*' is used (no credential exposure).
+    Reflects the origin for requests from origins in _mcp_allowed_origins.
+    Requests with an Origin not in the allowlist receive no CORS headers (browser
+    access blocked). Requests without an Origin header (non-browser clients) pass
+    through unaffected.
     """
 
     async def dispatch(  # type: ignore[override]
@@ -314,28 +316,29 @@ class _MCPCorsMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         origin = request.headers.get("origin", "")
-        if _mcp_allowed_origins and origin in _mcp_allowed_origins:
-            allow_origin = origin
+        if origin in _mcp_allowed_origins:
+            allow_origin: str | None = origin
+        elif origin:
+            # Origin header present but not in allowlist — block the CORS request.
+            logger.debug("MCP CORS: origin %r not in allowlist, blocking", origin)
+            allow_origin = None
         else:
-            # Unlisted origins get safe wildcard, not a rejection.
-            # MCP_CORS_ORIGINS enables credential-compatible reflection for listed
-            # origins; all other origins (including unconfigured/wildcard mode) still
-            # get '*' so any MCP client can connect without credentials.
-            if _mcp_allowed_origins and origin:
-                logger.debug("MCP CORS: origin %r not in allowlist, using wildcard", origin)
-            allow_origin = "*"
+            # No Origin header (non-browser client) — no CORS header needed.
+            allow_origin = None
 
         if request.method == "OPTIONS":
             resp = StarletteResponse(status_code=204)
-            resp.headers["Access-Control-Allow-Origin"] = allow_origin
-            resp.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-            resp.headers["Access-Control-Allow-Headers"] = "content-type, authorization"
-            resp.headers["Access-Control-Max-Age"] = "600"
+            if allow_origin is not None:
+                resp.headers["Access-Control-Allow-Origin"] = allow_origin
+                resp.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+                resp.headers["Access-Control-Allow-Headers"] = "content-type, authorization"
+                resp.headers["Access-Control-Max-Age"] = "600"
             resp.headers["Vary"] = "Origin"
             return resp
 
         response = await call_next(request)
-        response.headers["Access-Control-Allow-Origin"] = allow_origin
+        if allow_origin is not None:
+            response.headers["Access-Control-Allow-Origin"] = allow_origin
         response.headers["Vary"] = "Origin"
         return response
 

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -55,52 +55,52 @@ class TestOAuthMetadataScheme:
 
 
 class TestMcpOAuthCors:
-    """MCP OAuth endpoints must allow cross-origin requests from any MCP client."""
+    """MCP OAuth endpoints allow cross-origin requests only from allowed origins."""
 
     def test_oauth_token_cors_preflight(self, mcp_client):
         resp = mcp_client.options(
             "/oauth/token",
             headers={
-                "Origin": "https://claude.ai",
+                "Origin": "http://localhost:5173",
                 "Access-Control-Request-Method": "POST",
                 "Access-Control-Request-Headers": "content-type",
             },
         )
         assert resp.status_code == 204
-        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
 
     def test_oauth_register_cors_preflight(self, mcp_client):
         resp = mcp_client.options(
             "/oauth/register",
             headers={
-                "Origin": "https://example.com",
+                "Origin": "http://localhost:5173",
                 "Access-Control-Request-Method": "POST",
                 "Access-Control-Request-Headers": "content-type",
             },
         )
         assert resp.status_code == 204
-        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
 
     def test_well_known_cors_preflight(self, mcp_client):
         resp = mcp_client.options(
             "/.well-known/oauth-authorization-server",
             headers={
-                "Origin": "https://claude.ai",
+                "Origin": "http://localhost:5173",
                 "Access-Control-Request-Method": "GET",
             },
         )
         assert resp.status_code == 204
-        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
 
     def test_oauth_token_post_has_cors_header(self, mcp_client):
         resp = mcp_client.post(
             "/oauth/token",
             data={"grant_type": "authorization_code", "code": "fake"},
-            headers={"Origin": "https://claude.ai"},
+            headers={"Origin": "http://localhost:5173"},
         )
         # Should fail with 400 (bad code) but still have CORS headers
         assert resp.status_code == 400
-        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:5173"
 
     def test_allowlisted_origin_is_reflected(self, mcp_client, monkeypatch):
         """When MCP_CORS_ORIGINS is set, only listed origins are reflected."""
@@ -116,8 +116,8 @@ class TestMcpOAuthCors:
         )
         assert resp.headers.get("access-control-allow-origin") == "https://claude.ai"
 
-    def test_non_allowlisted_origin_gets_wildcard(self, mcp_client, monkeypatch):
-        """Origins not in the allowlist get * even when an allowlist is configured."""
+    def test_non_allowlisted_origin_gets_no_cors_header(self, mcp_client, monkeypatch):
+        """Origins not in the allowlist get no CORS header, blocking browser access."""
         import backend.main as main_module
 
         monkeypatch.setattr(main_module, "_mcp_allowed_origins", {"https://claude.ai"})
@@ -128,10 +128,10 @@ class TestMcpOAuthCors:
                 "Access-Control-Request-Method": "POST",
             },
         )
-        assert resp.headers.get("access-control-allow-origin") == "*"
+        assert resp.headers.get("access-control-allow-origin") is None
 
-    def test_no_origin_header_always_gets_wildcard(self, mcp_client, monkeypatch):
-        """Requests without an Origin header always get * regardless of allowlist state."""
+    def test_no_origin_header_gets_no_cors_header(self, mcp_client, monkeypatch):
+        """Requests without an Origin header get no CORS header (non-browser clients unaffected)."""
         import backend.main as main_module
 
         monkeypatch.setattr(main_module, "_mcp_allowed_origins", {"https://claude.ai"})
@@ -140,7 +140,24 @@ class TestMcpOAuthCors:
             headers={"Access-Control-Request-Method": "POST"},  # no Origin header
         )
         acao = resp.headers.get("access-control-allow-origin", "")
-        assert acao == "*"
+        assert acao == ""
+
+    def test_unlisted_origin_gets_no_cors_header_by_default(self, mcp_client):
+        """An unknown origin must not receive Access-Control-Allow-Origin in default config."""
+        resp = mcp_client.options(
+            "/oauth/token",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert resp.headers.get("access-control-allow-origin") is None
+
+    def test_no_origin_header_request_passes_through(self, mcp_client):
+        """Non-browser clients without Origin header can still reach MCP endpoints."""
+        resp = mcp_client.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") is None
 
     def test_mcp_cors_origins_parsed_from_env(self, monkeypatch):
         """MCP_CORS_ORIGINS string is split, stripped, and deduplicated correctly."""


### PR DESCRIPTION
## Summary

**Issue**: [Security] SEC-14: MCP CORS wildcard fallback (#1192)

When `MCP_CORS_ORIGINS` is unset (the default), the system incorrectly defaulted to wildcard CORS (`*`), allowing any website to probe OAuth discovery endpoints and attempt client registration. This fix replaces the insecure wildcard fallback with an allowlist-only policy.

## Problem

The empty set for `_mcp_allowed_origins` evaluated falsy in the allowlist check, causing all browser cross-origin requests to `/oauth/`, `/.well-known/`, and `/mcp` to receive `Access-Control-Allow-Origin: *`. This violates the secure-by-default principle.

## Changes

1. **`backend/main.py`**
   - Default `_mcp_allowed_origins` to `set(_default_origins)` instead of empty set (localhost origins only when unconfigured)
   - Replace wildcard fallback with explicit blocking: unlisted origins with an `Origin` header now receive no CORS header (browser access blocked)
   - Non-browser clients without an `Origin` header remain unaffected
   - Update class docstring to reflect new behavior

2. **`backend/config.py`**
   - Update `MCP_CORS_ORIGINS` comment: empty now means "localhost defaults only" instead of "use wildcard"

3. **`backend/tests/test_mcp_oauth.py`**
   - Update 5 existing tests to use allowed default origins (localhost:5173)
   - Add tests verifying unlisted origins get no CORS header
   - Confirm non-browser clients still work without Origin header

## Validation

- ✅ All 1320 tests pass, 14 skipped (full suite)
- ✅ MCP OAuth tests: 36 passed
- ✅ Type checking: no errors in changed files
- ✅ Linting: fixed E501 (line too long) in config.py
- ✅ Frontend build: successful

## Security Impact

**Severity**: MEDIUM
- Eliminates cross-origin probing of OAuth metadata from arbitrary websites
- Blocks unauthenticated client registration attempts from unknown origins
- `Access-Control-Allow-Credentials` is not set, so session cookies cannot be exfiltrated even with wildcard
- Non-browser MCP clients unaffected (they don't send Origin header)

Fixes #1192

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>