### PR TITLE
feat: record production deployments on GitHub

### DIFF
--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -165,8 +165,10 @@ jobs:
     name: Deploy to production
     runs-on: ubuntu-latest
     needs: [deploy-staging, staging-e2e]
+    environment: production
     permissions:
       contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v6
 
@@ -272,3 +274,26 @@ jobs:
             -H "Title: ${{ github.event.repository.name }} landed in prod" \
             -H "Tags: tada" \
             -d "$body" "ntfy.sh/$NTFY_TOPIC" || true
+
+      - name: Record production deployment on GitHub
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_SHA: ${{ needs.deploy-staging.outputs.deploy_sha }}
+          DEPLOY_RESULT: ${{ job.status }}
+        run: |
+          STATE="success"
+          [ "$DEPLOY_RESULT" != "success" ] && STATE="failure"
+          # DEPLOY_SHA is a 40-char hex SHA; no JSON-special chars, so printf interpolation is safe
+          DEP_ID=$(printf '{"ref":"%s","environment":"production","auto_merge":false,"required_contexts":[]}' "$DEPLOY_SHA" | \
+            gh api "repos/${{ github.repository }}/deployments" \
+            --input - \
+            --jq '.id') || { echo "ERROR: Failed to create GitHub deployment record"; exit 1; }
+          if [ -z "$DEP_ID" ]; then
+            echo "ERROR: DEP_ID is empty — deployment record not created"
+            exit 1
+          fi
+          gh api "repos/${{ github.repository }}/deployments/$DEP_ID/statuses" \
+            -f state="$STATE" \
+            -f environment="production" \
+            -f description="Deploy $DEPLOY_RESULT at ${DEPLOY_SHA:0:7}"

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -288,12 +288,16 @@ jobs:
           DEP_ID=$(printf '{"ref":"%s","environment":"production","auto_merge":false,"required_contexts":[]}' "$DEPLOY_SHA" | \
             gh api "repos/${{ github.repository }}/deployments" \
             --input - \
-            --jq '.id') || { echo "ERROR: Failed to create GitHub deployment record"; exit 1; }
+            --jq '.id | select(. != null)') || {
+              echo "::warning::Failed to create GitHub deployment record — API error"
+              exit 0
+            }
           if [ -z "$DEP_ID" ]; then
-            echo "ERROR: DEP_ID is empty — deployment record not created"
-            exit 1
+            echo "::warning::DEP_ID is empty — GitHub deployment record not created"
+            exit 0
           fi
           gh api "repos/${{ github.repository }}/deployments/$DEP_ID/statuses" \
             -f state="$STATE" \
             -f environment="production" \
-            -f description="Deploy $DEPLOY_RESULT at ${DEPLOY_SHA:0:7}"
+            -f description="Deploy $DEPLOY_RESULT at ${DEPLOY_SHA:0:7}" || \
+            echo "::warning::Failed to set deployment status — status record may be incomplete"


### PR DESCRIPTION
## Summary

Adds production deployment recording to the GitHub Deployments API. The `deploy-production` job now creates GitHub Deployment records on each production deploy (success or failure), enabling monitors to detect Railway rollout failures via the GitHub API.

## Changes

- Added `environment: production` to `deploy-production` job
- Added `deployments: write` permission to job permissions
- Added `Record production deployment on GitHub` step that:
  - Runs `if: always()` to capture both success and failure states
  - Creates a GitHub Deployment record with the deploy SHA
  - Sets deployment status to `success` or `failure` based on job outcome
  - Uses `gh api` with `GITHUB_TOKEN` for API calls

## Validation

✅ Level 1: YAML syntax valid
✅ Level 2: All required patterns present (1× each)
✅ Level 3: Structure checks all passed

- `environment: production` set on job
- `deployments: write` permission present
- Step present with `if: always()`
- Job step order preserved

## Test Plan

- [ ] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/staging-pipeline.yml'))"`
- [ ] Verify content: `grep "Record production deployment on GitHub\|deployments: write\|environment: production" .github/workflows/staging-pipeline.yml`
- [ ] Manual test: Deploy to staging/prod and check GitHub Environments tab for deployment records

## Context

This completes the missing step from issue #629 checklist: recording production deployments in GitHub's Deployments API so monitors can consume deployment history.

Fixes #629