### PR TITLE
Fix: guard health check curl against bash -e exit on timeout

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
           sleep 90
           echo "Polling ${RAILWAY_STAGING_URL}/healthz ..."
           for i in $(seq 1 20); do
-            HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null)
+            HTTP_CODE=$(curl -s -o /tmp/hc_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_STAGING_URL}/healthz" 2>/dev/null || true)
             HTTP_CODE=${HTTP_CODE:-000}
             BODY=$(cat /tmp/hc_body.txt 2>/dev/null || true)
             echo "Attempt $i/20: HTTP $HTTP_CODE — ${BODY:0:100}"
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "Confirming staging is reachable before Playwright smoke tests..."
           for i in $(seq 1 12); do
-            HTTP_CODE=$(curl -s -o /tmp/smoke_hc.txt -w "%{http_code}" --max-time 10 "${BASE_URL}/healthz" 2>/dev/null)
+            HTTP_CODE=$(curl -s -o /tmp/smoke_hc.txt -w "%{http_code}" --max-time 10 "${BASE_URL}/healthz" 2>/dev/null || true)
             HTTP_CODE=${HTTP_CODE:-000}
             BODY=$(cat /tmp/smoke_hc.txt 2>/dev/null || true)
             echo "Attempt $i/12: HTTP $HTTP_CODE — ${BODY:0:80}"
@@ -236,7 +236,7 @@ jobs:
           sleep 90
           echo "Polling ${RAILWAY_PRODUCTION_URL}/healthz ..."
           for i in $(seq 1 20); do
-            HTTP_CODE=$(curl -s -o /tmp/hc_prod_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_PRODUCTION_URL}/healthz" 2>/dev/null)
+            HTTP_CODE=$(curl -s -o /tmp/hc_prod_body.txt -w "%{http_code}" --max-time 5 "${RAILWAY_PRODUCTION_URL}/healthz" 2>/dev/null || true)
             HTTP_CODE=${HTTP_CODE:-000}
             BODY=$(cat /tmp/hc_prod_body.txt 2>/dev/null || true)
             echo "Attempt $i/20: HTTP $HTTP_CODE — ${BODY:0:100}"


### PR DESCRIPTION
## Summary

- All three `curl` health poll loops in `staging-pipeline.yml` run under `bash -e`
- When curl times out (exit code 28), bash aborted the script immediately — the 20-attempt retry loop never executed
- Add `|| true` to the three curl command substitutions so timeout is treated as HTTP `000` and the loop retries as designed

## Root Cause

The CI failure on run [27458599888](https://github.com/alexsiri7/reli/actions/runs/27458599888) showed:
```
Polling ***/healthz ...
##[error]Process completed with exit code 28.
```
No "Attempt 1/20:" line — the script exited before the echo because curl exit 28 triggered `bash -e`. The application change in the triggering commit (`5b33be0`, CORS fix) is unrelated — `/healthz` is outside the MCP CORS middleware path.

## Test plan

- [ ] CI runs on this PR (lint/typecheck/test/build)
- [ ] After merge, confirm the next "Staging → Production Pipeline" run shows "Attempt N/20:" lines in the health check step logs

Fixes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)