### PR TITLE
fix: limit dependency sweep query to prevent OOM

### DIFF
--- a/backend/dependency_sweep.py
+++ b/backend/dependency_sweep.py
@@ -16,7 +16,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 
-from sqlmodel import Session, or_, select
+from sqlmodel import Session, desc, or_, select
 
 import backend.db_engine as _engine_mod
 
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 MAX_CLUSTER_SIZE = 20  # Max Things per LLM cluster
 MAX_CLUSTERS_PER_SWEEP = 10  # Max clusters per sweep run
+MAX_THINGS_PER_DEPENDENCY_SWEEP = 500  # Max active Things to load per sweep to prevent OOM on memory-constrained hosts
 
 # ---------------------------------------------------------------------------
 # Dataclasses
@@ -77,11 +78,17 @@ def find_dependency_clusters(user_id: str = "") -> list[DependencyCluster]:
     relationships.
     """
     with Session(_engine_mod.engine) as session:
-        # Get all active Things
+        # Get all active Things (limited to prevent OOM on memory-constrained hosts)
         thing_stmt = select(ThingRecord).where(ThingRecord.active == True)  # noqa: E712 — SQLAlchemy requires == for column comparisons; `is True` evaluates in Python, not SQL
         if user_id:
             thing_stmt = thing_stmt.where(user_filter_clause(ThingRecord.user_id, user_id))
+        thing_stmt = thing_stmt.order_by(desc(ThingRecord.updated_at)).limit(MAX_THINGS_PER_DEPENDENCY_SWEEP)
         things = session.exec(thing_stmt).all()
+        if len(things) >= MAX_THINGS_PER_DEPENDENCY_SWEEP:
+            logger.warning(
+                "dependency_sweep: active Things capped at %d — some Things will not be included in this sweep cycle",
+                MAX_THINGS_PER_DEPENDENCY_SWEEP,
+            )
         thing_map = {
             t.id: {
                 "id": t.id,

--- a/backend/dependency_sweep.py
+++ b/backend/dependency_sweep.py
@@ -84,7 +84,7 @@ def find_dependency_clusters(user_id: str = "") -> list[DependencyCluster]:
             thing_stmt = thing_stmt.where(user_filter_clause(ThingRecord.user_id, user_id))
         thing_stmt = thing_stmt.order_by(desc(ThingRecord.updated_at)).limit(MAX_THINGS_PER_DEPENDENCY_SWEEP)
         things = session.exec(thing_stmt).all()
-        if len(things) >= MAX_THINGS_PER_DEPENDENCY_SWEEP:
+        if len(things) == MAX_THINGS_PER_DEPENDENCY_SWEEP:
             logger.warning(
                 "dependency_sweep: active Things capped at %d — some Things will not be included in this sweep cycle",
                 MAX_THINGS_PER_DEPENDENCY_SWEEP,

--- a/backend/tests/test_connections_ownership.py
+++ b/backend/tests/test_connections_ownership.py
@@ -1,6 +1,5 @@
 """Tests for accept_suggestion cross-user ownership check."""
 
-import json
 from datetime import datetime, timezone
 
 

--- a/backend/tests/test_dependency_sweep.py
+++ b/backend/tests/test_dependency_sweep.py
@@ -122,6 +122,20 @@ class TestFindDependencyClusters:
         clusters = find_dependency_clusters()
         assert len(clusters) == 0
 
+    def test_limits_things_loaded(self, db):
+        """Regression test for OOM (#1251): dependency_sweep must cap loaded Things."""
+        from backend.dependency_sweep import MAX_THINGS_PER_DEPENDENCY_SWEEP
+
+        # Insert MAX_THINGS_PER_DEPENDENCY_SWEEP + 100 active Things
+        for i in range(MAX_THINGS_PER_DEPENDENCY_SWEEP + 100):
+            _insert_thing(db, f"Thing {i}")
+
+        with patch("backend.dependency_sweep.logger") as mock_logger:
+            find_dependency_clusters(user_id="")
+            # Warning must be logged when limit is hit
+            mock_logger.warning.assert_called_once()
+            assert "capped at" in str(mock_logger.warning.call_args)
+
 
 class TestFormatClusterForLlm:
     def test_format_cluster_includes_deadline(self):

--- a/backend/tests/test_dependency_sweep.py
+++ b/backend/tests/test_dependency_sweep.py
@@ -136,6 +136,10 @@ class TestFindDependencyClusters:
             mock_logger.warning.assert_called_once()
             assert "capped at" in str(mock_logger.warning.call_args)
 
+        # Liveness check: function must complete and return a list (no OOM/hang)
+        result = find_dependency_clusters(user_id="")
+        assert isinstance(result, list)
+
 
 class TestFormatClusterForLlm:
     def test_format_cluster_includes_deadline(self):

--- a/backend/tests/test_dependency_sweep.py
+++ b/backend/tests/test_dependency_sweep.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, select
 import backend.db_engine as _engine_mod
 from backend.db_models import ConnectionSuggestionRecord, SweepFindingRecord
 from backend.dependency_sweep import (
+    MAX_THINGS_PER_DEPENDENCY_SWEEP,
     DependencyCluster,
     _format_cluster_for_llm,
     find_dependency_clusters,
@@ -124,8 +125,6 @@ class TestFindDependencyClusters:
 
     def test_limits_things_loaded(self, db):
         """Regression test for OOM (#1251): dependency_sweep must cap loaded Things."""
-        from backend.dependency_sweep import MAX_THINGS_PER_DEPENDENCY_SWEEP
-
         # Insert MAX_THINGS_PER_DEPENDENCY_SWEEP + 100 active Things
         for i in range(MAX_THINGS_PER_DEPENDENCY_SWEEP + 100):
             _insert_thing(db, f"Thing {i}")

--- a/backend/tests/test_morning_briefing.py
+++ b/backend/tests/test_morning_briefing.py
@@ -298,7 +298,7 @@ class TestMorningBriefingActionsTaken:
     @freeze_time("2026-06-16T12:00:00Z")
     def test_action_older_than_24h_excluded(self, patched_db, client):
         """Actions older than 24 hours are excluded from the briefing."""
-        from datetime import datetime, timedelta, timezone
+        from datetime import datetime, timezone
 
         from sqlmodel import Session
 

--- a/backend/tests/test_sweep.py
+++ b/backend/tests/test_sweep.py
@@ -4,9 +4,8 @@ import json
 from datetime import date, timedelta
 from unittest.mock import AsyncMock, patch
 
-from freezegun import freeze_time
-
 import pytest
+from freezegun import freeze_time
 from sqlmodel import Session
 
 import backend.db_engine as _engine_mod
@@ -1621,7 +1620,6 @@ class TestConnectionSweepUserScoping:
         Inserting more Things than the cap and counting vector_search_with_distances
         calls verifies the cap is enforced at the DB query level.
         """
-        import uuid
         from unittest.mock import patch as _patch
 
         from backend.connection_sweep import MAX_THINGS_PER_SWEEP, find_connection_candidates

--- a/backend/tests/test_sweep_scheduler.py
+++ b/backend/tests/test_sweep_scheduler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

Production deployment down due to out-of-memory killer on nightly dependency sweep. The sweep loads all active Things without limit, OOM-killing the Railway container at 03:01:56 UTC (1m56s after sweep start at 03:00 UTC). 

This mirrors the exact pattern fixed in PR #1249 for connection_sweep, which was missing from dependency_sweep.

**Severity**: HIGH — production site completely unreachable (HTTP 000)
**Root cause**: `backend/dependency_sweep.py` unbounded `select(ThingRecord).all()` loads all Things into memory
**Fix**: Add `MAX_THINGS_PER_DEPENDENCY_SWEEP = 500` limit and `.limit()` to the query, matching #1249 pattern

## Changes

| File | Changes |
|------|---------|
| `backend/dependency_sweep.py` | +9/-2 — Add limit constant, apply `.limit()` and `.order_by(desc(...))` to Things query, add warning log |
| `backend/tests/test_dependency_sweep.py` | +14/-0 — Add regression test verifying limit is enforced |

## Implementation Details

**`backend/dependency_sweep.py:37-38`** — Added constant
```python
MAX_THINGS_PER_DEPENDENCY_SWEEP = 500  # Max active Things per sweep to prevent OOM
```

**`backend/dependency_sweep.py:79-84` + imports** — Applied limit to query
- Added `desc` to imports: `from sqlmodel import Session, desc, or_, select`
- Applied `.order_by(desc(ThingRecord.updated_at)).limit(MAX_THINGS_PER_DEPENDENCY_SWEEP)` 
- Added warning log when limit is hit: *"dependency_sweep: active Things capped at 500 — some Things will not be included..."*

**`backend/tests/test_dependency_sweep.py`** — Regression test
- Creates 600 active Things (exceeding limit of 500)
- Verifies warning is logged when limit is reached
- Ensures future changes don't remove the limit

## Testing

✅ **Type check** (mypy): No new errors  
✅ **Lint** (ruff): 5 issues fixed (unused imports), 5 pre-existing remain  
✅ **Tests**: 1340 passed, 14 skipped, 0 failed (coverage: 88.15%)  

**Files modified during validation** (auto-fixed by ruff):
- `backend/tests/test_connections_ownership.py` — removed unused `json`
- `backend/tests/test_morning_briefing.py` — removed unused imports
- `backend/tests/test_sweep.py` — removed unused imports
- `backend/tests/test_sweep_scheduler.py` — removed unused `datetime`

## Verification

After merge and Railway rebuild:
1. Watch Railway logs at 03:00 UTC next sweep cycle — no OOM kill should occur
2. `/api/health` returns 200 at 03:05 UTC (previously HTTP 000)
3. Deploy page updates with green status

**Note**: Users with >500 active Things will have limited dependency sweep coverage in a single cycle. Things are ordered by `updated_at desc`, so recent changes are prioritized. This is the same trade-off made in PR #1249 (connection_sweep).

---

**Related**: PR #1248, PR #1249

Fixes #1251