### PR TITLE
fix: limit weekly briefing query to prevent OOM

### DIFF
--- a/backend/tests/test_weekly_briefing.py
+++ b/backend/tests/test_weekly_briefing.py
@@ -43,3 +43,37 @@ class TestUrgencySortKey:
             "Deadline in 2d",
             "Birthday in 5d",
         ]
+
+
+class TestWeeklyBriefingLimit:
+    def test_generate_weekly_briefing_limits_things_loaded(self, patched_db):
+        """Regression: weekly briefing must not load more than MAX_THINGS_PER_BRIEFING Things."""
+        import uuid
+
+        from sqlmodel import Session
+
+        import backend.db_engine as engine_mod
+        from backend.db_models import ThingRecord
+        from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, generate_weekly_briefing
+
+        over_limit = MAX_THINGS_PER_BRIEFING + 50
+
+        with Session(engine_mod.engine) as session:
+            for i in range(over_limit):
+                session.add(
+                    ThingRecord(
+                        id=str(uuid.uuid4()),
+                        title=f"Thing {i}",
+                        active=True,
+                    )
+                )
+            session.commit()
+
+        # Should not OOM or raise — and must return <= MAX_THINGS_PER_BRIEFING active rows
+        result = generate_weekly_briefing(user_id="")
+        # upcoming + open_questions both come from active_rows — total active things processed
+        # cannot exceed MAX_THINGS_PER_BRIEFING
+        total_processed = len(result.upcoming) + len(result.open_questions)
+        # The real assertion: the query must have been limited
+        # (upcoming/open_questions are subsets of active_rows, so can't exceed cap)
+        assert total_processed <= MAX_THINGS_PER_BRIEFING

--- a/backend/tests/test_weekly_briefing.py
+++ b/backend/tests/test_weekly_briefing.py
@@ -1,9 +1,17 @@
 """Tests for weekly_briefing helpers."""
 
-import pytest
+import json
+import logging
+import uuid
+from datetime import date, timedelta
 
+import pytest
+from sqlmodel import Session
+
+import backend.db_engine as engine_mod
+from backend.db_models import ThingRecord
 from backend.models import WeeklyBriefingItem
-from backend.weekly_briefing import _urgency_sort_key
+from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, _urgency_sort_key, generate_weekly_briefing
 
 
 def _make_item(detail: str | None = None) -> WeeklyBriefingItem:
@@ -48,16 +56,6 @@ class TestUrgencySortKey:
 class TestWeeklyBriefingLimit:
     def test_generate_weekly_briefing_limits_things_loaded(self, patched_db):
         """Regression: weekly briefing must not load more than MAX_THINGS_PER_BRIEFING Things."""
-        import json
-        import uuid
-        from datetime import date, timedelta
-
-        from sqlmodel import Session
-
-        import backend.db_engine as engine_mod
-        from backend.db_models import ThingRecord
-        from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, generate_weekly_briefing
-
         over_limit = MAX_THINGS_PER_BRIEFING + 50
         # Give every record a deadline within 7 days so active_rows feeds upcoming (1 entry per thing).
         soon = (date.today() + timedelta(days=3)).isoformat()
@@ -83,15 +81,6 @@ class TestWeeklyBriefingLimit:
 
     def test_warning_emitted_when_capped(self, patched_db, caplog):
         """Warning is logged when active Things reach the cap."""
-        import logging
-        import uuid
-
-        from sqlmodel import Session
-
-        import backend.db_engine as engine_mod
-        from backend.db_models import ThingRecord
-        from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, generate_weekly_briefing
-
         with Session(engine_mod.engine) as session:
             for i in range(MAX_THINGS_PER_BRIEFING):
                 session.add(ThingRecord(id=str(uuid.uuid4()), title=f"T{i}", active=True))

--- a/backend/tests/test_weekly_briefing.py
+++ b/backend/tests/test_weekly_briefing.py
@@ -48,7 +48,9 @@ class TestUrgencySortKey:
 class TestWeeklyBriefingLimit:
     def test_generate_weekly_briefing_limits_things_loaded(self, patched_db):
         """Regression: weekly briefing must not load more than MAX_THINGS_PER_BRIEFING Things."""
+        import json
         import uuid
+        from datetime import date, timedelta
 
         from sqlmodel import Session
 
@@ -57,6 +59,8 @@ class TestWeeklyBriefingLimit:
         from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, generate_weekly_briefing
 
         over_limit = MAX_THINGS_PER_BRIEFING + 50
+        # Give every record a deadline within 7 days so active_rows feeds upcoming (1 entry per thing).
+        soon = (date.today() + timedelta(days=3)).isoformat()
 
         with Session(engine_mod.engine) as session:
             for i in range(over_limit):
@@ -65,15 +69,35 @@ class TestWeeklyBriefingLimit:
                         id=str(uuid.uuid4()),
                         title=f"Thing {i}",
                         active=True,
+                        data=json.dumps({"deadline": soon}),
                     )
                 )
             session.commit()
 
-        # Should not OOM or raise — and must return <= MAX_THINGS_PER_BRIEFING active rows
+        # Should not OOM or raise — limit must have been applied at the query level
         result = generate_weekly_briefing(user_id="")
-        # upcoming + open_questions both come from active_rows — total active things processed
-        # cannot exceed MAX_THINGS_PER_BRIEFING
-        total_processed = len(result.upcoming) + len(result.open_questions)
-        # The real assertion: the query must have been limited
-        # (upcoming/open_questions are subsets of active_rows, so can't exceed cap)
-        assert total_processed <= MAX_THINGS_PER_BRIEFING
+        # upcoming is populated 1-to-1 from active_rows (one deadline per thing via `break`).
+        # Without the .limit() cap, len(upcoming) would approach over_limit.
+        # With the cap applied it must be <= MAX_THINGS_PER_BRIEFING.
+        assert len(result.upcoming) <= MAX_THINGS_PER_BRIEFING
+
+    def test_warning_emitted_when_capped(self, patched_db, caplog):
+        """Warning is logged when active Things reach the cap."""
+        import logging
+        import uuid
+
+        from sqlmodel import Session
+
+        import backend.db_engine as engine_mod
+        from backend.db_models import ThingRecord
+        from backend.weekly_briefing import MAX_THINGS_PER_BRIEFING, generate_weekly_briefing
+
+        with Session(engine_mod.engine) as session:
+            for i in range(MAX_THINGS_PER_BRIEFING):
+                session.add(ThingRecord(id=str(uuid.uuid4()), title=f"T{i}", active=True))
+            session.commit()
+
+        with caplog.at_level(logging.WARNING, logger="backend.weekly_briefing"):
+            generate_weekly_briefing(user_id="")
+
+        assert any("capped at" in r.message for r in caplog.records)

--- a/backend/weekly_briefing.py
+++ b/backend/weekly_briefing.py
@@ -31,6 +31,8 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+MAX_THINGS_PER_BRIEFING = 500
+
 
 def _s(n: int) -> str:
     return "s" if n != 1 else ""
@@ -127,11 +129,21 @@ def generate_weekly_briefing(
         completed_rows = session.exec(completed_stmt).all()
 
         # All active things (for upcoming deadlines and open questions)
-        active_stmt = select(ThingRecord).where(
-            ThingRecord.active,
-            user_filter_clause(ThingRecord.user_id, user_id),
+        # Capped to prevent OOM on memory-constrained hosts — same cap as morning_briefing
+        active_stmt = (
+            select(ThingRecord)
+            .where(
+                ThingRecord.active,
+                user_filter_clause(ThingRecord.user_id, user_id),
+            )
+            .limit(MAX_THINGS_PER_BRIEFING)
         )
         active_rows = session.exec(active_stmt).all()
+        if len(active_rows) >= MAX_THINGS_PER_BRIEFING:
+            logger.warning(
+                "weekly_briefing: capped at %d Things (some may be excluded from digest)",
+                MAX_THINGS_PER_BRIEFING,
+            )
 
         # New connections created in lookback window
         FromThing = aliased(ThingRecord)


### PR DESCRIPTION
## Summary

Fixes the production outage (#1256) where `reli.interstellarai.net` crashes at 03:01 UTC every Monday due to OOM in `generate_weekly_briefing`. The weekly briefing loads all active Things with no row limit, exhausting memory on Railway's container.

## Changes

- **backend/weekly_briefing.py**: 
  - Added `MAX_THINGS_PER_BRIEFING = 500` constant
  - Capped `active_stmt` query with `.limit()` to prevent unbounded row load
  - Added warning log when limit is hit
  - Mirrors exact fix from commit 5219aea (morning_briefing) and related OOM fixes (#1249, #1252, #1253)

- **backend/tests/test_weekly_briefing.py**:
  - Added `TestWeeklyBriefingLimit` regression test
  - Verifies the limit is enforced even with >500 active Things

## Root Cause

The nightly sweep triggers `generate_weekly_briefing` every Monday at 03:00 UTC. Unlike `morning_briefing.py`, `dependency_sweep.py`, and `connection_sweep.py` (which were fixed in the past 24 hours), `weekly_briefing.py` still had an unbounded `active_stmt` query. On Monday cycles, this loads every active Thing and crashes the container.

## Validation

- ✅ Ruff lint (no issues)
- ✅ All tests pass (11 tests, including new regression test)
- ✅ New limit prevents rows from exceeding cap

Fixes #1256